### PR TITLE
Fix tab bar flicker on content clicks and 0→1 tab transition

### DIFF
--- a/VIStk/Widgets/_SplitView.py
+++ b/VIStk/Widgets/_SplitView.py
@@ -703,6 +703,8 @@ class SplitView(Frame):
         if id(pane) not in self._pane_parents:
             return
         old = self._focused_pane
+        if pane is old and SplitView._global_focused_pane is pane:
+            return
         self._focused_pane = pane
         SplitView._global_focused_pane = pane
         self._update_focused_styles()

--- a/VIStk/Widgets/_TabBar.py
+++ b/VIStk/Widgets/_TabBar.py
@@ -93,6 +93,11 @@ class TabBar(Frame):
         self._insert_bar: "TabBar | None" = None
         self._insert_idx: int = -1
 
+        # Natural populated size, captured once and reused for the empty state
+        # so 0→1 transitions don't grow the bar by a few pixels.
+        self._natural_height: int = 0
+        self._natural_width: int = 0
+
         _TABBAR_REGISTRY.append(self)
         self._update_empty_state()
 
@@ -141,6 +146,8 @@ class TabBar(Frame):
             compound="left" if icon else "none",
             relief="flat",
             bd=0,
+            highlightthickness=0,
+            takefocus=0,
             bg=_BG_INACTIVE,
             activebackground=_BG_HOVER_TAB,
             command=lambda n=name: self._btn_click(n),
@@ -160,6 +167,8 @@ class TabBar(Frame):
             text="✕",
             relief="flat",
             bd=0,
+            highlightthickness=0,
+            takefocus=0,
             width=2,
             bg=_BG_INACTIVE,
             activebackground=_BG_HOVER_CLOSE,
@@ -254,6 +263,8 @@ class TabBar(Frame):
         When focused the bar uses the normal background; when unfocused
         it dims slightly so the user can see which pane is active.
         """
+        if self._focused == focused:
+            return
         self._focused = focused
         bg = _BG_FOCUSED if focused else _BG_UNFOCUSED
         self.configure(bg=bg)
@@ -308,12 +319,32 @@ class TabBar(Frame):
         if self._tabs:
             self.pack_propagate(True)
             self.configure(bg=_BG_BAR)
+            self.after_idle(self._capture_natural_size)
         else:
             self.pack_propagate(False)
             if self._is_vertical():
-                self.configure(width=_EMPTY_BAR_W, bg=_BG_EMPTY)
+                w = self._natural_width or _EMPTY_BAR_W
+                self.configure(width=w, bg=_BG_EMPTY)
             else:
-                self.configure(height=_EMPTY_BAR_H, bg=_BG_EMPTY)
+                h = self._natural_height or _EMPTY_BAR_H
+                self.configure(height=h, bg=_BG_EMPTY)
+
+    def _capture_natural_size(self):
+        """Remember the populated bar size so the empty state matches it."""
+        try:
+            if not self._tabs:
+                return
+            self.update_idletasks()
+            if self._is_vertical():
+                w = self.winfo_width()
+                if w > 1:
+                    self._natural_width = w
+            else:
+                h = self.winfo_height()
+                if h > 1:
+                    self._natural_height = h
+        except TclError:
+            pass
 
     # ── Right-click context menu ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Three small fixes to `VIStk/Widgets/_TabBar.py` and `VIStk/Widgets/_SplitView.py` that together eliminate the visible tab bar flicker users see when clicking inside a screen and when navigating back to a landing page after all tabs are closed.

## What changed

1. **Disable per-button focus ring.** Tab and close buttons now set `highlightthickness=0, takefocus=0`. Tk's default 2px focus ring around each button was repainting whenever keyboard focus shifted in the window (e.g. clicking an `Entry` inside a screen), producing a brief border flash that read as a bar resize.

2. **Short-circuit no-op restyles.**
   - `TabBar.set_focused_style` returns early when `self._focused == focused`.
   - `SplitView._set_focused` returns early when the pane is already the focused/global pane.

   Previously every `<Button-1>` on screen content re-ran `_update_focused_styles`, reconfiguring every tab button's bg and bar bg for no visible effect but forcing a redraw cycle.

3. **Preserve bar height across empty↔populated transitions.** `_update_empty_state` now captures the natural populated height/width on first populate (via `after_idle`) and reuses it as the empty-state size. The hardcoded `_EMPTY_BAR_H = 28` was smaller than the actual button-driven height (~33), so closing all tabs and reopening one caused a ~5px jump. The fallback to the original `_EMPTY_BAR_H`/`_EMPTY_BAR_W` is preserved for the pre-first-populate case.

## Why

Daisy reported that tabs flickered whenever the body of a screen was clicked, and that the bar grew by ~5 pixels every time the bar went from 0 tabs back to 1. Root-causing narrowed it to (1) Tk's focus-ring repaints on unrelated focus events and (2) redundant style reconfigures on same-pane clicks, plus (3) a mismatched empty-state height.

## Test plan

- [x] Launch PYWOM (`VIS WOM` in `L:/WOM/PYWOM`) and click inside a screen — bar should not flash or shift.
- [x] Navigate between tabs via Landing buttons — no bar height change on add.
- [x] Close all tabs, then click "Home" to return to Landing — bar stays the same height.
- [ ] Reviewer: test drag-to-reorder tabs and drag-to-detach — `takefocus=0` / `highlightthickness=0` changes should not affect drag bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)