### PR TITLE
Add Claude review + stale branch cleanup workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,46 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    paths:
+      - "VIStk/**/*.py"
+      - "Screens/**/*.py"
+      - "modules/**/*.py"
+
+# Cancel an in-flight review when a force-push lands on the same PR.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,49 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'

--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,0 +1,28 @@
+name: Stale Branch Cleanup
+
+on:
+  schedule:
+    - cron: '0 7 * * *'   # daily 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove stale branches
+        uses: fpicalausa/remove-stale-branches@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Delete branches with no activity in 60 days.
+          stale_branch_age_days: 60
+          # Long-lived / production / feature-track branches to keep.
+          exempted_branches_regex: '^(master|main|release/.*|ProcessControl|ProcessModeling|nuitka|bug-audit)$'
+          # Branches with an open PR are exempted automatically.
+          # Start in dry-run so we can review what would be deleted.
+          # Flip to false in a follow-up PR after one week of clean output.
+          dry_run: true
+          operations_per_run: 50


### PR DESCRIPTION
## Summary

Adds three GitHub Actions workflows:

- **`claude-code-review.yml`** — auto-reviews PRs that touch `VIStk/**/*.py`, `Screens/**/*.py`, or `modules/**/*.py`. Skips doc-only and asset-only PRs. Concurrency group cancels in-flight runs on force-push.
- **`claude.yml`** — `@claude` mention bot on issue comments, PR review comments, PR reviews, and issues.
- **`stale-branches.yml`** — nightly cleanup via `fpicalausa/remove-stale-branches@v2`. Deletes branches with no activity in 60 days, exempting `master`, `release/*`, and the long-lived branches `ProcessControl`, `ProcessModeling`, `nuitka`, `bug-audit`. Ships in dry-run mode for a one-week observation period.

## Why

The VIS repo had no automated PR review (confirmed: PR #27 opened today got none). PYWOM has had these workflows for a while; this aligns VIStk with that setup, plus adds branch hygiene.

## Follow-up actions required

- [ ] Add `CLAUDE_CODE_OAUTH_TOKEN` secret to this repo (copy value from PYWOM)
- [ ] Enable "Automatically delete head branches" in Settings → General → Pull Requests
- [ ] After merge, run `gh workflow run stale-branches.yml` manually to observe dry-run output
- [ ] Flip `dry_run: false` in a follow-up PR after a week of clean output

## Test plan

- [ ] Tiny test PR touching `VIStk/**/*.py` → expect Claude review
- [ ] Tiny test PR touching only `README.md` → expect no review (paths filter working)
- [ ] Comment `@claude say hi` on any PR → expect a reply
- [ ] Force-push to test PR → expect in-flight review run cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)