### PR TITLE
Bug audit: 23 fixes + release improvements

### DIFF
--- a/VIStk/Objects/_Root.py
+++ b/VIStk/Objects/_Root.py
@@ -21,12 +21,11 @@ class Root(Tk, Window):
     
     def unload(self):
         """Closes the window neatly for VIStk"""
-        for element in self.winfo_children():
-            try:
-                element.destroy()
-            except Exception: pass
-        
         self.Active = False
+        for after_id in self.tk.call("after", "info"):
+            try:
+                self.after_cancel(after_id)
+            except Exception: pass
         self.destroy()
 
     def exitQueue(self, action, *args, **kwargs):

--- a/VIStk/Objects/_TabManager.py
+++ b/VIStk/Objects/_TabManager.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import gc
+import inspect
+import queue
+import sys
 from tkinter import Frame
 
 from VIStk.Widgets._TabBar import TabBar, _BG_BAR
@@ -62,7 +66,7 @@ class TabManager(Frame):
         on_tab_split       (callable | None) ``(name, direction)``
     """
 
-    def __init__(self, parent, position: str = "top", **kwargs):
+    def __init__(self, parent, position: str = "top", menubar=None, **kwargs):
         kwargs.setdefault("bg", _BG_BAR)
         super().__init__(parent, **kwargs)
 
@@ -70,6 +74,10 @@ class TabManager(Frame):
         """name → {frame, module, hooks, icon, base_name, info, _info_trace}"""
         self._active: str | None = None
         self._position: str = position
+
+        self._action_queue: queue.SimpleQueue = queue.SimpleQueue()
+        self._menubar = menubar
+        self._detached_window = None
 
         self.on_tab_activate   = None
         self.on_tab_deactivate = None
@@ -118,6 +126,89 @@ class TabManager(Frame):
     def active(self) -> str | None:
         return self._active
 
+    @property
+    def active_module(self):
+        """Return the module of the currently active tab, or None."""
+        if self._active and self._active in self._tabs:
+            return self._tabs[self._active].get("module")
+        return None
+
+    # ── Menu delegation ───────────────────────────────────────────────────────
+
+    def register_menu_item(self, label: str, command):
+        """Register a single menu item (delegates to the window's menubar)."""
+        if self._menubar:
+            self._menubar.set_screen_items([{"label": label, "command": command}])
+
+    def add_cascade(self, label: str, items: list[dict]):
+        """Add a cascade menu (delegates to the window's menubar)."""
+        if self._menubar:
+            self._menubar.set_screen_items(items, label=label)
+
+    # ── Navigation ────────────────────────────────────────────────────────────
+
+    def navigate(self, name: str, args=None):
+        """Navigate this pane to a new screen.
+
+        Tears down the current screen (calling on_quit), cleans up modules,
+        imports the new screen, runs setup(), and handles args.
+        """
+        from VIStk.Objects._Host import _HOST_INSTANCE
+        if _HOST_INSTANCE is None:
+            return
+
+        # 1. Call on_quit on active screen
+        if self._active and self._active in self._tabs:
+            module = self._tabs[self._active].get("module")
+            hooks = self._tabs[self._active].get("hooks")
+            quit_fn = (getattr(hooks, "on_quit", None)
+                       or getattr(module, "on_quit", None))
+            if quit_fn:
+                try:
+                    if quit_fn() is False:
+                        return  # vetoed
+                except Exception:
+                    pass
+            base_name = self._tabs[self._active].get("base_name", self._active)
+            self.close_tab(self._active)
+            self._cleanup_screen_modules(base_name)
+
+        # 2. Import new screen
+        scr = _HOST_INSTANCE.Project.getScreen(name)
+        if scr is None:
+            return
+        module = _HOST_INSTANCE._import_screen(scr)
+        hooks = _HOST_INSTANCE._import_hooks(scr)
+        icon = _HOST_INSTANCE._load_tab_icon(scr)
+        display = _HOST_INSTANCE._unique_display_name(name)
+
+        # 3. Open new tab
+        self.open_tab(display, module, hooks=hooks, icon=icon, base_name=name)
+
+        # 4. Handle args via ArgHandler
+        if args is not None and module and hasattr(module, "ArgHandler"):
+            try:
+                module.ArgHandler.handle(args)
+            except Exception:
+                pass
+
+    def _cleanup_screen_modules(self, screen_name: str):
+        """Remove screen-specific entries from sys.modules to allow clean re-import."""
+        prefixes = (
+            f"Screens.{screen_name}.",
+            f"modules.{screen_name}.",
+        )
+        to_delete = [k for k in sys.modules if any(k.startswith(p) for p in prefixes)]
+        for key in to_delete:
+            del sys.modules[key]
+        gc.collect()
+
+    def _cleanup_all_modules(self):
+        """Clean up all screen modules owned by this TabManager."""
+        for name, entry in list(self._tabs.items()):
+            base_name = entry.get("base_name", name)
+            self._cleanup_screen_modules(base_name)
+
     def open_tab(self, name: str, module, hooks=None, icon=None,
                  insert_idx: int = -1, base_name: str = None) -> bool:
         """Open a new tab for *name* and build its screen UI.
@@ -144,12 +235,6 @@ class TabManager(Frame):
         frame._vis_tab_name    = name
         frame._vis_tab_manager = self
 
-        if module and hasattr(module, "setup"):
-            try:
-                module.setup(frame)
-            except Exception:
-                pass
-
         self._tabs[name] = {
             "frame":      frame,
             "module":     module,
@@ -159,13 +244,39 @@ class TabManager(Frame):
             "info":       "",
             "_info_trace": None,   # (StringVar, trace_id) | None
         }
+
+        if module and hasattr(module, "setup"):
+            try:
+                module.setup(frame)
+            except Exception:
+                pass
+
         self.tab_bar.open_tab(name, icon=icon, insert_idx=insert_idx)
         return True
 
-    def close_tab(self, name: str) -> bool:
-        """Close the named tab, running ``on_unfocused`` first."""
+    def close_tab(self, name: str, skip_on_quit: bool = False) -> bool:
+        """Close the named tab, running ``on_unfocused`` first.
+
+        Args:
+            name: Display name of the tab.
+            skip_on_quit: If True, skip the on_quit hook (used when
+                DetachedWindow has already checked it).
+        """
         if name not in self._tabs:
             return False
+
+        # Call on_quit unless skipped (e.g. window close already checked)
+        if not skip_on_quit:
+            module = self._tabs[name].get("module")
+            hooks = self._tabs[name].get("hooks")
+            quit_fn = (getattr(hooks, "on_quit", None)
+                       or getattr(module, "on_quit", None))
+            if quit_fn:
+                try:
+                    if quit_fn() is False:
+                        return False  # vetoed
+                except Exception:
+                    pass
 
         # Clean up StringVar trace if present
         trace_info = self._tabs[name].get("_info_trace")
@@ -201,7 +312,8 @@ class TabManager(Frame):
         hooks     = entry.get("hooks")
         icon      = entry.get("icon")
         base_name = entry.get("base_name", name)
-        self.close_tab(name)
+        if not self.close_tab(name):
+            return False
         self.open_tab(name, module, hooks=hooks, icon=icon,
                       insert_idx=idx, base_name=base_name)
         return True
@@ -270,6 +382,27 @@ class TabManager(Frame):
         if self.on_tab_deactivate:
             self.on_tab_deactivate(name)
 
+    def _call_configure_menu(self, name: str):
+        """Call configure_menu on the active tab's hooks or module.
+
+        Supports both new signature (tabmanager) and old signature (menubar)
+        for backwards compatibility.
+        """
+        cfg = self._get_hook(name, "configure_menu")
+        if cfg is None:
+            return
+        try:
+            sig = inspect.signature(cfg)
+            params = list(sig.parameters.keys())
+            if params and params[0] == "menubar":
+                # Old signature — pass menubar directly for compat
+                if self._menubar:
+                    cfg(self._menubar)
+            else:
+                cfg(self)
+        except Exception:
+            pass
+
     def _on_focus_change(self, name: str | None):
         prev = self._active
         if prev and prev != name:
@@ -335,6 +468,7 @@ class TabManager(Frame):
         hooks     = entry.get("hooks")
         icon      = entry.get("icon")
         base_name = entry.get("base_name", name)
-        source_mgr.close_tab(name)
+        if not source_mgr.close_tab(name):
+            return
         self.open_tab(name, module, hooks=hooks, icon=icon,
                       insert_idx=insert_idx, base_name=base_name)

--- a/VIStk/Objects/_VIMG.py
+++ b/VIStk/Objects/_VIMG.py
@@ -34,7 +34,7 @@ class VIMG():
 
     def resize(self, e=None):
         """Resizes an image to the size of its parent frame"""
-        img = Image.open(self.path)
+        img = self.Image.copy()
         f_w = self.fill.winfo_width()
         f_h = self.fill.winfo_height()
         f_r = f_h/f_w

--- a/VIStk/Objects/_WindowGeometry.py
+++ b/VIStk/Objects/_WindowGeometry.py
@@ -1,20 +1,6 @@
 from tkinter import *
 from typing import Literal
 
-query = Tk()
-try:
-    try: #On Linux
-        query.wm_attributes("-zoomed", True)
-    except TclError: #On Windows
-        query.state('zoomed')
-    query.update()
-    global hs, ws
-    ws = query.winfo_width()-2#Unclear about this offset
-    hs = query.winfo_height()-9#Might be operating system specific
-finally:
-    query.destroy()
-#print(f"Screen has usable size of {ws}x{hs}")
-
 class WindowGeometry():
     """Handles geometry relations and sizing/resizing for windows"""
     def __init__(self,window:Tk|Toplevel):
@@ -62,7 +48,8 @@ class WindowGeometry():
 
     def setGeometry(self,width:int=None,height:int=None,x:int=None,y:int=None,align:Literal["center","n","ne","e","se","s","sw","w","nw"]=None,size_style:Literal["pixels","screen_relative","window_relative"]=None,window_ref:Tk|Toplevel=None):
         """Sets the geometry of the window"""
-        global hs, ws
+        ws = self.window.winfo_screenwidth() - 2
+        hs = self.window.winfo_screenheight() - 9
         ox, oy = 0, 0
 
         if width is None: width = self.geometry[0]

--- a/VIStk/Structures/Installer.py
+++ b/VIStk/Structures/Installer.py
@@ -135,7 +135,7 @@ for sname, scfg in info[title]["Screens"].items():
 installables = [title]  # Host group is always first
 _archive_binaries = set()
 for i in archive.namelist():
-    if not any(breaker in i for breaker in ["Icons/","Images/",".VIS/","_internal/","Screens/","modules/"]):
+    if not any(breaker in i for breaker in ["Icons/","Images/",".VIS/","Screens/","modules/",".Runtime/","Shared/"]):
         if "." in i:
             name = ".".join(i.split(".")[:-1])
         else:
@@ -146,6 +146,14 @@ for i in archive.namelist():
 for name in _archive_binaries:
     if name in _standalone_screens and name not in installables:
         installables.append(name)
+
+# Detect license/EULA file in archive
+_license_text = None
+for _lname in ("LICENSE", "LICENSE.txt", "EULA.txt", "EULA.md"):
+    if _lname in archive.namelist():
+        with archive.open(_lname) as _lf:
+            _license_text = _lf.read().decode("utf-8", errors="replace")
+        break
 
 #%Core Install & Shorcut Creation
 def shortcut(name:str, location:Path):
@@ -180,7 +188,7 @@ def shortcut(name:str, location:Path):
         subprocess.call(f"chmod +x {os.path.join(platformdirs.user_desktop_path(),name+'.desktop')}", shell=True)
 
 # Prefixes for files that keep their directory structure during extraction
-_dir_prefixes = (".VIS/", "Images/", "Icons/", "_internal/", "Screens/", "modules/")
+_dir_prefixes = (".VIS/", "Images/", "Icons/", "Screens/", "modules/", ".Runtime/", "Shared/")
 
 def extal(file, location):
     """Extracts file to the location. Only chmod binaries on Linux."""
@@ -192,11 +200,18 @@ def extal(file, location):
             subprocess.call(f"chmod +x {os.path.join(location,file)}", shell=True)
 
 def adjacents(location):
-    """Installs adjacent files from .VIS, Images, Icons, _internal"""
-    os.makedirs(os.path.join(location, ".VIS"), exist_ok=True)
+    """Installs adjacent files from .VIS, Images, Icons, .Runtime"""
+    vis_dir = os.path.join(location, ".VIS")
+    runtime_dir = os.path.join(location, ".Runtime")
+    os.makedirs(vis_dir, exist_ok=True)
     os.makedirs(os.path.join(location, "Images"), exist_ok=True)
     os.makedirs(os.path.join(location, "Icons"), exist_ok=True)
-    os.makedirs(os.path.join(location, "_internal"), exist_ok=True)
+    os.makedirs(runtime_dir, exist_ok=True)
+    if sys.platform == "win32":
+        subprocess.call(["attrib", "+h", vis_dir],
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.call(["attrib", "+h", runtime_dir],
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
 def _find_running_processes(location):
@@ -250,13 +265,7 @@ def _kill_app_processes(location):
 
 def write_install_log(location, selected_screens, desktop_shortcuts):
     """Write install_log.json recording what was installed."""
-    # Collect _internal/ subdirectories (immediate children only)
-    internal_dir = os.path.join(location, "_internal")
-    directories = [".VIS", "Icons", "Images", "_internal"]
-    if os.path.isdir(internal_dir):
-        for entry in os.listdir(internal_dir):
-            if os.path.isdir(os.path.join(internal_dir, entry)):
-                directories.append(f"_internal/{entry}")
+    directories = [".VIS", "Icons", "Images", ".Runtime"]
 
     # Build screen list with versions
     screens = []
@@ -285,7 +294,7 @@ def write_install_log(location, selected_screens, desktop_shortcuts):
         "registry_key": registry_key,
     }
 
-    log_path = os.path.join(location, "install_log.json")
+    log_path = os.path.join(location, ".VIS", "install_log.json")
     with open(log_path, "w") as f:
         json.dump(log, f, indent=2)
 
@@ -342,7 +351,7 @@ def verify_installation(location, arc) -> list[str]:
     """
     if arc is None:
         return ["Archive not available — cannot verify."]
-    log_path = os.path.join(location, "install_log.json")
+    log_path = os.path.join(location, ".VIS", "install_log.json")
     if not os.path.exists(log_path):
         return ["install_log.json not found — cannot verify."]
     try:
@@ -437,7 +446,7 @@ if QUIET is True:
         cinstalls = list(installables)
         print(f"No screens specified — installing all {len(cinstalls)} screen(s).")
 
-    is_update_quiet = os.path.exists(os.path.join(location, "install_log.json"))
+    is_update_quiet = os.path.exists(os.path.join(location, ".VIS", "install_log.json"))
 
     # Check for running processes in quiet mode
     if is_update_quiet:
@@ -459,8 +468,8 @@ if QUIET is True:
     adjacents(location)
 
     # Collect files to install
-    _base_prefixes_q = (".VIS/", "Images/", "Icons/", "_internal/")
-    _host_prefixes_q = ("Screens/", "modules/")
+    _base_prefixes_q = (".VIS/", "Images/", "Icons/", ".Runtime/")
+    _host_prefixes_q = ("Screens/", "modules/", "Shared/")
     # In quiet mode with no screens specified, install everything
     host_selected_q = (not cinstalls) or (title in cinstalls)
     quiet_install_files = []
@@ -502,25 +511,41 @@ if QUIET is True:
         archive.close()
         sys.exit()
 
+    total_size = sum(archive.getinfo(f).file_size for f in quiet_files_to_extract)
+    _q_line_w = 70
+
+    def _q_status(text):
+        sys.stdout.write(f"\r{text:<{_q_line_w}}")
+        sys.stdout.flush()
+
     # Backup for rollback
     quiet_backup_dir = None
     if is_update_quiet and quiet_files_to_extract:
         quiet_backup_dir = tempfile.mkdtemp(prefix="vis_backup_")
-        for file in quiet_files_to_extract:
+        for idx, file in enumerate(quiet_files_to_extract):
             dest = Path(location) / file
             if dest.exists():
                 bk = Path(quiet_backup_dir) / file
                 bk.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(dest, bk)
+            pct = int((idx + 1) / len(quiet_files_to_extract) * 50)
+            _q_status(f"  Backing up [{pct}%] {file[:45]}")
+        _q_status("")
 
     try:
+        installed_size = 0
         for file in quiet_files_to_extract:
-            print(f"  Extracting {file}")
             if file.startswith(_dir_prefixes) or file.endswith(".py"):
                 archive.extract(file, location)
             else:
                 extal(file, location)
+            installed_size += archive.getinfo(file).file_size
+            pct = int(installed_size / total_size * 100) if total_size > 0 else 100
+            _q_status(f"  Installing [{pct}%] {file[:45]}")
+        _q_status("")
+        print()
     except Exception as exc:
+        print()
         if quiet_backup_dir and os.path.exists(quiet_backup_dir):
             print("  Extraction failed — restoring backup...")
             for file in quiet_files_to_extract:
@@ -702,7 +727,57 @@ def makechecks(source:list[str], show_versions:bool=True):
             ver_lbl = ttk.Label(install_options, text=f"{scr_ver}", foreground="gray40")
             ver_lbl.grid(row=row, column=3, sticky=(tk.E,), padx=(0, 8))
 
-makechecks(installables)
+# ── EULA / License page ───────────────────────────────────────────────────
+_eula_agree_var = tk.IntVar(value=0)
+
+def _show_eula():
+    """Display the license agreement in the scrollable area."""
+    for w in install_options.winfo_children():
+        w.destroy()
+    header["text"] = "License Agreement"
+
+    eula_text = tk.Text(install_options, wrap="word", relief="flat",
+                        padx=8, pady=8, font=("TkDefaultFont", 9))
+    eula_text.insert("1.0", _license_text)
+    eula_text.configure(state="disabled")
+    eula_text.grid(row=0, column=1, columnspan=3, sticky=(tk.N, tk.S, tk.E, tk.W))
+    install_options.rowconfigure(0, weight=1)
+
+    agree_check = ttk.Checkbutton(install_options, text="I agree to the terms above",
+                                   variable=_eula_agree_var,
+                                   command=_toggle_eula_next)
+    agree_check.grid(row=1, column=1, columnspan=3, sticky=(tk.W,), pady=(4, 0))
+    agree_check.state(['!alternate'])
+
+def _toggle_eula_next():
+    """Enable or disable the Next button based on the agree checkbox."""
+    if _eula_agree_var.get() == 1:
+        next_btn.state(["!disabled"])
+    else:
+        next_btn.state(["disabled"])
+
+def _show_installables():
+    """Display the installables selection page."""
+    global next_btn
+    for w in install_options.winfo_children():
+        w.destroy()
+    header["text"] = "Select Installables"
+    makechecks(installables)
+    # Ensure Next button goes to shortcuts page
+    try: next_btn.destroy()
+    except Exception: pass
+    next_btn = ttk.Button(control, text="Next", command=nextpage)
+    next_btn.grid(row=1, column=2, padx=2, pady=4, sticky=(tk.N, tk.S, tk.E, tk.W))
+
+def _eula_next():
+    """Transition from EULA page to installables page."""
+    _show_installables()
+
+# Show initial page
+if _license_text:
+    _show_eula()
+else:
+    makechecks(installables)
 
 #File Location
 file_location = tk.StringVar()
@@ -743,14 +818,15 @@ control.columnconfigure(2,weight=1)
 
 def previous():
     global next_btn
-    next_btn = ttk.Button(control,text="Next",command=nextpage)
-    next_btn.grid(row=1,column=2,padx=2,pady=4,sticky=(tk.N,tk.S,tk.E,tk.W))
-
-    for w in install_options.winfo_children():
-        w.destroy()
-
-    header["text"] = "Select Installables"
-    makechecks(installables)
+    if _license_text:
+        # Go back to EULA page
+        _show_eula()
+        next_btn = ttk.Button(control, text="Next", command=_eula_next)
+        next_btn.grid(row=1, column=2, padx=2, pady=4, sticky=(tk.N, tk.S, tk.E, tk.W))
+        _toggle_eula_next()  # Restore agree-gate state
+    else:
+        # Go back to installables page
+        _show_installables()
 
 #Back Button
 back = ttk.Button(control, text="Back", command=previous)
@@ -762,6 +838,11 @@ close.grid(row=1,column=0,padx=2,pady=4,sticky=(tk.N,tk.S,tk.E,tk.W))
 
 def binstall(desktop:list[str], selected_screens:list[str]):
     """Installs the selected binaries"""
+    # Snapshot shortcut selections before destroying the UI
+    shortcut_selections = [
+        (name, var.get() == 1)
+        for name, var in zip(desktop, var_options)
+    ]
     close.state(["disabled"])
     fs.state(["disabled"])
     install_options.unbind("<Configure>")
@@ -777,7 +858,7 @@ def binstall(desktop:list[str], selected_screens:list[str]):
     adjacents(location)#Install adjacent files
 
     # Detect existing installation for update-in-place
-    existing_log_path = os.path.join(location, "install_log.json")
+    existing_log_path = os.path.join(location, ".VIS", "install_log.json")
     is_update = os.path.exists(existing_log_path)
 
     # Check for running application processes before proceeding
@@ -804,8 +885,8 @@ def binstall(desktop:list[str], selected_screens:list[str]):
                 return
 
     # Build the full list of files to install and compute total size
-    _base_prefixes = (".VIS/", "Images/", "Icons/", "_internal/")
-    _host_prefixes = ("Screens/", "modules/")
+    _base_prefixes = (".VIS/", "Images/", "Icons/", ".Runtime/")
+    _host_prefixes = ("Screens/", "modules/", "Shared/")
     install_files = []
     host_selected = title in selected_screens
     for file in archive.namelist():
@@ -959,8 +1040,8 @@ def binstall(desktop:list[str], selected_screens:list[str]):
 
     # Create desktop shortcuts
     actual_shortcuts = []
-    for name, var in zip(desktop, var_options):
-        if var.get() == 1:
+    for name, checked in shortcut_selections:
+        if checked:
             file_label.config(text=f"Creating shortcut: {name}")
             root.update()
             shortcut(name, location)
@@ -1016,7 +1097,8 @@ def binstall(desktop:list[str], selected_screens:list[str]):
 
 def nextpage():
     """Goes to the next installer page"""
-    next_btn.destroy()
+    try: next_btn.destroy()
+    except Exception: pass
 
     for w in install_options.winfo_children():
         w.destroy()
@@ -1033,8 +1115,13 @@ def nextpage():
     install = ttk.Button(control, text="Install",command=lambda: binstall(selected_screens, selected_screens))
     install.grid(row=1,column=2,padx=2,pady=4,sticky=(tk.N,tk.S,tk.E,tk.W))
 
-next_btn = ttk.Button(control,text="Next",command=nextpage)
-next_btn.grid(row=1,column=2,padx=2,pady=4,sticky=(tk.N,tk.S,tk.E,tk.W))
+if _license_text:
+    next_btn = ttk.Button(control, text="Next", command=_eula_next)
+    next_btn.grid(row=1, column=2, padx=2, pady=4, sticky=(tk.N, tk.S, tk.E, tk.W))
+    next_btn.state(["disabled"])  # Disabled until "I agree" is checked
+else:
+    next_btn = ttk.Button(control, text="Next", command=nextpage)
+    next_btn.grid(row=1, column=2, padx=2, pady=4, sticky=(tk.N, tk.S, tk.E, tk.W))
 
 # ── Installer menubar ──────────────────────────────────────────────────────
 
@@ -1045,7 +1132,7 @@ def _run_uninstaller():
         inst_dir = Path(loc)
     else:
         inst_dir = Path(loc, title)
-    log_path = inst_dir / "install_log.json"
+    log_path = inst_dir / ".VIS" / "install_log.json"
     if log_path.exists():
         try:
             with open(log_path) as f:

--- a/VIStk/Structures/Uninstaller.py
+++ b/VIStk/Structures/Uninstaller.py
@@ -60,13 +60,13 @@ handler.handle(sys.argv)
 def _find_install_log():
     """Return the parsed install_log.json dict and its parent directory."""
     if custom_path:
-        log_path = os.path.join(custom_path, "install_log.json")
+        log_path = os.path.join(custom_path, ".VIS", "install_log.json")
     elif getattr(sys, "frozen", False):
-        # Running as compiled exe — log is in same directory
-        log_path = os.path.join(os.path.dirname(sys.executable), "install_log.json")
+        # Running as compiled exe — log is in same directory as exe
+        log_path = os.path.join(os.path.dirname(sys.executable), ".VIS", "install_log.json")
     else:
         # Development fallback
-        log_path = os.path.join(os.path.dirname(__file__), "install_log.json")
+        log_path = os.path.join(os.path.dirname(__file__), ".VIS", "install_log.json")
 
     if not os.path.exists(log_path):
         return None, None
@@ -139,7 +139,7 @@ def remove_installed_files(log, location, progress_fn=None):
         steps.append(("dir", os.path.join(location, d), d))
 
     # install_log.json itself
-    steps.append(("file", os.path.join(location, "install_log.json"), "install_log.json"))
+    steps.append(("file", os.path.join(location, ".VIS", "install_log.json"), ".VIS/install_log.json"))
 
     total = len(steps)
     for i, (kind, path, label) in enumerate(steps):
@@ -154,22 +154,37 @@ def remove_installed_files(log, location, progress_fn=None):
             pass
 
     if progress_fn:
-        progress_fn(total, total, "Done")
+        progress_fn(total, total, "Cleaning up")
 
-    # Try to remove the install directory if empty
+    # Remove all remaining directories except Settings
+    _keep_dirs = {"Settings"}
     try:
-        remaining = os.listdir(location)
-        # Only self (the uninstaller exe) should remain
-        if len(remaining) <= 1:
-            for f in remaining:
-                fp = os.path.join(location, f)
-                if fp != sys.executable:
-                    try:
-                        os.remove(fp)
-                    except Exception:
-                        pass
+        for item in os.listdir(location):
+            if item in _keep_dirs:
+                continue
+            fp = os.path.join(location, item)
+            if os.path.isdir(fp):
+                try:
+                    shutil.rmtree(fp)
+                except Exception:
+                    pass
     except Exception:
         pass
+
+    # Remove remaining loose files (except the uninstaller exe itself)
+    try:
+        for item in os.listdir(location):
+            fp = os.path.join(location, item)
+            if os.path.isfile(fp) and fp != sys.executable:
+                try:
+                    os.remove(fp)
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+    if progress_fn:
+        progress_fn(total, total, "Done")
 
 
 def _own_pids() -> set[int]:
@@ -306,6 +321,10 @@ root.columnconfigure(2, weight=1, minsize=360)
 # ── Load app icon ─────────────────────────────────────────────────────────────
 d_icon = None
 _icon_photo = None
+_pinfo = {}
+_ptitle = None
+_install_dir = location
+_icon_ext = ".ico" if sys.platform == "win32" else ".xbm"
 if log is not None:
     try:
         _install_dir = log.get("install_location", location)
@@ -401,7 +420,20 @@ for idx, scr in enumerate(installed_screens):
     screen_options.rowconfigure(row, weight=1)
     name = scr["name"]
 
-    if d_icon is not None:
+    # Look up per-screen icon from project.json, fall back to default
+    _scr_img = None
+    try:
+        _scr_info = _pinfo[_ptitle]["Screens"].get(name, {})
+        _scr_icon_name = _scr_info.get("icon")
+        if _scr_icon_name:
+            _scr_icon_path = os.path.join(_install_dir, "Icons", _scr_icon_name + _icon_ext)
+            if os.path.exists(_scr_icon_path):
+                _scr_img = Image.open(_scr_icon_path)
+    except Exception:
+        pass
+    if _scr_img is not None:
+        img_items.append(PIL.ImageTk.PhotoImage(_scr_img.resize((16, 16))))
+    elif d_icon is not None:
         img_items.append(PIL.ImageTk.PhotoImage(d_icon.resize((16, 16))))
     else:
         img_items.append(None)

--- a/VIStk/Structures/_Help.py
+++ b/VIStk/Structures/_Help.py
@@ -75,22 +75,14 @@ def contextual_help(tokens: list[str]) -> None:
         print("  version         major.minor.patch")
         print("  current         version string or none")
 
-    # ── stop ──────────────────────────────────────────────────────────────────
-    elif cmd in ("stop", "Stop"):
-        print("Usage:  VIS stop\n")
-        print("Sends a quit signal to the running Host via IPC.")
-        print("No effect if no Host is running.")
-
     # ── release ───────────────────────────────────────────────────────────────
     elif cmd in ("release", "Release", "r", "R"):
         print("Usage:  VIS release [-Flag <suffix>] [-Type Major|Minor|Patch] [-Note <text>]")
         print("        VIS release Screen <name> [-Flag <suffix>]\n")
         print(
-            "Compiles all screens with release=true via PyInstaller, bundles with\n"
-            "Icons/, Images/, and .VIS/, and produces a self-extracting installer\n"
-            "in your Downloads folder.\n\n"
-            "The default screen compiles as the project name with the project icon.\n"
-            "All other screens use their own names and icons.\n\n"
+            "Compiles the Host with Nuitka (standalone), screens as .pyd modules,\n"
+            "shared packages to Shared/, bundles with Images/ and .VIS/, and\n"
+            "produces a self-extracting installer in your Downloads folder.\n\n"
             "Flags (optional, any order):\n"
             "  -Flag <suffix>           suffix appended to build folder and installer name\n"
             "  -Type Major|Minor|Patch  bump project version before building\n"
@@ -112,7 +104,6 @@ def _top_level():
         ("stitch",  "Rewire imports for a screen"),
         ("rename",  "Rename a screen throughout the project"),
         ("edit",    "Set a screen attribute in project.json"),
-        ("stop",    "Stop the running Host"),
         ("release", "Build and package as compiled executables"),
     ]
     print("VIS - VIStk project CLI\n")

--- a/VIStk/Structures/_Release.py
+++ b/VIStk/Structures/_Release.py
@@ -1,6 +1,7 @@
 from VIStk.Structures._Project import *
 from VIStk.Structures._VINFO import *
 from VIStk.Structures._Screen import *
+import re as _re
 import subprocess
 import shutil
 import glob
@@ -11,172 +12,393 @@ import hashlib
 import json
 from VIStk.Structures._Version import Version
 
+
 class Release(Project):
     """A VIS Release object"""
     def __init__(self, flag:str="",type:str="",note:str=""):
-        """Creates a Release object to release or examine a releaes of a project"""
+        """Creates a Release object to release or examine a release of a project"""
         super().__init__()
         self.type = type
         self.flag = flag
         self.note = note
 
-        self.location = self.dist_location.replace(".",self.p_project)
-        self._internal = f"{self.location}{self.title}-{self.flag}/_internal/"
+        loc = self.dist_location
+        if loc.startswith("./"):
+            loc = self.p_project + "/" + loc[2:]
+        elif not os.path.isabs(loc):
+            loc = self.p_project + "/" + loc
+        self.location = loc.rstrip("/") + "/"
 
-    def build(self):
-        """Build project spec file for release
+    # ── Nuitka runner ─────────────────────────────────────────────────────────
+
+    _LINE_WIDTH = 70
+
+    def _status(self, text: str, newline: bool = False):
+        """Overwrite the single progress line. Pads to _LINE_WIDTH."""
+        end = "\n" if newline else ""
+        sys.stdout.write(f"\r{text:<{self._LINE_WIDTH}}{end}")
+        sys.stdout.flush()
+
+    def _run_nuitka(self, parts: list, name: str, cwd: str) -> bool:
+        """Run a Nuitka command, showing progress on a single overwritten line.
+
+        Returns True on success, False on failure.
         """
+        self._cat_index += 1
+        self._step += 1
+        prefix = f"  [{self._step}/{self._total_steps}] {self._category} {self._cat_index}/{self._cat_count} - {name}"
+        self._status(prefix + " ...")
 
-        #Announce Spec Creation
-        print(f"Creating project.spec for {self.title}", flush=True)
+        proc = subprocess.Popen(
+            parts, cwd=cwd,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, errors="replace",
+        )
 
-        #Load spec template and inject hidden imports in memory
-        with open(self.p_vinfo+"/Templates/spec.txt","r") as f:
-            oldspec = f.readlines()
-        spec=""
-        for line in oldspec:
-            if "hiddenimports" in line:
-                if self.collect_packages:
-                    line = "\thiddenimports=" + str(self.hidden_imports) + " + _collected,\n"
-                else:
-                    line = "\thiddenimports=" + str(self.hidden_imports) + ",\n"
-            spec = spec + line
+        last_error = ""
+        for raw in proc.stdout:
+            for segment in raw.replace('\r', '\n').split('\n'):
+                segment = segment.strip()
+                if not segment:
+                    continue
+                # C file compilation progress
+                m = _re.search(r'Compiled (\d+)[/ ](?:out of )?(\d+)', segment)
+                if m:
+                    self._status(f"{prefix} — C {m.group(1)}/{m.group(2)}")
+                    continue
+                if 'Backend C linking' in segment:
+                    self._status(f"{prefix} — linking")
+                    continue
+                # Capture last FATAL/error line for failure reporting
+                if 'FATAL' in segment or 'error:' in segment.lower():
+                    last_error = segment
 
-        #Load Collect
-        with open(self.p_vinfo+"/Templates/collect.txt","r") as f:
-            collect = f.read()
+        proc.wait()
+        if proc.returncode != 0:
+            # Print failure on its own line so it stays visible
+            msg = f"{prefix} FAILED"
+            if last_error:
+                msg += f" — {last_error[:60]}"
+            self._status(msg, newline=True)
+            return False
+        return True
 
-        #Initialize locations for builds
-        spec_list = []
-        name_list = []
-        if os.path.exists(self.p_vinfo+"/Build"):
-            shutil.rmtree(self.p_vinfo+"/Build")
-        os.mkdir(self.p_vinfo+"/Build")
+    def compile_host(self):
+        """Compile the Host as a standalone Nuitka executable.
 
-        #Loop and Build Screens as .txt
-        for i in self.screenlist:
-            if i.release:
-                # Default screen releases as the project name with the project icon
-                is_default = (i.name == self.default_screen)
-                exe_name = self.title if is_default else i.name
-                icon = self.d_icon if is_default else (i.icon if i.icon is not None else self.d_icon)
+        Nuitka names the output folder after the entry script stem
+        (e.g. ``Host.dist``).  After compilation the contents are merged
+        into the final distribution folder (e.g. ``dist/PYWOM/``).
+        """
+        pendix = self.title if self.flag == "" else f"{self.title}-{self.flag}"
+        final = f"{self.location}{pendix}"
 
-                name_list.append(exe_name)
-                if str.upper(sys.platform)=="WIN32":
-                    ixt = ".ico"
-                else:
-                    ixt = ".xbm"
-                icon = icon + ixt
-                spec_list.append(spec.replace("$name$",exe_name))
-                spec_list[-1] = spec_list[-1].replace("$icon$",icon)
-                entry_script = self.host_script if is_default else i.script
-                spec_list[-1] = spec_list[-1].replace("$file$", entry_script)
+        ixt = ".ico" if sys.platform == "win32" else ".xbm"
+        icon_file = f"{self.p_project}/Icons/{self.d_icon}{ixt}"
 
-                #Load metadata template
-                with open(self.p_templates+"/version.txt","r") as f:
-                    meta = f.read()
+        # Read nuitka config from project.json
+        with open(self.p_sinfo, "r") as f:
+            info = json.load(f)
+        nuitka_cfg = info[self.title].get("release_info", {}).get("nuitka", {})
+        onefile = nuitka_cfg.get("onefile", False)
+        extra_args = nuitka_cfg.get("extra_args", [])
 
-                #Update Overall Project Version
-                meta = meta.replace("$M$",str(i.Version._major))
-                meta = meta.replace("$m$",str(i.Version._minor))
-                meta = meta.replace("$p$",str(i.Version._patch))
+        mode = "--onefile" if onefile else "--standalone"
 
-                #Update Screen Version
-                meta = meta.replace("$sM$",str(i.s_version._major))
-                meta = meta.replace("$sm$",str(i.s_version._minor))
-                meta = meta.replace("$sp$",str(i.s_version._patch))
+        parts = [sys.executable, "-m", "nuitka", mode]
+        parts.append("--follow-imports")
+        parts.append("--enable-plugin=tk-inter")
 
-                #Update Company Info
-                if self.company != None:
-                    meta = meta.replace("$company$",self.company)
-                    meta = meta.replace("$year$",str(datetime.datetime.now().year))
-                else:
-                    meta = meta.replace("            VALUE \"CompanyName\",      VER_COMPANYNAME_STR\n","")
-                    meta = meta.replace("            VALUE \"LegalCopyright\",   VER_LEGALCOPYRIGHT_STR\n","")
-                    meta = meta.replace("#define VER_LEGAL_COPYRIGHT_STR     \"Copyright \u00a9 $year$ $company$\\0\"\n\n","")
+        # Include hidden imports (pywomlib, VIStk, etc.)
+        for imp in self.hidden_imports:
+            parts.append(f"--include-module={imp}")
 
-                #Update Name & Description
-                meta = meta.replace("$name$",exe_name)
-                meta = meta.replace("$desc$",i.desc)
+        # Bundle project packages so screen .pyds can resolve imports at runtime
+        parts.append("--include-package=modules")
+        parts.append("--include-package=Screens")
 
-                #Write Screen Version Metadata to .txt
-                with open(self.p_vinfo+f"/Build/{exe_name}.txt","w") as f:
-                    f.write(meta)
+        # Icon
+        if icon_file and exists(icon_file):
+            parts.append(f"--windows-icon-from-ico={icon_file}")
 
-                #Speclist point to correct path
-                spec_list[-1] = spec_list[-1].replace("$meta$",f"./Build/{exe_name}.txt")
-                spec_list.append("\n\n")
+        # Company and product info
+        if self.company:
+            parts.append(f"--windows-company-name={self.company}")
+            parts.append(f"--windows-product-name={self.title}")
+            year = datetime.datetime.now().year
+            parts.append(f"--windows-file-description={self.title}")
+            parts.append(f"--copyright=Copyright {year} {self.company}")
 
-        #Create _a, _pyz, _exe and insert into Collect
-        if sys.platform == "linux": #No Collects on Linux
-            collect = ""
-            for i in range(0,len(spec_list),1):
-                spec_list[i] = spec_list[i].replace("exclude_binaries=True","exclude_binaries=False")
-        else:
-            insert = ""
-            for i in name_list:
-                insert=insert+"\n\t"+i+"_exe,\n\t"+i+"_a.binaries,\n\t"+i+"_a.zipfiles,\n\t"+i+"_a.datas,"
-            collect = collect.replace("$insert$",insert)
-            collect = collect.replace("$version$",self.title+"-"+self.flag) if self.flag != "" else collect.replace("$version$",self.title)
+        parts.append(f"--windows-product-version={self.Version}")
 
-        #Header for specfile
-        header = "# -*- mode: python ; coding: utf-8 -*-\n\n"
-        if self.collect_packages:
-            header += "from PyInstaller.utils.hooks import collect_submodules\n"
-            header += "_collected = []\n"
-            for pkg in self.collect_packages:
-                header += f"_collected += collect_submodules('{pkg}')\n"
-            header += "\n"
-        else:
-            header += "\n"
+        parts.append(f"--output-dir={self.location}")
+        parts.append(f"--output-filename={self.title}.exe")
 
-        #Write Spec
-        with open(self.p_vinfo+"/project.spec","w") as f:
-            f.write(header)
-            f.writelines(spec_list)
-            f.write(collect)
+        if sys.platform == "win32":
+            parts.append("--windows-console-mode=disable")
 
-        #Announce Completion
-        print(f"Finished creating project.spec for {self.title} {self.flag if not self.flag =='' else 'current'}", flush=True)#advanced version will improve this
+        parts.append("--assume-yes-for-downloads")
+
+        # Extra args from project.json
+        parts.extend(extra_args)
+
+        # Entry script is the Host
+        entry_script = self.host_script
+        parts.append(entry_script)
+
+        ok = self._run_nuitka(parts, self.title, self.p_project)
+
+        if not ok:
+            return False
+
+        # Nuitka names the .dist folder after the entry script stem
+        host_stem = os.path.splitext(os.path.basename(entry_script))[0]
+        nuitka_dist = f"{self.location}{host_stem}.dist"
+
+        _skip = {'.build', '_internal', '__pycache__'}
+        if exists(nuitka_dist):
+            if exists(final):
+                # Merge new build into existing folder (preserves screen exes etc.)
+                for dirpath, dirs, files in os.walk(nuitka_dist):
+                    dirs[:] = [d for d in dirs if d not in _skip and not d.endswith('.build')]
+                    rel = os.path.relpath(dirpath, nuitka_dist)
+                    dest = os.path.join(final, rel)
+                    os.makedirs(dest, exist_ok=True)
+                    for f in files:
+                        src = os.path.join(dirpath, f)
+                        shutil.copy2(src, os.path.join(dest, f))
+                shutil.rmtree(nuitka_dist)
+            else:
+                os.rename(nuitka_dist, final)
+
+        return True
+
+    def compile_screens(self, mode="all"):
+        """Compile each screen.
+
+        Every tabbed screen is compiled as a ``.pyd`` module in ``Screens/``
+        so the Host can load it dynamically at runtime.  The default screen
+        is skipped (it's the Host entry point compiled separately).
+
+        Standalone screens (``tabbed=false``) with ``release=true`` are
+        compiled as their own ``.exe`` and merged into the Host dist folder
+        so they share the runtime.
+
+        ``mode`` filters which screens to compile: ``"pyd"`` for tabbed
+        screens only, ``"exe"`` for standalone release screens only, or
+        ``"all"`` for both (default).
+        """
+        pendix = self.title if self.flag == "" else f"{self.title}-{self.flag}"
+        final = f"{self.location}{pendix}"
+        ixt = ".ico" if sys.platform == "win32" else ".xbm"
+
+        has_tabbed = False
+        for scr in self.screenlist:
+
+            if scr.tabbed and mode in ("all", "pyd"):
+                # Every tabbed screen → .pyd module
+                if not has_tabbed:
+                    os.makedirs(f"{final}/Screens", exist_ok=True)
+                    has_tabbed = True
+
+                stem = os.path.splitext(scr.script)[0]
+                parts = [
+                    sys.executable, "-m", "nuitka", "--module",
+                    f"--output-dir={self.location}",
+                    "--assume-yes-for-downloads",
+                    scr.script,
+                ]
+                ok = self._run_nuitka(parts, scr.name, self.p_project)
+
+                if not ok:
+                    return False
+
+                # Move .pyd to Screens/ with clean name (strip cpython tag)
+                import glob as _glob
+                built_pyds = _glob.glob(f"{self.location}{stem}*.pyd")
+                for bp in built_pyds:
+                    shutil.move(bp, f"{final}/Screens/{stem}.pyd")
+
+            elif not scr.tabbed and scr.release and mode in ("all", "exe"):
+                # Standalone screen with release=true — compile as its own exe
+                icon = (scr.icon if scr.icon else self.d_icon) + ixt
+                icon_file = f"{self.p_project}/Icons/{icon}"
+
+                parts = [
+                    sys.executable, "-m", "nuitka", "--standalone",
+                    "--enable-plugin=tk-inter",
+                    f"--output-dir={self.location}",
+                    f"--output-filename={scr.name}.exe",
+                    "--assume-yes-for-downloads",
+                ]
+                if icon_file and exists(icon_file):
+                    parts.append(f"--windows-icon-from-ico={icon_file}")
+                if self.company:
+                    parts.append(f"--windows-company-name={self.company}")
+                    parts.append(f"--windows-product-name={self.title}")
+                    year = datetime.datetime.now().year
+                    parts.append(f"--windows-file-description={scr.name}")
+                    parts.append(f"--copyright=Copyright {year} {self.company}")
+                parts.append(f"--windows-product-version={self.Version}")
+                if sys.platform == "win32":
+                    parts.append("--windows-console-mode=disable")
+                # Standalone screens share the Host runtime in .Runtime/
+                # Only follow direct imports — shared packages live alongside
+                parts.append("--follow-imports")
+                parts.append(scr.script)
+
+                ok = self._run_nuitka(parts, scr.name, self.p_project)
+
+                if not ok:
+                    return False
+
+                # Merge standalone build into the shared dist folder
+                scr_stem = os.path.splitext(scr.script)[0]
+                scr_dist = f"{self.location}{scr_stem}.dist"
+                if exists(scr_dist):
+                    _skip = {'.build', '_internal', '__pycache__'}
+                    for dirpath, dirs, files in os.walk(scr_dist):
+                        dirs[:] = [d for d in dirs if d not in _skip and not d.endswith('.build')]
+                        rel = os.path.relpath(dirpath, scr_dist)
+                        dest = os.path.join(final, rel)
+                        os.makedirs(dest, exist_ok=True)
+                        for f in files:
+                            dest_file = os.path.join(dest, f)
+                            if not exists(dest_file):
+                                shutil.copy2(os.path.join(dirpath, f), dest_file)
+                    shutil.rmtree(scr_dist)
+
+        return True
+
+    def compile_shared(self):
+        """Compile shared packages as .pyd modules into Shared/.
+
+        Top-level packages from ``hidden_imports`` (names without dots) are
+        compiled here.  Module-level hints like ``PIL._tkinter_finder`` are
+        skipped — those are passed to the Host build instead.
+
+        ``collect_packages`` entries are also compiled if present.
+        """
+        # Top-level packages from hidden_imports (no dots = full package)
+        packages = [imp for imp in self.hidden_imports if "." not in imp]
+        # Plus anything in collect_packages
+        for pkg in self.collect_packages:
+            if pkg not in packages:
+                packages.append(pkg)
+
+        if not packages:
+            return True
+
+        pendix = self.title if self.flag == "" else f"{self.title}-{self.flag}"
+        final = f"{self.location}{pendix}"
+        shared_dir = f"{final}/Shared"
+        os.makedirs(shared_dir, exist_ok=True)
+
+        for pkg in packages:
+            # Resolve the installed package path
+            try:
+                mod = __import__(pkg)
+                pkg_path = os.path.dirname(mod.__file__)
+            except Exception:
+                print(f"  Skipping {pkg} — not importable", flush=True)
+                continue
+
+            parts = [
+                sys.executable, "-m", "nuitka", "--module",
+                f"--output-dir={self.location}",
+                "--assume-yes-for-downloads",
+                pkg_path,
+            ]
+            ok = self._run_nuitka(parts, pkg, self.p_project)
+
+            if not ok:
+                return False
+
+            # Move .pyd to Shared/ directory — strip cpython tag
+            import glob as _glob
+            built_pyds = _glob.glob(f"{self.location}{pkg}*.pyd")
+            for bp in built_pyds:
+                shutil.move(bp, f"{shared_dir}/{pkg}.pyd")
+
+        return True
 
     def clean(self):
-        """Cleans up build environment to save space and appends to _internal"""
-        #Announce Removal
-        print("Cleaning up build environment", flush=True)
+        """Appends project data to dist folder.
 
-        #Remove Build Folder
-        if exists(self.p_vinfo+"/Build"):
-            shutil.rmtree(self.p_vinfo+"/Build")
-
-        #Announce Appending Screen Data
+        Copies Images, .VIS/project.json, and writes an installed
+        project.json with rewritten screen script paths.  Removes any
+        stray Nuitka ``.build`` directories from the output.
+        """
         print("Appending Screen Data To Environment", flush=True)
 
-        #Append Screen Data
         pendix = self.title if self.flag == "" else f"{self.title}-{self.flag}"
         out_dir = f"{self.location}{pendix}"
 
-        #Remove Pre-existing Folders for Icons, Images, & .VIS
-        for folder in ("Icons", "Images", ".VIS"):
-            target = f"{out_dir}/{folder}/"
-            if exists(target):
-                shutil.rmtree(target)
+        # Copy Images
+        src = f"{self.p_project}/Images/"
+        if exists(src):
+            shutil.copytree(src, f"{out_dir}/Images/", dirs_exist_ok=True)
 
-        #Copy Project Folders
-        for folder in ("Icons", "Images", ".VIS", "Screens", "modules"):
-            src = f"{self.p_project}/{folder}/"
+        # Copy Icons
+        src = f"{self.p_project}/Icons/"
+        if exists(src):
+            shutil.copytree(src, f"{out_dir}/Icons/", dirs_exist_ok=True)
+
+        # Copy license file if present
+        for name in ("LICENSE", "LICENSE.txt", "EULA.txt", "EULA.md"):
+            src = f"{self.p_project}/{name}"
             if exists(src):
-                shutil.copytree(src, f"{out_dir}/{folder}/", dirs_exist_ok=True)
+                shutil.copy2(src, f"{out_dir}/{name}")
+                break
 
-        #Copy screen entry scripts so the Host can dynamically import them
-        for i in self.screenlist:
-            if i.tabbed:
-                src_script = f"{self.p_project}/{i.script}"
-                if exists(src_script):
-                    shutil.copy2(src_script, f"{out_dir}/{i.script}")
+        # Copy project.json only (Host.py is compiled into the exe)
+        vis_dest = f"{out_dir}/.VIS"
+        os.makedirs(vis_dest, exist_ok=True)
+        src = f"{self.p_vinfo}/project.json"
+        if exists(src):
+            shutil.copy2(src, f"{vis_dest}/project.json")
 
+        # Rewrite installed project.json with .pyd script paths
+        installed_json = f"{vis_dest}/project.json"
+        if exists(installed_json):
+            with open(installed_json, "r") as f:
+                info = json.load(f)
+            for screen_name, screen_data in info[self.title]["Screens"].items():
+                if screen_data.get("tabbed", False):
+                    stem = os.path.splitext(screen_data["script"])[0]
+                    screen_data["script"] = f"Screens/{stem}.pyd"
+            with open(installed_json, "w") as f:
+                json.dump(info, f, indent=4)
 
-        #Announce Completion
-        print(f"\n\nReleased a new{' '+self.flag+' ' if not self.flag is None else ''}build of {self.title}!", flush=True)
+        # Remove any .build or .dist directories that leaked into the output
+        for item in os.listdir(out_dir):
+            full = os.path.join(out_dir, item)
+            if os.path.isdir(full) and (item.endswith(".build") or item.endswith(".dist") or item == "_internal"):
+                shutil.rmtree(full)
+
+        # Remove Host.py if left over from a previous build
+        stale_host = os.path.join(vis_dest, "Host.py")
+        if os.path.exists(stale_host):
+            os.remove(stale_host)
+
+        # Move runtime into hidden .Runtime/ subfolder
+        # Keep only asset dirs, Screens, and license files at root
+        _keep_at_root = {".VIS", "Icons", "Images", "Screens", "Shared", ".Runtime"}
+        _keep_files = {"LICENSE", "LICENSE.txt", "EULA.txt", "EULA.md"}
+        runtime_dir = os.path.join(out_dir, ".Runtime")
+        os.makedirs(runtime_dir, exist_ok=True)
+
+        for item in os.listdir(out_dir):
+            if item in _keep_at_root or item in _keep_files:
+                continue
+            full = os.path.join(out_dir, item)
+            dest = os.path.join(runtime_dir, item)
+            if os.path.isdir(full):
+                shutil.move(full, dest)
+            else:
+                shutil.move(full, dest)
+
+        print(f"\n\nReleased a new{' '+self.flag+' ' if self.flag else ' '}build of {self.title}!", flush=True)
 
     def newVersion(self):
         """Updates the project version, PERMANENT, cannot be undone"""
@@ -204,52 +426,230 @@ class Release(Project):
 
     def release(self):
         """Releases a version of your project"""
+        #Check default screen
+        if self.default_screen is None:
+            print("Warning: No default screen set in project.json.", flush=True)
+            print("The Host will launch with no visible window.", flush=True)
+            confirm = input("Continue anyway? (y/n): ")
+            if confirm.lower() not in ("y", "yes"):
+                return
+
         #Check Version
         if self.type != "":
             if not self.newVersion():
                 return
 
-        #Build
-        self.build()
-
-        #Announce and Update Required Tools
+        #Update Required Tools
         print("Updating pip...", flush=True)
         subprocess.call(f"python -m pip install --upgrade pip --quiet",shell=True)
 
-        print("Updating setuptools...", flush=True)
-        subprocess.call(f"python -m pip install --upgrade setuptools --quiet",shell=True)
+        print("Updating nuitka...", flush=True)
+        subprocess.call(f"python -m pip install --upgrade nuitka --quiet",shell=True)
 
         print("Updating pyinstaller...", flush=True)
         subprocess.call(f"python -m pip install --upgrade pyinstaller --quiet",shell=True)
 
-        #Determine Binary Destination
-        if sys.platform == "linux":
-            destination = self.location+self.title
-            if self.flag != "": destination = destination + "-" + self.flag
-        else:
-            destination = self.location
+        #Clean previous build output
+        pendix = self.title if self.flag == "" else f"{self.title}-{self.flag}"
+        final = f"{self.location}{pendix}"
+        if exists(final):
+            shutil.rmtree(final)
 
-        #Announce and Run PyInstaller
-        print(f"Running PyInstaller for {self.title}{' ' + self.flag if not self.flag =='' else ''}", flush=True)
-        subprocess.call(f"pyinstaller {self.p_vinfo}/project.spec --noconfirm --distpath {destination} --log-level FATAL",shell=True,cwd=self.p_vinfo)
+        #Compile — count steps per category
+        shared_pkgs = [imp for imp in self.hidden_imports if "." not in imp]
+        for pkg in self.collect_packages:
+            if pkg not in shared_pkgs:
+                shared_pkgs.append(pkg)
+        pkg_count = len(shared_pkgs)
+
+        screen_count = 0
+        binary_count = 1  # Host
+        for scr in self.screenlist:
+            if scr.tabbed:
+                screen_count += 1
+            elif scr.release:
+                binary_count += 1
+
+        total = pkg_count + screen_count + binary_count
+        self._step = 0
+        self._total_steps = total
+        print(f"\n{self.title} Release - {total} Compilations", flush=True)
+
+        # Required Packages (.pyd)
+        self._category = "Required Packages"
+        self._cat_index = 0
+        self._cat_count = pkg_count
+        if not self.compile_shared():
+            self._status("", newline=True)
+            print(f"\nRelease FAILED during Required Packages.", flush=True)
+            return
+
+        # Screens (.pyd)
+        self._category = "Screens"
+        self._cat_index = 0
+        self._cat_count = screen_count
+        if not self.compile_screens(mode="pyd"):
+            self._status("", newline=True)
+            print(f"\nRelease FAILED during Screen compilation.", flush=True)
+            return
+
+        # Binaries (.exe)
+        self._category = "Binaries"
+        self._cat_index = 0
+        self._cat_count = binary_count
+        if not self.compile_screens(mode="exe"):
+            self._status("", newline=True)
+            print(f"\nRelease FAILED during Binary compilation.", flush=True)
+            return
+        if not self.compile_host():
+            self._status("", newline=True)
+            print(f"\nRelease FAILED during Host compilation.", flush=True)
+            return
+
+        self._status("", newline=True)
 
         #Clean Environment
         self.clean()
 
-        #%Installer & Uninstaller Generation
+        #%Launcher Generation (cached per icon)
         pendix = self.title if self.flag == "" else f"{self.title}-{self.flag}"
         final = f"{self.location}{pendix}"
-        binaries_zip = f"{self.location}binaries.zip"
-
-        #Resolve icon for both installer and uninstaller
-        icon_file = self.d_icon
-        if sys.platform == "win32":
-            icon_file = self.p_project + "/Icons/" + icon_file + ".ico"
-        else:
-            icon_file = self.p_project + "/Icons/" + icon_file + ".xbm"
+        runtime_dir = f"{final}/.Runtime"
 
         cache_dir = self.p_vinfo + "/cache"
         os.makedirs(cache_dir, exist_ok=True)
+
+        launcher_src = VISROOT.replace("\\", "/") + "Structures/Launcher.py"
+        ixt = ".ico" if sys.platform == "win32" else ".xbm"
+
+        # Read launcher source hash once
+        launcher_hasher = hashlib.sha256()
+        with open(launcher_src, "rb") as f:
+            launcher_hasher.update(f.read())
+        launcher_src_hash = launcher_hasher.hexdigest()
+
+        # Build a mapping of exe name → icon file for each app exe in .Runtime/
+        _no_launcher = {"Uninstaller.exe"}
+        exe_icon_map = {}
+        if os.path.exists(runtime_dir):
+            for item in os.listdir(runtime_dir):
+                if item.endswith(".exe") and item not in _no_launcher:
+                    # Find the matching screen's icon, or fall back to default
+                    stem = os.path.splitext(item)[0]
+                    scr_icon = self.d_icon
+                    for scr in self.screenlist:
+                        if scr.name == stem and scr.icon:
+                            scr_icon = scr.icon
+                            break
+                    icon_path = f"{self.p_project}/Icons/{scr_icon}{ixt}"
+                    if not exists(icon_path):
+                        icon_path = f"{self.p_project}/Icons/{self.d_icon}{ixt}"
+                    exe_icon_map[item] = icon_path
+
+        # Build one cached launcher per unique icon
+        unique_icons = set(exe_icon_map.values())
+        icon_to_cache = {}
+        for icon_path in unique_icons:
+            # Hash launcher source + icon to detect changes
+            hasher = hashlib.sha256()
+            hasher.update(launcher_src_hash.encode())
+            if exists(icon_path):
+                with open(icon_path, "rb") as f:
+                    hasher.update(f.read())
+            icon_hash = hasher.hexdigest()[:12]
+
+            cache_name = f"launcher_{icon_hash}"
+            cache_path = cache_dir + f"/{cache_name}"
+            if sys.platform == "win32":
+                cache_path += ".exe"
+            hash_file = cache_dir + f"/{cache_name}.hash"
+
+            cached_hash = ""
+            if os.path.exists(hash_file) and os.path.exists(cache_path):
+                with open(hash_file, "r") as f:
+                    cached_hash = f.read().strip()
+
+            if cached_hash == icon_hash:
+                pass  # Cache hit
+            else:
+                icon_name = os.path.splitext(os.path.basename(icon_path))[0]
+                print(f"Compiling launcher ({icon_name})", flush=True)
+                icon_arg = f"--icon {icon_path} " if exists(icon_path) else ""
+                subprocess.call(
+                    f"pyinstaller --noconfirm --onefile "
+                    f"--windowed --name {cache_name} --log-level FATAL "
+                    f"{icon_arg}"
+                    f"{launcher_src}",
+                    shell=True, cwd=self.location
+                )
+                launcher_results = glob.glob(f"{cache_name}*", root_dir=self.location + "dist/")
+                if not launcher_results:
+                    print(f"Build failed: {cache_name} not found in dist/")
+                    return
+                built_launcher = launcher_results[0]
+                shutil.copy2(self.location + f"dist/{built_launcher}", cache_path)
+                with open(hash_file, "w") as f:
+                    f.write(icon_hash)
+                shutil.rmtree(self.location + "dist/", ignore_errors=True)
+                shutil.rmtree(self.location + "build/", ignore_errors=True)
+                spec_file = self.location + f"{cache_name}.spec"
+                if os.path.exists(spec_file):
+                    os.remove(spec_file)
+                print(f"Launcher cached ({icon_name})", flush=True)
+
+            icon_to_cache[icon_path] = cache_path
+
+        # Place launchers with correct per-screen icons
+        count = 0
+        for exe_name, icon_path in exe_icon_map.items():
+            cache_path = icon_to_cache[icon_path]
+            shutil.copy2(cache_path, os.path.join(final, exe_name))
+            count += 1
+        if count:
+            print(f"Launchers placed for {count} executable(s)", flush=True)
+
+        #%Installer & Uninstaller Generation
+        binaries_zip = f"{self.location}binaries.zip"
+
+        #Resolve icon for installer and uninstaller
+        with open(self.p_sinfo, "r") as f:
+            _inst_info = json.load(f)
+        installer_icon_name = _inst_info[self.title].get("metadata", {}).get("installer_icon", self.d_icon)
+        ixt = ".ico" if sys.platform == "win32" else ".xbm"
+        icon_file = self.p_project + "/Icons/" + installer_icon_name + ixt
+        if not exists(icon_file):
+            # Fall back to default app icon
+            icon_file = self.p_project + "/Icons/" + self.d_icon + ixt
+
+        cache_dir = self.p_vinfo + "/cache"
+        os.makedirs(cache_dir, exist_ok=True)
+
+        # Generate version info file for PyInstaller builds
+        ver_parts = str(self.Version).split(".")
+        ver_tuple = ", ".join(ver_parts + ["0"] * (4 - len(ver_parts)))
+        ver_str = str(self.Version)
+        year = datetime.datetime.now().year
+        version_info_path = cache_dir + "/version_info.txt"
+        _esc = lambda s: s.replace("'", "\\'") if s else ""
+        with open(version_info_path, "w") as vf:
+            vf.write(f"""VSVersionInfo(
+  ffi=FixedFileInfo(filevers=({ver_tuple}), prodvers=({ver_tuple})),
+  kids=[
+    StringFileInfo([
+      StringTable('040904B0', [
+        StringStruct('CompanyName', '{_esc(self.company)}'),
+        StringStruct('FileDescription', '{_esc(self.title)} Installer'),
+        StringStruct('FileVersion', '{ver_str}'),
+        StringStruct('LegalCopyright', 'Copyright {year} {_esc(self.company)}'),
+        StringStruct('OriginalFilename', '{_esc(pendix)}_Installer.exe'),
+        StringStruct('ProductName', '{_esc(self.title)}'),
+        StringStruct('ProductVersion', '{ver_str}'),
+      ])
+    ]),
+    VarFileInfo([VarStruct('Translation', [1033, 1200])])
+  ]
+)
+""")
 
         #%Uninstaller compilation (cached)
         uninstaller_src = VISROOT.replace("\\","/")+"Structures/Uninstaller.py"
@@ -258,9 +658,9 @@ class Release(Project):
             cache_uninstaller += ".exe"
         uninst_hash_file = cache_dir + "/uninstaller.hash"
 
-        #Hash uninstaller source + icon to detect changes
+        #Hash uninstaller source + icon + version info to detect changes
         uninst_hasher = hashlib.sha256()
-        for path in (uninstaller_src, icon_file):
+        for path in (uninstaller_src, icon_file, version_info_path):
             with open(path, "rb") as f:
                 uninst_hasher.update(f.read())
         uninst_current_hash = uninst_hasher.hexdigest()
@@ -280,6 +680,7 @@ class Release(Project):
                 f"{'--uac-admin ' if sys.platform == 'win32' else ''}"
                 f"--windowed --name Uninstaller --log-level FATAL "
                 f"--icon {icon_file} --hidden-import PIL._tkinter_finder "
+                f"--version-file {version_info_path} "
                 f"{uninstaller_src}",
                 shell=True, cwd=self.location
             )
@@ -297,8 +698,8 @@ class Release(Project):
                 f.write(uninst_current_hash)
 
             #Clean PyInstaller build artifacts
-            shutil.rmtree(self.location+"dist/")
-            shutil.rmtree(self.location+"build/")
+            shutil.rmtree(self.location+"dist/", ignore_errors=True)
+            shutil.rmtree(self.location+"build/", ignore_errors=True)
             if os.path.exists(self.location+"Uninstaller.spec"):
                 os.remove(self.location+"Uninstaller.spec")
 
@@ -321,9 +722,9 @@ class Release(Project):
             cache_base += ".exe"
         cache_hash_file = cache_dir + "/installer.hash"
 
-        #Hash installer source + icon to detect changes
+        #Hash installer source + icon + version info to detect changes
         hasher = hashlib.sha256()
-        for path in (installer_src, icon_file):
+        for path in (installer_src, icon_file, version_info_path):
             with open(path, "rb") as f:
                 hasher.update(f.read())
         current_hash = hasher.hexdigest()
@@ -344,6 +745,7 @@ class Release(Project):
                 f"--windowed --name installer_base --log-level FATAL "
                 f"--icon {icon_file} --hidden-import PIL._tkinter_finder "
                 f"--hidden-import psutil "
+                f"--version-file {version_info_path} "
                 f"{installer_src}",
                 shell=True, cwd=self.location
             )
@@ -361,8 +763,8 @@ class Release(Project):
                 f.write(current_hash)
 
             #Clean PyInstaller build artifacts
-            shutil.rmtree(self.location+"dist/")
-            shutil.rmtree(self.location+"build/")
+            shutil.rmtree(self.location+"dist/", ignore_errors=True)
+            shutil.rmtree(self.location+"build/", ignore_errors=True)
             if os.path.exists(self.location+"installer_base.spec"):
                 os.remove(self.location+"installer_base.spec")
 

--- a/VIStk/Structures/_Screen.py
+++ b/VIStk/Structures/_Screen.py
@@ -7,7 +7,6 @@ from VIStk.Structures._VINFO import *
 from tkinter import *
 from pathlib import Path
 import sys
-import os
 import subprocess
 from notifypy import Notify
 
@@ -71,11 +70,12 @@ class Screen(VINFO):
         with open(self.p_sinfo,"r") as f:
             info = json.load(f)
 
-        self.desc = info[self.title]["Screens"][self.name]["desc"]
+        scr_data = info[self.title]["Screens"][self.name]
+        self.desc = scr_data.get("desc", "")
         """Screen Description"""
-        self.s_version = Version(info[self.title]["Screens"][self.name]["version"])
+        self.s_version = Version(scr_data.get("version", "0.0.0"))
         """Screen `Version`"""
-        self.current = info[self.title]["Screens"][self.name]["current"]#remove later
+        self.current = scr_data.get("current", "0.0.0")#remove later
         self.tabbed: bool = info[self.title]["Screens"][self.name].get("tabbed", False)
         """Whether this screen opens as a tab inside the Host window"""
         self.single_instance: bool = info[self.title]["Screens"][self.name].get("single_instance", False)
@@ -118,7 +118,7 @@ class Screen(VINFO):
         re-indented to match the section header's indentation, so this works
         correctly for sections inside functions as well as at module level.
         """
-        pattern = rf"([ \t]*#%{re.escape(section_name)}\n).*?(?=\n?[ \t]*#%)"
+        pattern = rf"([ \t]*#%{re.escape(section_name)}\n).*?(?=\n?[ \t]*#%|\Z)"
 
         def replacer(m: re.Match) -> str:
             header = m.group(1)
@@ -152,14 +152,47 @@ class Screen(VINFO):
         elements_str = ("\n".join(element_lines) + "\n") if element_lines else ""
         text = self._replace_section(text, "Screen Elements", elements_str)
 
-        #Modules
-        modules = glob.glob(self.m_path+'/m_*')#get all modules
-        for i in range(0,len(modules),1):#iterate into module format
-            modules[i] = modules[i].replace("\\","/")
-            modules[i] = modules[i].replace(self.m_path+"/","modules."+self.name+".")[:-3]
-            stitched.append(modules[i])
-        modules_str = ("from " + " import *\nfrom ".join(modules) + " import *\n") if modules else ""
+        #Modules — package import pattern
+        modules_pkg_init = os.path.join(self.p_project, "modules", "__init__.py")
+        if not os.path.exists(modules_pkg_init):
+            Path(modules_pkg_init).touch()
+
+        modules = glob.glob(self.m_path+'/m_*')
+        for m in modules:
+            stitched.append(m)
+        modules_str = f"from modules import {self.name}\n" if modules else ""
         text = self._replace_section(text, "Screen Modules", modules_str)
+
+        if modules:
+            mod_names = [Path(m).stem for m in sorted(modules)]
+            generated_block = (
+                f"_module_names = {mod_names!r}\n"
+                f"\n"
+                f"def __getattr__(name):\n"
+                f"    if name in _module_names:\n"
+                f"        import importlib\n"
+                f"        mod = importlib.import_module(f'.{{name}}', __name__)\n"
+                f"        globals()[name] = mod\n"
+                f"        return mod\n"
+                f"    raise AttributeError(f\"module {{__name__!r}} has no attribute {{name!r}}\")\n"
+            )
+
+            init_path = self.m_path + "/__init__.py"
+
+            if os.path.exists(init_path):
+                with open(init_path, "r") as f:
+                    existing = f.read()
+                new_init = self._replace_section(existing, "Modules (Auto-generated)", generated_block)
+            else:
+                new_init = (
+                    "#%Modules (Auto-generated)\n"
+                    f"{generated_block}\n"
+                    "#%Screen Variables\n\n"
+                    "#%Exports\n"
+                )
+
+            with open(init_path, "w") as f:
+                f.write(new_init)
 
         #write out
         with open(self.p_project+"/"+self.script,"w") as f:
@@ -191,14 +224,14 @@ class Screen(VINFO):
             f"# Fill in the items list, then set label= to whatever should appear\n"
             f"# in the Host menu bar.\n"
             f"\n"
-            f"def configure_menu(menubar):\n"
-            f"    menubar.set_screen_items([\n"
+            f"def configure_menu(tabmanager):\n"
+            f"    tabmanager.add_cascade(\"{menu}\", [\n"
             f"        # {{\"label\": \"Item\",    \"command\": some_fn}},\n"
             f"        # {{\"separator\": True}},\n"
             f"        # {{\"label\": \"Submenu\", \"items\": [\n"
             f"        #     {{\"label\": \"Sub-item\", \"command\": some_fn}},\n"
             f"        # ]}},\n"
-            f"    ], label=\"{menu}\")\n"
+            f"    ])\n"
         )
         with open(menu_path, "w") as f:
             f.write(content)
@@ -216,8 +249,8 @@ class Screen(VINFO):
                     f"\n# Auto-wired by: VIS add screen {self.name} menu {menu}\n"
                     f"from modules.{self.name}.m_{menu} import configure_menu as _cm_{menu}\n"
                     f"\n"
-                    f"def configure_menu(menubar):\n"
-                    f"    _cm_{menu}(menubar)\n"
+                    f"def configure_menu(tabmanager):\n"
+                    f"    _cm_{menu}(tabmanager)\n"
                 )
                 with open(hooks_path, "a") as f:
                     f.write(delegation)
