### PR TITLE
Fix silent navigation: drain TabManager action queue, open new tabs

### DIFF
--- a/VIStk/Objects/_TabManager.py
+++ b/VIStk/Objects/_TabManager.py
@@ -76,6 +76,7 @@ class TabManager(Frame):
         self._position: str = position
 
         self._action_queue: queue.SimpleQueue = queue.SimpleQueue()
+        self._action_pump_id: str | None = None
         self._menubar = menubar
         self._detached_window = None
 
@@ -100,6 +101,41 @@ class TabManager(Frame):
         self.tab_bar.on_drag_detach  = self._on_detach_request
         self.tab_bar.on_drag_merge   = self._on_merge_request
         self.tab_bar.on_tab_split    = self._on_split_request
+
+        # Start the action-queue pump. Project.open() enqueues navigation
+        # lambdas here; without a consumer they'd sit forever.
+        self._action_pump_id = self.after(16, self._pump_actions)
+        self.bind("<Destroy>", self._stop_action_pump, add="+")
+
+    # ── Action queue pump ─────────────────────────────────────────────────────
+
+    def _pump_actions(self):
+        """Drain queued navigation callables on the Tk main loop."""
+        try:
+            while True:
+                fn = self._action_queue.get_nowait()
+                try:
+                    fn()
+                except Exception:
+                    pass
+        except queue.Empty:
+            pass
+        try:
+            self._action_pump_id = self.after(16, self._pump_actions)
+        except Exception:
+            self._action_pump_id = None
+
+    def _stop_action_pump(self, event=None):
+        """Cancel the pending pump on widget destruction."""
+        # <Destroy> bubbles up from descendants; only act for this widget.
+        if event is not None and event.widget is not self:
+            return
+        if self._action_pump_id is not None:
+            try:
+                self.after_cancel(self._action_pump_id)
+            except Exception:
+                pass
+            self._action_pump_id = None
 
     # ── Layout ─────────────────────────────────────────────────────────────────
 

--- a/VIStk/Structures/_Project.py
+++ b/VIStk/Structures/_Project.py
@@ -315,17 +315,25 @@ class Project(VINFO):
             return None
 
     def open(self, screen: str, target=None, args=None) -> None:
-        """Unified navigation: routes through Host action queue if running.
+        """Unified navigation: opens the target screen as a new tab or window.
 
-        When a Host is active, the navigation is deferred via the active
-        TabManager's action queue so it runs safely from the main loop.
+        When a Host is active the call is deferred via the active TabManager's
+        action queue so it runs safely from the main loop, then routed to
+        ``Host.open`` — which appends a new tab (for tabbed screens) or opens
+        a new DetachedWindow (for standalone screens). Single-instance tabs
+        are focused instead of duplicated.
 
         When no Host is running the call falls back to ``Screen.load()``.
 
+        To *replace* the current pane instead of opening a new tab, call
+        ``tab_manager.navigate(screen)`` directly.
+
         Args:
             screen: Name of the target screen.
-            target: Optional TabManager to navigate in (defaults to active).
-            args:   Optional dict of args passed to the screen's ArgHandler.
+            target: Optional TabManager whose action queue is used to defer
+                the call. Defaults to the active TabManager.
+            args:   Optional dict of args passed to the screen's ArgHandler
+                (currently ignored in the Host path; TODO: thread through).
         """
         from VIStk.Objects._Host import _HOST_INSTANCE
         scr = self.getScreen(screen)
@@ -334,7 +342,7 @@ class Project(VINFO):
         if _HOST_INSTANCE is not None:
             tm = target or _HOST_INSTANCE.active_tab_manager
             if tm is not None:
-                tm._action_queue.put(lambda: tm.navigate(screen, args=args))
+                tm._action_queue.put(lambda: _HOST_INSTANCE.open(screen))
             else:
                 _HOST_INSTANCE.open(screen)
         else:


### PR DESCRIPTION
## Summary

- Drain `TabManager._action_queue` via a 16 ms `after()` pump (was put-to but never consumed → all `Project().open()` calls silently no-op'd once a tab was active).
- Switch `Project.open()` to enqueue `Host.open(screen)` instead of `TabManager.navigate(screen)`, so navigation opens a new tab rather than replacing the current one.

## Why

`Project().open()` routed queued lambdas into `tm._action_queue`, but nothing in the repo ever drained that queue — confirmed via repo-wide search. Every landing-page button, `View → Home`, and Tools menu item in downstream projects appeared dead. On top of that, the queued target was `tm.navigate()`, which tears down the current tab before opening the new one — so even if the queue had been drained, clicking a button would have replaced Landing instead of opening beside it.

## Changes

**`VIStk/Objects/_TabManager.py`**
- Track `_action_pump_id`.
- Schedule `_pump_actions()` at the end of `__init__` — drains the queue and reschedules itself every 16 ms.
- Bind `<Destroy>` to `_stop_action_pump()` to cancel the pending `after()` on teardown (guarded so descendant destroys don't trigger it).

**`VIStk/Structures/_Project.py`**
- `Project.open()` now queues `_HOST_INSTANCE.open(screen)` instead of `tm.navigate(screen)`.
- Updated docstring to note that callers wanting replace-in-place should use `tab_manager.navigate()` directly.
- `args` is currently ignored on the Host path (TODO: thread through).

## Test plan

- [x] PYWOM landing page: all six buttons open new tabs alongside Landing
- [x] `View → Home` navigates back to Landing
- [x] `Tools → Floor View / Asset Manager / WOM Servant / Reports` open correctly
- [x] `single_instance` tabs focus existing instance instead of opening a duplicate (default path in `Host._open_tab`)
- [ ] Args-through-ArgHandler path (deferred — no current PYWOM callers pass args)

🤖 Generated with [Claude Code](https://claude.com/claude-code)