@@ -240,36 +273,32 @@ class Screen(VINFO):
     def load(self, *args):
         """Loads this screen.
 
-        If a Host is running (port file present), sends the screen name via IPC
-        so the Host handles routing (tab or subprocess).  Falls back to
-        spawning a Host subprocess when running from source.  In a compiled
-        (frozen) app, subprocess spawning is skipped — the compiled exe is
-        already the Host.
+        If a Host is running in-process, routes through it.  Otherwise
+        spawns a Host subprocess with this screen name as the first arg.
+        In a compiled (frozen) app, subprocess spawning is skipped.
         """
-        if send_to_host(self.title, self.name):
+        from VIStk.Objects._Host import _HOST_INSTANCE
+        if _HOST_INSTANCE is not None:
+            _HOST_INSTANCE.open(self.name)
             return
         if getattr(sys, 'frozen', False):
             return  # compiled exe is the Host; can't spawn another
-        import time, tempfile
         host_path = str(Path(getPath()) / ".VIS" / "Host.py")
-        subprocess.Popen([sys.executable, host_path])
-        port_file = os.path.join(tempfile.gettempdir(),
-                                 self.title.replace(" ", "_") + "_vis_host.port")
-        for _ in range(30):
-            time.sleep(0.1)
-            if os.path.exists(port_file):
-                time.sleep(0.1)
-                break
-        send_to_host(self.title, self.name)
-        sys.exit(0)
+        subprocess.Popen([sys.executable, host_path, self.name])
 
     def close(self) -> bool:
-        """Ask the Host to close this screen (tab or Toplevel).
+        """Ask the Host to close this screen's tab.
 
-        Returns ``True`` if the request was delivered, ``False`` if no Host
-        is running (in standalone mode there is nothing to close via IPC).
+        Returns ``True`` if the tab was found and closed, ``False`` otherwise.
         """
-        return send_to_host(self.title, f"__VIS_CLOSE__:{self.name}")
+        from VIStk.Objects._Host import _HOST_INSTANCE
+        if _HOST_INSTANCE is None:
+            return False
+        tm, display = _HOST_INSTANCE._find_tab_by_base(self.name)
+        if tm is not None and display is not None:
+            tm.close_tab(display)
+            return True
+        return False
 
     def getModules(self, script:str=None) -> list[str]:
         """Gets a list of all modules in the screens folder"""

--- a/VIStk/Structures/_VINFO.py
+++ b/VIStk/Structures/_VINFO.py
@@ -1,42 +1,11 @@
 import os
 import json
-import socket
 import sys
-import tempfile
 import zipfile
 import shutil
 import VIStk
 from VIStk.Structures._Version import Version
 
-
-def send_to_host(project_title: str, screen_name: str) -> bool:
-    """Send a screen-open request to a running Host via IPC.
-
-    Reads the port file written by ``Host._start_ipc()`` and connects to
-    the local TCP server.  Returns ``True`` if the message was delivered,
-    ``False`` if no Host is running or the connection fails.
-
-    Args:
-        project_title: The VIS project title (used to locate the port file).
-        screen_name:   Name of the screen to open.
-    """
-    safe = project_title.replace(" ", "_")
-    port_file = os.path.join(tempfile.gettempdir(), f"{safe}_vis_host.port")
-    if not os.path.exists(port_file):
-        return False
-    try:
-        with open(port_file) as f:
-            port = int(f.read().strip())
-        with socket.create_connection(("127.0.0.1", port), timeout=1) as s:
-            s.sendall(screen_name.encode("utf-8"))
-        return True
-    except Exception:
-        # Host unreachable — port file is stale; remove it so a new Host can start
-        try:
-            os.remove(port_file)
-        except OSError:
-            pass
-        return False
 
 VISROOT = VIStk.__file__.replace("__init__.pyc","").replace("__init__.py","")
 
@@ -59,8 +28,11 @@ def getPath()->str:
         start = os.getcwd()
     wd = start.replace("\\","/").split("/")
     for i in range(len(wd),0,-1):
-        if os.path.exists("/".join(wd[:i])+"/.VIS/"):
-            return "/".join(wd[:i])
+        candidate = "/".join(wd[:i])
+        if not candidate.endswith("/"):
+            candidate += "/"
+        if os.path.exists(candidate + ".VIS/"):
+            return candidate.rstrip("/")
     else:
         return None
 
@@ -68,7 +40,6 @@ _RESERVED_VIS_COMMANDS = {
     "-v", "-V", "-Version", "-version",
     "new", "New", "N", "n",
     "add", "Add", "a", "A",
-    "stop", "Stop",
     "stitch", "Stitch", "s", "S",
     "rename", "Rename",
     "edit", "Edit",
@@ -87,7 +58,7 @@ def validName(name:str):
     if "<" in name or ">" in name or ":" in name or '"' in name or "|" in name or "?" in name or "*" in name:
         print('Invlaid ASCII characters for windows file creation, please remove all <>:"|?* from file name.')
         return False
-    if name.split(".")[0] in ["CON","PRN","AUX","NUL","COM1","COM2","COM3","COM4","COM5","COM6","COM7","COM8","COM9","LPT1","LPT2","LPT3","LPT4","LPT5","LPT6","LPT7","LPT8","LPT9"]:
+    if name.split(".")[0].upper() in {"CON","PRN","AUX","NUL","COM1","COM2","COM3","COM4","COM5","COM6","COM7","COM8","COM9","LPT1","LPT2","LPT3","LPT4","LPT5","LPT6","LPT7","LPT8","LPT9"}:
         print(f"Filename {name} reserved by OS.")
         return False
     if "" == name:

--- a/VIStk/Structures/_Version.py
+++ b/VIStk/Structures/_Version.py
@@ -3,9 +3,14 @@ class Version():
     def __init__(self, version:str):
         """Creates a Version Number Object from a string"""
         nums = version.split(".")
-        self._major=int(nums[0])
-        self._minor=int(nums[1])
-        self._patch=int(nums[2])
+        if len(nums) < 3:
+            raise ValueError(f"Version string must be 'major.minor.patch', got '{version}'")
+        try:
+            self._major=int(nums[0])
+            self._minor=int(nums[1])
+            self._patch=int(nums[2])
+        except ValueError:
+            raise ValueError(f"Version segments must be integers, got '{version}'")
 
     def __str__(self) -> str:
         return f"{self._major}.{self._minor}.{self._patch}"

--- a/VIStk/VIS.py
+++ b/VIStk/VIS.py
@@ -1,33 +1,12 @@
 import sys
 import os
 import subprocess
-import tempfile
-import time
 import zipfile
 from importlib import metadata
+from pathlib import Path
 from VIStk.Structures import *
+from VIStk.Structures._VINFO import getPath
 
-
-def _start_host_and_wait(project, timeout: float = 5.0) -> bool:
-    """Spawn the project Host as a subprocess and wait for IPC to become ready.
-
-    Returns True if the Host's port file appears within *timeout* seconds,
-    False otherwise.  Returns False immediately in compiled (frozen) apps
-    where subprocess spawning is not possible.
-    """
-    if getattr(sys, 'frozen', False):
-        return False
-    host_path = project.p_project + "/" + project.host_script
-    subprocess.Popen([sys.executable, host_path])
-    safe = project.title.replace(" ", "_")
-    port_file = os.path.join(tempfile.gettempdir(), f"{safe}_vis_host.port")
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        if os.path.exists(port_file):
-            time.sleep(0.15)  # Give the socket a moment to finish binding
-            return True
-        time.sleep(0.05)
-    return False
 
 inp = sys.argv
 
@@ -50,7 +29,7 @@ def __main__():
     match inp[1]:
         case "-v"|"-V"|"-Version"|"-version":
             print(f"VIS Version {metadata.version('VIStk')}")
-            
+
         case "new"|"New"|"N"|"n":#Create a new VIS project
             VINFO()
             scr_name = input("Enter a name for the default screen (or Enter to skip): ").strip()
@@ -84,13 +63,6 @@ def __main__():
                                     print("Usage: VIS add screen <name> elements <elem1-elem2-...>")
                     else:
                         project.newScreen(inp[3])
-
-        case "stop" | "Stop":
-            info = VINFO()
-            if send_to_host(info.title, "__VIS_QUIT__"):
-                print(f"Stopped Host for project '{info.title}'.")
-            else:
-                print(f"No Host is running for project '{info.title}'.")
 
         case "stitch" | "Stitch" | "s" | "S":
             if len(inp) < 3:
@@ -131,37 +103,36 @@ def __main__():
                     screen = project.getScreen(inp[3])
                     if screen is not None:
                         screen.isolate()
-
                     else:
                         print(f"Cannot Locate Screen: \"{inp[3]}\"")
                         return None
 
-                args = inp[argstart:]
-                i=0
-                while i < len(args):
-                    if "-" == args[i][0]:
-                        match args[i][1:]:
-                            case "Flag" | "flag" | "F" | "f":
-                                if i + 1 >= len(args):
-                                    print(f"Missing value for {args[i]}")
-                                    return None
-                                flag = args[i+1]
-                                i += 2
-                            case "Type" | "type" | "T" | "t":
-                                if i + 1 >= len(args):
-                                    print(f"Missing value for {args[i]}")
-                                    return None
-                                type = args[i+1]
-                                i += 2
-                            case "Note" | "note" | "N" | "n":
-                                if i + 1 >= len(args):
-                                    print(f"Missing value for {args[i]}")
-                                    return None
-                                note = args[i+1]
-                                i += 2
-                            case _:
-                                print(f"Unknown Argument \"{args[i]}\"")
+            args = inp[argstart:]
+            i=0
+            while i < len(args):
+                if "-" == args[i][0]:
+                    match args[i][1:]:
+                        case "Flag" | "flag" | "F" | "f":
+                            if i + 1 >= len(args):
+                                print(f"Missing value for {args[i]}")
                                 return None
+                            flag = args[i+1]
+                            i += 2
+                        case "Type" | "type" | "T" | "t":
+                            if i + 1 >= len(args):
+                                print(f"Missing value for {args[i]}")
+                                return None
+                            type = args[i+1]
+                            i += 2
+                        case "Note" | "note" | "N" | "n":
+                            if i + 1 >= len(args):
+                                print(f"Missing value for {args[i]}")
+                                return None
+                            note = args[i+1]
+                            i += 2
+                        case _:
+                            print(f"Unknown Argument \"{args[i]}\"")
+                            return None
 
             rel = Release(flag,type,note)
             rel.release()
@@ -170,33 +141,9 @@ def __main__():
         case _:
             project = Project()
             if inp[1] == project.title:
-                if len(inp) >= 3:
-                    # VIS <ProjectName> <ScreenName> — open a screen.
-                    # Tabbed screens route through the Host; standalone screens
-                    # launch directly as a subprocess without requiring the Host.
-                    screen = project.getScreen(inp[2])
-                    if screen is not None:
-                        if screen.tabbed:
-                            if not send_to_host(project.title, screen.name):
-                                if _start_host_and_wait(project):
-                                    send_to_host(project.title, screen.name)
-                                else:
-                                    print(f"Failed to start Host for '{project.title}'.")
-                        else:
-                            script = project.p_project + "/" + screen.script
-                            subprocess.Popen([sys.executable, script])
-                    else:
-                        names = ", ".join(s.name for s in project.screenlist)
-                        print(f"Unknown screen: \"{inp[2]}\". Available: {names}")
-                else:
-                    # VIS <ProjectName> — start Host if needed, then open default screen.
-                    safe = project.title.replace(" ", "_")
-                    port_file = os.path.join(tempfile.gettempdir(),
-                                             f"{safe}_vis_host.port")
-                    if not os.path.exists(port_file):
-                        if not _start_host_and_wait(project):
-                            print(f"Failed to start Host for '{project.title}'.")
-                    if project.default_screen:
-                        send_to_host(project.title, project.default_screen)
+                # VIS <ProjectName> [ScreenName] — launch Host subprocess
+                host_path = str(Path(getPath()) / ".VIS" / "Host.py")
+                extra_args = inp[2:]  # screen name if provided
+                subprocess.Popen([sys.executable, host_path] + extra_args)
             else:
                 print(f"Unknown command: \"{inp[1]}\". Run 'VIS -v' for version info.")

--- a/VIStk/Widgets/_HostMenu.py
+++ b/VIStk/Widgets/_HostMenu.py
@@ -58,8 +58,8 @@ class HostMenu:
         self._quit_command = quit_command
         self._close_command = close_command
         self._project_labels: list[str] = []
-        self._screen_indices: list[int] = []
-        self._replaced_shared: set[int] = set()
+        self._screen_labels: list[str] = []
+        self._replaced_shared: set[str] = set()
         self._shared_menus: dict[str, Menu] = {}
         self._shared_defaults: dict[str, dict[str, dict]] = {}
         self._hidden_shared: list[tuple[str, int, Menu]] = []
@@ -125,25 +125,25 @@ class HostMenu:
                 old_menu = self._shared_menus[label]
                 self._hidden_shared.append((label, idx, old_menu))
                 self.menubar.entryconfigure(idx, menu=cascade)
-                self._replaced_shared.add(idx)
-                self._screen_indices.append(idx)
+                self._replaced_shared.add(label)
+                self._screen_labels.append(label)
                 return
             except TclError:
                 pass
 
         self.menubar.add_cascade(label=label, menu=cascade)
-        self._screen_indices.append(self.menubar.index("end"))
+        self._screen_labels.append(label)
 
     def clear_screen_items(self):
         """Remove all accumulated screen cascades and restore shared ones."""
-        for idx in reversed(self._screen_indices):
-            if idx in self._replaced_shared:
+        for label in reversed(self._screen_labels):
+            if label in self._replaced_shared:
                 continue
             try:
-                self.menubar.delete(idx)
+                self.menubar.delete(label)
             except TclError:
                 pass
-        self._screen_indices.clear()
+        self._screen_labels.clear()
         self._replaced_shared.clear()
         # Restore hidden shared cascades
         for label, idx, old_menu in self._hidden_shared:
@@ -251,6 +251,28 @@ class HostMenu:
             for item_label, opts in defaults.items():
                 try:
                     cascade.entryconfig(item_label, **opts)
+                except TclError:
+                    pass
+
+    # ── Default snapshot ──────────────────────────────────────────────────────
+
+    def save_defaults(self):
+        """Snapshot the current menubar state (called once after setup)."""
+        idx = self.menubar.index("end")
+        self._default_end = idx if idx is not None else 0
+
+    def restore_defaults(self):
+        """Reset the menubar to the snapshot taken by save_defaults().
+
+        Removes any cascades added after the snapshot.
+        """
+        if not hasattr(self, "_default_end") or self._default_end is None:
+            return
+        current = self.menubar.index("end")
+        if current is not None and self._default_end is not None:
+            for i in range(current, self._default_end, -1):
+                try:
+                    self.menubar.delete(i)
                 except TclError:
                     pass
 

--- a/VIStk/Widgets/_MenuItem.py
+++ b/VIStk/Widgets/_MenuItem.py
@@ -42,8 +42,8 @@ class MenuItem(Button):
         #Should have a more VIStk way to switch screens
 
         if not self.screen is None:
-            self.screen.load()
             self.root.destroy()
+            self.screen.load()
             return
         if ".exe" in self.path:
             os.startfile(self.path)

--- a/VIStk/Widgets/_QuestionWindow.py
+++ b/VIStk/Widgets/_QuestionWindow.py
@@ -81,9 +81,20 @@ class QuestionWindow(SubRoot):
                                         window_ref=parent)
 
     def ycom(self,command):
+        selection = self.get_dropdown_value()
         self.destroy()
         if not command is None:
-            command()
+            if selection is not None:
+                command(selection)
+            else:
+                command()
+
+    def get_dropdown_value(self):
+        """Return the selected dropdown value, or None if no dropdown exists."""
+        for elem in self.screen_elements:
+            if isinstance(elem, ttk.Combobox):
+                return elem.get() or None
+        return None
 
     def xcom(self):
         self.destroy()

--- a/VIStk/Widgets/_ScrollableFrame.py
+++ b/VIStk/Widgets/_ScrollableFrame.py
@@ -5,6 +5,7 @@ import sys
 class ScrollableFrame(ttk.Frame):
     _active = None  # class-level: which instance currently owns the scroll
     _is_linux = sys.platform == "linux"
+    _bound = False  # class-level: whether the global scroll binding exists
 
     def __init__(self, root, *args, **kwargs):
         super().__init__(root, *args, **kwargs)
@@ -34,28 +35,24 @@ class ScrollableFrame(ttk.Frame):
         self.canvas.bind("<Enter>", self._on_enter)
         self.canvas.bind("<Leave>", self._on_leave)
 
-    def _bind_scroll(self):
-        if ScrollableFrame._is_linux:
-            self.canvas.bind_all("<Button-4>", ScrollableFrame._dispatch_scroll)
-            self.canvas.bind_all("<Button-5>", ScrollableFrame._dispatch_scroll)
-        else:
-            self.canvas.bind_all("<MouseWheel>", ScrollableFrame._dispatch_scroll)
+        if not ScrollableFrame._bound:
+            ScrollableFrame._bind_scroll_global(self.canvas)
 
-    def _unbind_scroll(self):
-        if ScrollableFrame._is_linux:
-            self.canvas.unbind_all("<Button-4>")
-            self.canvas.unbind_all("<Button-5>")
+    @classmethod
+    def _bind_scroll_global(cls, canvas):
+        if cls._is_linux:
+            canvas.bind_all("<Button-4>", cls._dispatch_scroll)
+            canvas.bind_all("<Button-5>", cls._dispatch_scroll)
         else:
-            self.canvas.unbind_all("<MouseWheel>")
+            canvas.bind_all("<MouseWheel>", cls._dispatch_scroll)
+        cls._bound = True
 
     def _on_enter(self, event):
         ScrollableFrame._active = self
-        self._bind_scroll()
 
     def _on_leave(self, event):
         if ScrollableFrame._active is self:
             ScrollableFrame._active = None
-            self._unbind_scroll()
 
     @staticmethod
     def _dispatch_scroll(event):
@@ -66,8 +63,8 @@ class ScrollableFrame(ttk.Frame):
 
     def sizeFrame(self, event:Event):
         """Sizing the Frame"""
-        canvas_width=self.master.winfo_width()
-        canvas_height=self.master.winfo_height()
+        canvas_width=event.width
+        canvas_height=event.height
         self.canvas.config(width=canvas_width-17, height=canvas_height)
         self.canvas.itemconfig(self.sfid, width=canvas_width-17)
 

--- a/VIStk/Widgets/_VISMenu.py
+++ b/VIStk/Widgets/_VISMenu.py
@@ -56,8 +56,16 @@ class VISMenu():
             self.ob_dict[0].bind("<Configure>", lambda e: fUtil.autosize(e))
         if len(self.ob_dict) >1:
             self.ob_dict[0].bind("<Configure>", lambda e: fUtil.autosize(e,relations=self.ob_dict[1:]))
-        self.root.bind("<KeyPress>",self.menuNav)        
-    
+        self._kb_id = self.root.bind("<KeyPress>", self.menuNav, add="+")
+        self.parent.bind("<Destroy>", self._on_destroy, add="+")
+
+    def _on_destroy(self, event):
+        if event.widget is self.parent:
+            try:
+                self.root.unbind("<KeyPress>", self._kb_id)
+            except Exception:
+                pass
+
     def menuNav(self,happ:Event):
         k=happ.char
         if self.n_dict.get(k) != None:

--- a/VIStk/Widgets/_WarningWindow.py
+++ b/VIStk/Widgets/_WarningWindow.py
@@ -4,5 +4,5 @@ from tkinter import *
 class WarningWindow(QuestionWindow):
     def __init__(self, warning:str|list[str], parent:Toplevel|Tk, *args, **kwargs):
         super().__init__(question=warning, parent=parent, answer="u", ycommand=None, *args, **kwargs)
-        self.screen_elements[0]["anchor"] = "center"
+        self.screen_elements[0].configure(anchor="center")
         self.modalize()

--- a/VIStk/fUtil.py
+++ b/VIStk/fUtil.py
@@ -19,8 +19,8 @@ class fUtil():
     def mkfont(size:int,bold:bool=False,font:str="default"):
         """Creates a font string with wom fonts"""
 
-        if font == "default":
-            return f"{fUtil().defont} {size}{' bold' if bold is True else ''}"
+        chosen = fUtil().defont if font == "default" else font
+        return f"{chosen} {size}{' bold' if bold is True else ''}"
 
     @staticmethod
     def autosize(e:Event=None, relations:list[Widget]=None, offset:int=None,shrink:int=0):


### PR DESCRIPTION
## Summary
- Fixes 23 bugs found across VIStk Objects, Widgets, Structures, and CLI
- Improves release pipeline: per-screen launcher icons, slim standalone builds, Shared/ capitalization, cpython tag stripping, uninstaller cleanup

## Bug fixes by subsystem

### Objects
- `_WindowGeometry`: remove spurious `Tk()` at import; use per-window screen measurement
- `_TabManager`: check `close_tab` veto return on merge and force_refresh
- `_Root`: cancel pending `after()` callbacks before destroy
- `_VIMG`: use cached `self.Image.copy()` instead of re-opening file on every resize

### Widgets
- `_WarningWindow`: use `.configure(anchor=...)` instead of `Button[...] = ...` (TypeError crash)
- `_ScrollableFrame`: read `event.width/height` not `self.master`; bind scroll globally once instead of `unbind_all`
- `_HostMenu`: store cascade labels instead of stale integer indices
- `_VISMenu`: `bind("<KeyPress>", add="+")` + unbind on destroy
- `_MenuItem`: destroy root before `screen.load()` to avoid killing new window
- `_QuestionWindow`: forward dropdown combobox selection to `ycommand`

### Structures
- `_Version`: validate segment count and numeric format
- `_Screen`: use `.get()` for `desc`/`version`/`current`; replace `open().close()` with `Path.touch()`
- `_VINFO`: case-insensitive reserved name check; fix drive-root path resolution
- `Uninstaller`: init icon variables before try block; delete all folders except Settings
- `Installer`: snapshot shortcut selections before UI destroy

### CLI & Release
- `VIS.py`: fix `release screen` arg-parsing indentation
- `_Release.py`: per-icon cached launchers, slim standalone screen builds, `shared/` → `Shared/`, strip cpython tag from Shared .pyd, `rmtree` with `ignore_errors`

## Test plan
- [ ] Run `VIS release` and verify launcher stubs have correct icons
- [ ] Verify `.Runtime/` exes are smaller (no redundant package bundling)
- [ ] Confirm `Shared/` folder has clean `.pyd` names (no cpython suffix)
- [ ] Test uninstaller preserves `Settings/` folder
- [ ] Open a `WarningWindow` — should no longer crash
- [ ] Test `ScrollableFrame` with multiple instances side by side

🤖 Generated with [Claude Code](https://claude.com/claude-code)