### PR TITLE
VIStk 0.4.6 — Screen Groups, Partial Installs & Missing-Screen Banner

### DIFF
--- a/VIStk/Objects/_Host.py
+++ b/VIStk/Objects/_Host.py
@@ -73,14 +73,45 @@ class Host:
 
         Tabbed screens open as tabs in the active TabManager's window.
         Standalone (tabbed=False) screens open as new DetachedWindows.
+        When running from a compiled installation, refuses to open a
+        screen whose binary is not present on disk and shows an inline
+        banner in the active window's InfoRow instead.
         """
         scr = self.Project.getScreen(screen_name)
         if scr is None:
+            return
+        if not self._check_installed(scr):
             return
         if scr.tabbed:
             self._open_tab(scr)
         else:
             self._open_standalone(scr)
+
+    def _check_installed(self, scr) -> bool:
+        """Return True if ``scr`` can be opened; show a banner and return
+        False when running from a frozen build that's missing the binary."""
+        from VIStk.Structures._Install import is_screen_installed
+        if is_screen_installed(scr.name):
+            return True
+        msg = getattr(scr, "warn_message", None) or (
+            f"'{scr.name}' is not installed. "
+            "Reinstall and select it to enable this feature."
+        )
+        dw = self._active_detached_window()
+        if dw is not None:
+            try:
+                dw.InfoRow.show_banner(msg, level="warn")
+            except Exception:
+                pass
+        return False
+
+    def _active_detached_window(self):
+        """Return the DetachedWindow that owns ``active_tab_manager``, or
+        the first open window as fallback."""
+        for dw in self.detached_windows:
+            if self.active_tab_manager in dw.tab_managers:
+                return dw
+        return self.detached_windows[0] if self.detached_windows else None
 
     # ── Tabs ───────────────────────────────────────────────────────────────────
 

--- a/VIStk/Structures/Installer.py
+++ b/VIStk/Structures/Installer.py
@@ -147,6 +147,39 @@ for name in _archive_binaries:
     if name in _standalone_screens and name not in installables:
         installables.append(name)
 
+# ── Group-aware install entries (0.4.6) ───────────────────────────────────
+# Build a structured view of the install page from release_info.groups.
+# A group is rendered in the GUI only when it has at least one standalone
+# child actually present in the archive; tabbed screens ship with the Host
+# and cannot be toggled independently. Groups with no eligible children are
+# dropped from the GUI (they may still exist in project.json for release
+# subset purposes).
+_release_groups = info[title].get("release_info", {}).get("groups", {})
+_grouped_screen_names: set[str] = set()
+for _g_data in _release_groups.values():
+    _grouped_screen_names.update(_g_data.get("screens", {}).keys())
+
+_install_entries: list[dict] = [{"kind": "screen", "name": title}]
+for _gname, _gdata in _release_groups.items():
+    _children = []
+    for _sname, _sdata in _gdata.get("screens", {}).items():
+        if _sname in _standalone_screens and _sname in _archive_binaries:
+            _children.append({
+                "name": _sname,
+                "default": bool(_sdata.get("default", True)),
+            })
+    if _children:
+        _install_entries.append({
+            "kind": "group",
+            "name": _gname,
+            "description": _gdata.get("description", ""),
+            "children": _children,
+        })
+for _name in _archive_binaries:
+    if (_name in _standalone_screens and _name not in _grouped_screen_names
+            and _name != title):
+        _install_entries.append({"kind": "screen", "name": _name})
+
 # Detect license/EULA file in archive
 _license_text = None
 for _lname in ("LICENSE", "LICENSE.txt", "EULA.txt", "EULA.md"):
@@ -263,6 +296,14 @@ def _kill_app_processes(location):
     return killed
 
 
+def _group_of(screen_name: str) -> str | None:
+    """Return the release group containing ``screen_name`` from the archive
+    project.json, or None if ungrouped."""
+    for gname, gdata in _release_groups.items():
+        if screen_name in gdata.get("screens", {}):
+            return gname
+    return None
+
 def write_install_log(location, selected_screens, desktop_shortcuts):
     """Write install_log.json recording what was installed."""
     directories = [".VIS", "Icons", "Images", ".Runtime"]
@@ -276,6 +317,7 @@ def write_install_log(location, selected_screens, desktop_shortcuts):
             "name": name,
             "version": scr_info.get("version", ""),
             "executable": name + ext,
+            "group": _group_of(name),
         })
 
     registry_key = ""
@@ -445,6 +487,36 @@ if QUIET is True:
     if not cinstalls:
         cinstalls = list(installables)
         print(f"No screens specified — installing all {len(cinstalls)} screen(s).")
+    else:
+        # Expand any group names to their default-selected member screens.
+        # A group containing tabbed screens implicitly pulls in the Host
+        # (tabbed screens ship inside the Host exe).
+        _expanded: list[str] = []
+        for _tok in cinstalls:
+            if _tok in _release_groups:
+                _members = _release_groups[_tok].get("screens", {})
+                _has_tabbed = False
+                _standalone_members: list[str] = []
+                for _sname, _sdata in _members.items():
+                    if not _sdata.get("default", True):
+                        continue
+                    if _sname in _tabbed_screens:
+                        _has_tabbed = True
+                    elif _sname in _standalone_screens:
+                        _standalone_members.append(_sname)
+                _expand_to: list[str] = []
+                if _has_tabbed and title not in _expand_to:
+                    _expand_to.append(title)
+                _expand_to.extend(_standalone_members)
+                if _expand_to:
+                    _expanded.extend(s for s in _expand_to if s not in _expanded)
+                    print(f"  Group '{_tok}' -> {', '.join(_expand_to)}")
+                else:
+                    print(f"  Warning: group '{_tok}' has no default-selected members.")
+            else:
+                if _tok not in _expanded:
+                    _expanded.append(_tok)
+        cinstalls = _expanded
 
     is_update_quiet = os.path.exists(os.path.join(location, ".VIS", "install_log.json"))
 
@@ -727,6 +799,317 @@ def makechecks(source:list[str], show_versions:bool=True):
             ver_lbl = ttk.Label(install_options, text=f"{scr_ver}", foreground="gray40")
             ver_lbl.grid(row=row, column=3, sticky=(tk.E,), padx=(0, 8))
 
+# ── Grouped installer page (0.4.6) ────────────────────────────────────────
+# The installables page shows groups as collapsible rows with a right-side
+# arrow; expanding a group reveals indented per-screen checkboxes whose
+# initial state honours the per-screen ``default`` flag from
+# ``release_info.groups``. Clicking a group's master checkbox toggles every
+# child on or every child off regardless of default (defaults only apply to
+# initial render).
+_screen_vars: dict[str, tk.IntVar] = {}
+_group_vars: dict[str, tk.IntVar] = {}
+_group_expanded: dict[str, bool] = {}
+_group_child_widgets: dict[str, list[list[tk.Widget]]] = {}
+_group_arrow_vars: dict[str, tk.StringVar] = {}
+_grouped_page_active = False
+
+def _screen_icon(name: str):
+    """Return a 16x16 PhotoImage for ``name``; falls back to project icon."""
+    scr_info = info[title]["Screens"].get(name, {})
+    icon_name = scr_info.get("icon")
+    if icon_name:
+        ext = ".ico" if sys.platform == "win32" else ".XBM"
+        try:
+            with archive.open("Icons/" + icon_name + ext) as f:
+                return PIL.ImageTk.PhotoImage(Image.open(f).resize((16, 16)))
+        except Exception:
+            pass
+    return PIL.ImageTk.PhotoImage(d_icon.resize((16, 16)))
+
+def _refresh_tri_states():
+    """Update every group's tri-state indicator and the master All var."""
+    if not _grouped_page_active:
+        return
+    total_on = 0
+    total_leaves = 0
+    for entry in _install_entries:
+        if entry["kind"] == "group":
+            gname = entry["name"]
+            on = sum(_screen_vars[c["name"]].get() for c in entry["children"])
+            n = len(entry["children"])
+            total_on += on
+            total_leaves += n
+            gvar = _group_vars[gname]
+            widget = _group_checkbox_widgets.get(gname)
+            if on == 0:
+                gvar.set(0)
+                if widget: widget.state(['!alternate'])
+            elif on == n:
+                gvar.set(1)
+                if widget: widget.state(['!alternate'])
+            else:
+                gvar.set(0)
+                if widget: widget.state(['alternate'])
+        else:
+            v = _screen_vars.get(entry["name"])
+            if v is not None:
+                total_on += v.get()
+                total_leaves += 1
+    # Master "All"
+    widget = _master_all_widget[0]
+    if widget is None:
+        return
+    if total_on == 0:
+        var_all.set(0)
+        widget.state(['!alternate'])
+    elif total_on == total_leaves:
+        var_all.set(1)
+        widget.state(['!alternate'])
+    else:
+        var_all.set(0)
+        widget.state(['alternate'])
+
+_group_checkbox_widgets: dict[str, ttk.Checkbutton] = {}
+_master_all_widget: list[ttk.Checkbutton | None] = [None]
+
+def _on_group_clicked(gname: str):
+    """User toggled a group's master checkbox."""
+    gvar = _group_vars[gname]
+    children = [entry for entry in _install_entries
+                if entry["kind"] == "group" and entry["name"] == gname][0]["children"]
+    # Decide direction based on current child states (not on gvar after click).
+    any_off = any(_screen_vars[c["name"]].get() == 0 for c in children)
+    target = 1 if any_off else 0
+    for c in children:
+        _screen_vars[c["name"]].set(target)
+    _refresh_tri_states()
+
+def _on_child_clicked():
+    _refresh_tri_states()
+
+def _on_all_clicked():
+    """Master "All" checkbox: toggles every leaf regardless of group.
+
+    Direction is decided by current leaf state rather than ``var_all.get()``
+    because a tri-state master cycles through combinations of ``alternate``
+    and the underlying IntVar that are not reliable across platforms.
+    """
+    any_off = any(v.get() == 0 for v in _screen_vars.values())
+    target = 1 if any_off else 0
+    for v in _screen_vars.values():
+        v.set(target)
+    _refresh_tri_states()
+
+def _toggle_group_expand(gname: str):
+    _group_expanded[gname] = not _group_expanded[gname]
+    _group_arrow_vars[gname].set("▼" if _group_expanded[gname] else "▶")
+    for widgets in _group_child_widgets.get(gname, []):
+        for w in widgets:
+            if _group_expanded[gname]:
+                w.grid()
+            else:
+                w.grid_remove()
+
+def makechecks_grouped():
+    """Render the group-aware installables page."""
+    global var_all, img_options, _grouped_page_active
+    global _screen_vars, _group_vars, _group_expanded
+    global _group_child_widgets, _group_arrow_vars
+    global _group_checkbox_widgets
+    _screen_vars = {}
+    _group_vars = {}
+    _group_expanded = {}
+    _group_child_widgets = {}
+    _group_arrow_vars = {}
+    _group_checkbox_widgets = {}
+    img_options = []
+    _grouped_page_active = True
+
+    for w in install_options.winfo_children():
+        w.destroy()
+
+    # Layout: col 1 = arrow/indent, col 2 = checkbox+label, col 3 = version
+    var_all = tk.IntVar()
+    select_all = ttk.Checkbutton(install_options, text="All",
+                                 variable=var_all, command=_on_all_clicked)
+    select_all.grid(row=0, column=1, columnspan=2, sticky=(tk.N, tk.S, tk.E, tk.W))
+    select_all.state(['!alternate'])
+    _master_all_widget[0] = select_all
+
+    row = 1
+    for entry in _install_entries:
+        install_options.rowconfigure(row, weight=1)
+        if entry["kind"] == "screen":
+            name = entry["name"]
+            img = (PIL.ImageTk.PhotoImage(d_icon.resize((16, 16)))
+                   if name == title else _screen_icon(name))
+            img_options.append(img)
+            var = tk.IntVar(value=1)  # ungrouped screens default-on
+            _screen_vars[name] = var
+            cb = ttk.Checkbutton(install_options, text=name,
+                                 variable=var, command=_on_child_clicked,
+                                 image=img, compound=tk.LEFT)
+            cb.grid(row=row, column=2, sticky=(tk.N, tk.S, tk.E, tk.W))
+            cb.state(['!alternate'])
+            scr_ver = (app_version if name == title
+                       else info[title]["Screens"].get(name, {}).get("version", ""))
+            if scr_ver:
+                ver_lbl = ttk.Label(install_options, text=scr_ver, foreground="gray40")
+                ver_lbl.grid(row=row, column=3, sticky=(tk.E,), padx=(0, 8))
+            row += 1
+        else:
+            gname = entry["name"]
+            desc = entry["description"]
+            # Group header row
+            arrow_var = tk.StringVar(value="▶")
+            _group_arrow_vars[gname] = arrow_var
+            _group_expanded[gname] = False
+            arrow_btn = ttk.Label(install_options, textvariable=arrow_var,
+                                  foreground="gray30", cursor="hand2")
+            arrow_btn.grid(row=row, column=1, sticky=(tk.W,), padx=(2, 0))
+            arrow_btn.bind("<Button-1>", lambda e, g=gname: _toggle_group_expand(g))
+
+            img = PIL.ImageTk.PhotoImage(d_icon.resize((16, 16)))
+            img_options.append(img)
+            gvar = tk.IntVar(value=0)  # populated by _refresh_tri_states after init
+            _group_vars[gname] = gvar
+            gtext = gname + (f"  —  {desc}" if desc else "")
+            gcheck = ttk.Checkbutton(install_options, text=gtext,
+                                     variable=gvar,
+                                     command=lambda g=gname: _on_group_clicked(g),
+                                     image=img, compound=tk.LEFT)
+            gcheck.grid(row=row, column=2, sticky=(tk.N, tk.S, tk.E, tk.W))
+            gcheck.state(['!alternate'])
+            _group_checkbox_widgets[gname] = gcheck
+            row += 1
+            # Child rows (initially hidden)
+            _group_child_widgets[gname] = []
+            for child in entry["children"]:
+                cname = child["name"]
+                cdefault = bool(child["default"])
+                cvar = tk.IntVar(value=1 if cdefault else 0)
+                _screen_vars[cname] = cvar
+                cimg = _screen_icon(cname)
+                img_options.append(cimg)
+                cb = ttk.Checkbutton(install_options, text="    " + cname,
+                                     variable=cvar, command=_on_child_clicked,
+                                     image=cimg, compound=tk.LEFT)
+                install_options.rowconfigure(row, weight=1)
+                cb.grid(row=row, column=2, sticky=(tk.N, tk.S, tk.E, tk.W))
+                cb.state(['!alternate'])
+                cb.grid_remove()
+                row_widgets = [cb]
+                scr_ver = info[title]["Screens"].get(cname, {}).get("version", "")
+                if scr_ver:
+                    ver_lbl = ttk.Label(install_options, text=scr_ver, foreground="gray40")
+                    ver_lbl.grid(row=row, column=3, sticky=(tk.E,), padx=(0, 8))
+                    ver_lbl.grid_remove()
+                    row_widgets.append(ver_lbl)
+                _group_child_widgets[gname].append(row_widgets)
+                row += 1
+
+    _refresh_tri_states()
+
+def _collect_selected_screens() -> list[str]:
+    """Return the list of screens currently checked on the installables page."""
+    return [name for name, v in _screen_vars.items() if v.get() == 1]
+
+def _prompt_dependencies(selected: list[str]) -> bool:
+    """Warn about unmet ``requires`` / ``suggests`` before leaving the page.
+
+    Returns True to proceed to the next page, False to stay. May mutate
+    ``_screen_vars`` if the user opts to auto-add missing required screens.
+
+    Implemented as a loop rather than recursion so that clicking Cancel at
+    a later prompt aborts navigation cleanly without undoing earlier Yes
+    decisions (the screens added so far stay selected — the user lands
+    back on the installables page with the richer selection).
+    """
+    from tkinter import messagebox
+    # The auto-add loop can iterate at most ``len(_screen_vars)`` times
+    # because each successful pass selects at least one new screen.
+    for _ in range(len(_screen_vars) + 1):
+        selected_set = set(selected)
+        available = set(_screen_vars.keys())
+        missing_req: list[tuple[str, str]] = []
+        excluded_req: list[tuple[str, str]] = []
+        suggested: list[tuple[str, str]] = []
+        custom_msgs: list[str] = []
+        for name in selected:
+            scr = info[title]["Screens"].get(name, {})
+            unmet_any = False
+            for req in (scr.get("requires") or []):
+                if req in selected_set:
+                    continue
+                unmet_any = True
+                if req in available:
+                    missing_req.append((name, req))
+                else:
+                    excluded_req.append((name, req))
+            for sug in (scr.get("suggests") or []):
+                if sug in selected_set or sug not in available:
+                    continue
+                suggested.append((name, sug))
+            wm = scr.get("warn_message")
+            if wm and unmet_any:
+                custom_msgs.append(wm)
+
+        if not missing_req and not excluded_req and not suggested:
+            return True
+
+        lines: list[str] = []
+        if missing_req:
+            lines.append("Missing required screens:")
+            for a, b in missing_req:
+                lines.append(f"  • {a} requires {b}")
+        if excluded_req:
+            if lines: lines.append("")
+            lines.append("Required screens not included in this installer:")
+            for a, b in excluded_req:
+                lines.append(f"  • {a} requires {b} (unavailable)")
+        if suggested:
+            if lines: lines.append("")
+            lines.append("Suggested additions:")
+            for a, b in suggested:
+                lines.append(f"  • {a} suggests {b}")
+        if custom_msgs:
+            lines.append("")
+            for m in dict.fromkeys(custom_msgs):
+                lines.append(m)
+
+        if missing_req:
+            lines.append("")
+            lines.append("Yes: add the missing required screens and continue")
+            lines.append("No: continue anyway (not recommended)")
+            lines.append("Cancel: stay on this page")
+            resp = messagebox.askyesnocancel("Missing Dependencies",
+                                             "\n".join(lines), icon="warning")
+            if resp is None:
+                return False
+            if resp is False:
+                return True  # No → continue without adding
+            # Yes → auto-add missing required screens and re-evaluate.
+            for _requirer, req in missing_req:
+                if req in _screen_vars:
+                    _screen_vars[req].set(1)
+            _refresh_tri_states()
+            selected = _collect_selected_screens()
+            continue  # re-run loop with the new selection
+        if excluded_req:
+            lines.append("")
+            lines.append("Continue without them?")
+            return bool(messagebox.askokcancel("Screens Unavailable",
+                                               "\n".join(lines), icon="warning"))
+        # Only suggestions remain
+        lines.append("")
+        lines.append("Continue without them?")
+        return bool(messagebox.askokcancel("Suggested Additions",
+                                           "\n".join(lines), icon="info"))
+    # Guard against a pathological cycle — should not be reached because
+    # each iteration either terminates via a messagebox return or adds a
+    # screen, but defaulting to "stay" is the safer fall-through.
+    return False
+
 # ── EULA / License page ───────────────────────────────────────────────────
 _eula_agree_var = tk.IntVar(value=0)
 
@@ -762,7 +1145,7 @@ def _show_installables():
     for w in install_options.winfo_children():
         w.destroy()
     header["text"] = "Select Installables"
-    makechecks(installables)
+    makechecks_grouped()
     # Ensure Next button goes to shortcuts page
     try: next_btn.destroy()
     except Exception: pass
@@ -777,7 +1160,7 @@ def _eula_next():
 if _license_text:
     _show_eula()
 else:
-    makechecks(installables)
+    makechecks_grouped()
 
 #File Location
 file_location = tk.StringVar()
@@ -1097,17 +1480,19 @@ def binstall(desktop:list[str], selected_screens:list[str]):
 
 def nextpage():
     """Goes to the next installer page"""
+    global _grouped_page_active
+    selected_screens = _collect_selected_screens()
+    if not _prompt_dependencies(selected_screens):
+        return  # user cancelled; stay on the installables page
+    selected_screens = _collect_selected_screens()  # may have been mutated
+
     try: next_btn.destroy()
     except Exception: pass
 
     for w in install_options.winfo_children():
         w.destroy()
 
-    selected_screens = []
-    for idx in range(len(var_options)):
-        if var_options[idx].get() == 1:
-            selected_screens.append(installables[idx])
-
+    _grouped_page_active = False  # shortcut page uses the flat makechecks
     header["text"] = "Select Desktop Shortcuts"
     makechecks(selected_screens, show_versions=False)
 

--- a/VIStk/Structures/_Install.py
+++ b/VIStk/Structures/_Install.py
@@ -1,0 +1,55 @@
+"""Runtime install-state introspection for VIStk apps.
+
+When a user clicks a navigation button that points at a screen whose binary
+was not included in their installer (e.g. the developer built a subset
+release, or the user unchecked the group at install time), VIStk shows a
+non-blocking banner in the Host's ``InfoRow``. These helpers answer
+"is this screen actually on disk?" for that pre-open check.
+
+In dev mode (``sys.frozen`` is falsy) the checks always return ``True`` —
+every screen is available from source.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _install_dir() -> Path | None:
+    """Return the install directory when running from a compiled build."""
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).parent
+    return None
+
+
+def is_screen_installed(name: str, install_dir: Path | None = None) -> bool:
+    """Return True if screen ``name`` is present on disk in the installation.
+
+    Dev mode always returns True. For frozen builds the check prefers
+    ``.VIS/install_log.json``; when the log is missing or stale the helper
+    falls back to a direct filesystem check for the tabbed ``Screens/<name>.pyd``
+    or standalone ``.Runtime/<name>.exe`` artifact.
+    """
+    root = install_dir or _install_dir()
+    if root is None:
+        return True  # dev mode — assume every screen is importable from source
+
+    log_path = root / ".VIS" / "install_log.json"
+    if log_path.exists():
+        try:
+            with open(log_path) as f:
+                log = json.load(f)
+            names = {s.get("name") for s in log.get("screens", [])}
+            if names:
+                return name in names
+        except Exception:
+            pass  # fall through to filesystem check
+
+    ext = ".exe" if sys.platform == "win32" else ""
+    if (root / ".Runtime" / (name + ext)).exists():
+        return True
+    if (root / "Screens" / f"{name}.pyd").exists():
+        return True
+    return False

--- a/VIStk/Structures/_Project.py
+++ b/VIStk/Structures/_Project.py
@@ -7,10 +7,12 @@ from VIStk.Structures._Screen import *
 _EDITABLE_SCREEN_ATTRS = {
     "script", "release", "icon", "desc", "tabbed",
     "single_instance", "version", "current",
+    "requires", "suggests", "warn_message",
 }
 _BOOL_ATTRS      = {"release", "tabbed", "single_instance"}
-_NULLABLE_ATTRS  = {"icon", "current"}
+_NULLABLE_ATTRS  = {"icon", "current", "warn_message"}
 _VERSION_ATTRS   = {"version"}
+_LIST_ATTRS      = {"requires", "suggests"}
 
 class Project(VINFO):
     """VIS Project Object
@@ -243,6 +245,11 @@ class Project(VINFO):
                 print(f"Invalid version '{value}'. Must be major.minor.patch format.")
                 return 0
             coerced = value
+        elif attribute in _LIST_ATTRS:
+            if value.lower() in ("none", "null", "", "[]"):
+                coerced = []
+            else:
+                coerced = [p.strip() for p in value.split(",") if p.strip()]
         else:
             coerced = value
 
@@ -267,6 +274,9 @@ class Project(VINFO):
                 "single_instance": lambda: setattr(scr, "single_instance", coerced),
                 "version":         lambda: setattr(scr, "s_version", Version(coerced)),
                 "current":         lambda: setattr(scr, "current", coerced),
+                "requires":        lambda: setattr(scr, "requires", list(coerced)),
+                "suggests":        lambda: setattr(scr, "suggests", list(coerced)),
+                "warn_message":    lambda: setattr(scr, "warn_message", coerced),
             }
             attr_map[attribute]()
 
@@ -358,6 +368,129 @@ class Project(VINFO):
             self.Screen.load()
         except AttributeError:
             return None
+
+    # ── Screen group management (release_info.groups) ──────────────────────
+
+    def _load_info(self) -> dict:
+        with open(self.p_sinfo, "r") as f:
+            return json.load(f)
+
+    def _save_info(self, info: dict) -> None:
+        with open(self.p_sinfo, "w") as f:
+            json.dump(info, f, indent=4)
+
+    def groups(self) -> dict:
+        """Return the full ``release_info.groups`` dictionary (may be empty)."""
+        info = self._load_info()
+        return info[self.title].get("release_info", {}).get("groups", {})
+
+    def group_names(self) -> list[str]:
+        return list(self.groups().keys())
+
+    def group_info(self, group_name: str) -> dict | None:
+        return self.groups().get(group_name)
+
+    def screens_in_group(self, group_name: str) -> list[str]:
+        g = self.groups().get(group_name, {})
+        return list(g.get("screens", {}).keys())
+
+    def group_of(self, screen_name: str) -> str | None:
+        """Return the group containing ``screen_name``, or None if ungrouped."""
+        for gname, gdata in self.groups().items():
+            if screen_name in gdata.get("screens", {}):
+                return gname
+        return None
+
+    def group_default(self, group_name: str, screen_name: str) -> bool:
+        """Whether ``screen_name`` is default-selected within ``group_name``."""
+        g = self.groups().get(group_name, {})
+        s = g.get("screens", {}).get(screen_name, {})
+        return bool(s.get("default", True))
+
+    def required_by(self, screen_name: str) -> list[str]:
+        scr = self.getScreen(screen_name)
+        return list(scr.requires) if scr else []
+
+    def suggested_by(self, screen_name: str) -> list[str]:
+        scr = self.getScreen(screen_name)
+        return list(scr.suggests) if scr else []
+
+    def add_group(self, name: str, description: str = "") -> int:
+        if not validName(name):
+            return 0
+        if name in _RESERVED_VIS_COMMANDS:
+            print(f"'{name}' is a reserved VIS command.")
+            return 0
+        if self.hasScreen(name):
+            print(f"'{name}' collides with a screen name.")
+            return 0
+        info = self._load_info()
+        release_info = info[self.title].setdefault("release_info", {})
+        groups = release_info.setdefault("groups", {})
+        if name in groups:
+            print(f"Group '{name}' already exists.")
+            return 0
+        groups[name] = {"description": description, "screens": {}}
+        self._save_info(info)
+        print(f"Created group '{name}'.")
+        return 1
+
+    def remove_group(self, name: str) -> int:
+        info = self._load_info()
+        groups = info[self.title].get("release_info", {}).get("groups", {})
+        if name not in groups:
+            print(f"Group '{name}' does not exist.")
+            return 0
+        groups.pop(name)
+        self._save_info(info)
+        print(f"Removed group '{name}'.")
+        return 1
+
+    def assign_to_group(self, screen_name: str, group_name: str, default: bool = True) -> int:
+        if not self.hasScreen(screen_name):
+            print(f"Screen '{screen_name}' does not exist.")
+            return 0
+        info = self._load_info()
+        groups = info[self.title].get("release_info", {}).get("groups", {})
+        if group_name not in groups:
+            print(f"Group '{group_name}' does not exist.")
+            return 0
+        # A screen belongs to at most one group — strip it from any others.
+        for gname, gdata in groups.items():
+            if gname != group_name:
+                gdata.get("screens", {}).pop(screen_name, None)
+        groups[group_name].setdefault("screens", {})[screen_name] = {"default": default}
+        self._save_info(info)
+        print(f"Assigned '{screen_name}' to group '{group_name}' (default={default}).")
+        return 1
+
+    def unassign_from_group(self, screen_name: str) -> int:
+        info = self._load_info()
+        groups = info[self.title].get("release_info", {}).get("groups", {})
+        found_in = None
+        for gname, gdata in groups.items():
+            if screen_name in gdata.get("screens", {}):
+                del gdata["screens"][screen_name]
+                found_in = gname
+                break
+        if found_in is None:
+            print(f"Screen '{screen_name}' is not in any group.")
+            return 0
+        self._save_info(info)
+        print(f"Unassigned '{screen_name}' from group '{found_in}'.")
+        return 1
+
+    def set_group_default(self, screen_name: str, default: bool) -> int:
+        info = self._load_info()
+        groups = info[self.title].get("release_info", {}).get("groups", {})
+        for gname, gdata in groups.items():
+            if screen_name in gdata.get("screens", {}):
+                gdata["screens"][screen_name]["default"] = default
+                self._save_info(info)
+                print(f"Set default for '{screen_name}' in group '{gname}' to {default}.")
+                return 1
+        print(f"Screen '{screen_name}' is not in any group.")
+        return 0
 
     def getInfo(self) -> str:
         """Gets the `Project` and `Screen` Info"""

--- a/VIStk/Structures/_Release.py
+++ b/VIStk/Structures/_Release.py
@@ -15,8 +15,17 @@ from VIStk.Structures._Version import Version
 
 class Release(Project):
     """A VIS Release object"""
-    def __init__(self, flag:str="",type:str="",note:str=""):
-        """Creates a Release object to release or examine a release of a project"""
+    def __init__(self, flag:str="",type:str="",note:str="",
+                 subset_groups: list[str] | None = None,
+                 subset_screens: list[str] | None = None):
+        """Creates a Release object to release or examine a release of a project
+
+        ``subset_groups`` and ``subset_screens`` scope the build to a subset of
+        screens. When both are ``None`` every screen is built (existing
+        behaviour). When either is provided, only screens in that union are
+        compiled; the Host is always included. The resulting installer's
+        embedded ``project.json`` is pruned to the same subset.
+        """
         super().__init__()
         self.type = type
         self.flag = flag
@@ -28,6 +37,37 @@ class Release(Project):
         elif not os.path.isabs(loc):
             loc = self.p_project + "/" + loc
         self.location = loc.rstrip("/") + "/"
+
+        self._subset_screens: set[str] | None = self._resolve_subset(
+            subset_groups, subset_screens
+        )
+        """Set of screen names included in this build, or None for all."""
+
+    def _resolve_subset(self, subset_groups, subset_screens) -> set[str] | None:
+        if not subset_groups and not subset_screens:
+            return None
+        names: set[str] = set()
+        if subset_groups:
+            groups = self.groups()
+            for g in subset_groups:
+                if g not in groups:
+                    print(f"Warning: group '{g}' not found; skipping.", flush=True)
+                    continue
+                for s in groups[g].get("screens", {}).keys():
+                    names.add(s)
+        if subset_screens:
+            for s in subset_screens:
+                if not self.hasScreen(s):
+                    print(f"Warning: screen '{s}' not found; skipping.", flush=True)
+                    continue
+                names.add(s)
+        if not names:
+            print("Warning: subset resolved to zero screens; aborting.", flush=True)
+        return names
+
+    def _screen_in_subset(self, scr) -> bool:
+        """True if ``scr`` should be compiled in this build."""
+        return self._subset_screens is None or scr.name in self._subset_screens
 
     # ── Nuitka runner ─────────────────────────────────────────────────────────
 
@@ -194,6 +234,8 @@ class Release(Project):
 
         has_tabbed = False
         for scr in self.screenlist:
+            if not self._screen_in_subset(scr):
+                continue
 
             if scr.tabbed and mode in ("all", "pyd"):
                 # Every tabbed screen → .pyd module
@@ -363,6 +405,21 @@ class Release(Project):
         if exists(installed_json):
             with open(installed_json, "r") as f:
                 info = json.load(f)
+            # Prune screens not in the subset (0.4.6)
+            if self._subset_screens is not None:
+                keep = self._subset_screens
+                for sname in list(info[self.title]["Screens"].keys()):
+                    if sname not in keep:
+                        info[self.title]["Screens"].pop(sname)
+                groups = (info[self.title].get("release_info", {})
+                          .get("groups", {}))
+                for gname in list(groups.keys()):
+                    screens = groups[gname].get("screens", {})
+                    for sn in list(screens.keys()):
+                        if sn not in keep:
+                            screens.pop(sn)
+                    if not screens:
+                        groups.pop(gname)
             for screen_name, screen_data in info[self.title]["Screens"].items():
                 if screen_data.get("tabbed", False):
                     stem = os.path.splitext(screen_data["script"])[0]
@@ -465,10 +522,19 @@ class Release(Project):
         screen_count = 0
         binary_count = 1  # Host
         for scr in self.screenlist:
+            if not self._screen_in_subset(scr):
+                continue
             if scr.tabbed:
                 screen_count += 1
             elif scr.release:
                 binary_count += 1
+
+        if self._subset_screens is not None:
+            if not self._subset_screens:
+                print("Subset release aborted: no screens selected.", flush=True)
+                return
+            print(f"Subset release: {len(self._subset_screens)} screen(s) included.",
+                  flush=True)
 
         total = pkg_count + screen_count + binary_count
         self._step = 0

--- a/VIStk/Structures/_Screen.py
+++ b/VIStk/Structures/_Screen.py
@@ -80,6 +80,12 @@ class Screen(VINFO):
         """Whether this screen opens as a tab inside the Host window"""
         self.single_instance: bool = info[self.title]["Screens"][self.name].get("single_instance", False)
         """When True only one instance of this screen may be open at a time"""
+        self.requires: list[str] = list(scr_data.get("requires", []))
+        """Names of screens that must be installed alongside this one (hard dependency)."""
+        self.suggests: list[str] = list(scr_data.get("suggests", []))
+        """Names of screens recommended alongside this one (soft suggestion)."""
+        self.warn_message: str | None = scr_data.get("warn_message")
+        """Optional custom message shown by the installer when a dependency is unmet."""
       
     def addElement(self,element:str) -> int:
         if validName(element):

--- a/VIStk/Structures/_VINFO.py
+++ b/VIStk/Structures/_VINFO.py
@@ -44,6 +44,7 @@ _RESERVED_VIS_COMMANDS = {
     "rename", "Rename",
     "edit", "Edit",
     "release", "Release", "r", "R",
+    "group", "Group",
 }
 
 def validName(name:str):

--- a/VIStk/Structures/__init__.py
+++ b/VIStk/Structures/__init__.py
@@ -2,9 +2,11 @@ from VIStk.Structures._Project import *
 from VIStk.Structures._Release import *
 from VIStk.Structures._Screen import *
 from VIStk.Structures._VINFO import *
+from VIStk.Structures._Install import is_screen_installed
 
 __all__ = ["Project",
            "Release",
            "Screen",
            "VINFO",
+           "is_screen_installed",
            ]

--- a/VIStk/VIS.py
+++ b/VIStk/VIS.py
@@ -87,11 +87,63 @@ def __main__():
             else:
                 Project().edit_screen(inp[2], inp[3], inp[4])
 
+        case "group" | "Group":
+            if len(inp) < 3:
+                print("Usage: VIS group <add|remove|assign|unassign|default|list> ...")
+                return
+            project = Project()
+            match inp[2]:
+                case "add":
+                    if len(inp) < 4:
+                        print("Usage: VIS group add <group_name> [description]")
+                        return
+                    desc = " ".join(inp[4:]) if len(inp) > 4 else ""
+                    project.add_group(inp[3], desc)
+                case "remove":
+                    if len(inp) < 4:
+                        print("Usage: VIS group remove <group_name>")
+                        return
+                    project.remove_group(inp[3])
+                case "assign":
+                    if len(inp) < 5:
+                        print("Usage: VIS group assign <screen> <group> [true|false]")
+                        return
+                    default = True
+                    if len(inp) >= 6:
+                        default = inp[5].lower() in ("true", "yes", "1")
+                    project.assign_to_group(inp[3], inp[4], default)
+                case "unassign":
+                    if len(inp) < 4:
+                        print("Usage: VIS group unassign <screen>")
+                        return
+                    project.unassign_from_group(inp[3])
+                case "default":
+                    if len(inp) < 5:
+                        print("Usage: VIS group default <screen> <true|false>")
+                        return
+                    d = inp[4].lower() in ("true", "yes", "1")
+                    project.set_group_default(inp[3], d)
+                case "list":
+                    groups = project.groups()
+                    if not groups:
+                        print("No groups defined.")
+                    else:
+                        for gname, gdata in groups.items():
+                            desc = gdata.get("description", "")
+                            print(f"  {gname}" + (f" — {desc}" if desc else ""))
+                            for sname, sdata in gdata.get("screens", {}).items():
+                                d_mark = "" if sdata.get("default", True) else "  [off by default]"
+                                print(f"      - {sname}{d_mark}")
+                case _:
+                    print(f"Unknown group subcommand: {inp[2]!r}")
+
         case "release" | "Release" | "r" | "R":
             project=Project()
             flag:str=""
             type:str=""
             note:str=""
+            subset_groups:list[str]=[]
+            subset_screens:list[str]=[]
             argstart = 2
 
             if len(inp) >= 3:
@@ -130,11 +182,25 @@ def __main__():
                                 return None
                             note = args[i+1]
                             i += 2
+                        case "Groups" | "groups" | "G" | "g":
+                            if i + 1 >= len(args):
+                                print(f"Missing value for {args[i]}")
+                                return None
+                            subset_groups = [g.strip() for g in args[i+1].split(",") if g.strip()]
+                            i += 2
+                        case "Screens" | "screens":
+                            if i + 1 >= len(args):
+                                print(f"Missing value for {args[i]}")
+                                return None
+                            subset_screens = [s.strip() for s in args[i+1].split(",") if s.strip()]
+                            i += 2
                         case _:
                             print(f"Unknown Argument \"{args[i]}\"")
                             return None
 
-            rel = Release(flag,type,note)
+            rel = Release(flag, type, note,
+                          subset_groups=subset_groups or None,
+                          subset_screens=subset_screens or None)
             rel.release()
             rel.restoreAll()
 

--- a/VIStk/Widgets/_InfoRow.py
+++ b/VIStk/Widgets/_InfoRow.py
@@ -4,6 +4,12 @@ from tkinter import Frame, Label
 _BG = "grey55"
 _FG = "grey88"
 
+_BANNER_BG = {
+    "warn":  "#c29d3d",
+    "error": "#b33a3a",
+    "info":  "#3a77a8",
+}
+
 
 class InfoRow(Frame):
     """Status bar displayed at the bottom of the Host window.
@@ -58,6 +64,11 @@ class InfoRow(Frame):
         self._fps_lbl.pack(side="right")
         self._app_version = app_version
 
+        # Banner state (for show_banner / _dismiss_banner)
+        self._banner_frame: Frame | None = None
+        self._banner_text_lbl: Label | None = None
+        self._banner_after_id: str | None = None
+
     # ── Public API ─────────────────────────────────────────────────────────────
 
     def set_screen(self, name: str, version: str = "") -> None:
@@ -71,3 +82,56 @@ class InfoRow(Frame):
             self._fps_lbl.config(text=f"v{self._app_version}  |  {fps:.1f} fps")
         else:
             self._fps_lbl.config(text=f"{fps:.1f} fps")
+
+    def show_banner(self, text: str, duration_ms: int = 5000,
+                    level: str = "warn") -> None:
+        """Show a transient inline message across the InfoRow.
+
+        The banner overlays the normal InfoRow contents until the user
+        dismisses it with the ✕ or the duration elapses. Used by the Host
+        to explain why a navigation click could not open a screen (e.g.
+        the screen was not included in this installation).
+
+        ``level`` selects the background colour: ``"warn"`` (amber),
+        ``"error"`` (red), or ``"info"`` (blue).
+
+        Calling this while a banner is already visible replaces the text
+        and resets the auto-dismiss timer rather than stacking.
+        """
+        bg = _BANNER_BG.get(level, _BANNER_BG["warn"])
+        if self._banner_frame is not None:
+            self._banner_text_lbl.config(text=text)
+            self._banner_frame.config(bg=bg)
+            self._banner_text_lbl.config(bg=bg)
+            if self._banner_after_id is not None:
+                try: self.after_cancel(self._banner_after_id)
+                except Exception: pass
+            self._banner_after_id = self.after(duration_ms, self._dismiss_banner)
+            return
+
+        self._banner_frame = Frame(self, bg=bg)
+        self._banner_frame.place(relx=0, rely=0, relwidth=1, relheight=1)
+        self._banner_text_lbl = Label(self._banner_frame, text=text, bg=bg,
+                                      fg="white", anchor="w", padx=8)
+        self._banner_text_lbl.pack(side="left", fill="both", expand=True)
+        dismiss = Label(self._banner_frame, text="✕", bg=bg, fg="white",
+                        cursor="hand2", padx=10)
+        dismiss.pack(side="right")
+        dismiss.bind("<Button-1>", lambda e: self._dismiss_banner())
+        self._banner_after_id = self.after(duration_ms, self._dismiss_banner)
+
+    def _dismiss_banner(self) -> None:
+        # Guard against firing after the parent window has been destroyed —
+        # show_banner schedules self.after() and Tk does not cancel pending
+        # after-callbacks when a widget is destroyed.
+        try:
+            if not self.winfo_exists():
+                return
+        except Exception:
+            return
+        if self._banner_frame is not None:
+            try: self._banner_frame.destroy()
+            except Exception: pass
+        self._banner_frame = None
+        self._banner_text_lbl = None
+        self._banner_after_id = None

--- a/changelog.md
+++ b/changelog.md
@@ -541,7 +541,10 @@ The existing "Open in new window" entry is unchanged; it still creates a `Detach
 
 ---
 
-### 0.4.5 Installer Polish
+### 0.4.5 Installer Polish *(absorbed into 0.4.6)*
+
+Implemented in-tree but not released as its own PyPI version. These
+features ship as part of 0.4.6.
 
 **License / EULA page**
 
@@ -562,21 +565,88 @@ The existing "Open in new window" entry is unchanged; it still creates a `Detach
 
 ---
 
-### 0.4.6 Installer Screen Groups & Partial Installs
+### 0.4.6 Screen Groups, Partial Installs & Missing-Screen Banner
+
+*Released — absorbs every feature from 0.4.5.*
 
 **Screen groups**
 
-- `project.json` gains an optional `release_info.groups` dictionary mapping a group label to a list of screen names
-- Screens belonging to a group appear under a single checkbox in the installer, with the group label as the display name
-- Selecting/deselecting a group selects/deselects all screens within it
-- Screens not assigned to any group continue to appear as individual checkboxes (current behavior)
-- Groups are respected by `--Quiet` mode — passing a group name installs all screens within it
+- `project.json` gains a `release_info.groups` block; each group maps a
+  label to a `{description, screens: {screen_name: {default: bool}}}` entry.
+- A screen belongs to at most one group; ungrouped screens continue to
+  render as individual checkboxes (current behaviour preserved).
+- Group rows in the installer render as a checkbox + label + right-side
+  expand arrow. Expanding a group reveals indented child checkboxes with
+  per-screen version labels.
+- Clicking a group master toggles every child on or every child off
+  (defaults only set the initial state). Tri-state (`alternate`) is shown
+  when a group has a mix of checked/unchecked children; likewise for the
+  top-level "All".
+- Groups with no standalone-screen child actually present in the archive
+  are hidden from the GUI — tabbed screens ship with the Host and cannot
+  be toggled independently at install time.
 
-**Missing screen handling**
+**Per-screen dependencies**
 
-- When the Host or `Project().open()` attempts to open a screen that is not installed (exe not present in the install directory), a user-facing message is displayed instead of silently failing
-- The message identifies the missing screen by name and suggests reinstalling with that screen selected
-- Allows developers to distribute a smaller installer with a subset of screens; users who attempt to access an uninstalled screen get a clear explanation rather than a crash or silent no-op
+- New schema: `Screens.<name>.requires: list[str]`, `suggests: list[str]`,
+  and `warn_message: str|null`.
+- On installer Next click the selected set is cross-checked; unmet
+  `requires` trigger a 3-button dialog (Yes = auto-add + continue,
+  No = continue anyway, Cancel = stay). Unmet `suggests` and required
+  screens that aren't in the archive at all use a simpler OK/Cancel
+  dialog. `warn_message` is folded into the dialog body.
+
+**Partial install — developer-side subset release**
+
+- `vis release -Groups <A,B>` builds an installer containing only the
+  union of screens in the listed groups.
+- `vis release -Screens <X,Y>` builds an installer containing only the
+  listed screens. The two flags may be combined.
+- The Host is always included. Excluded screens are never compiled and
+  their entries are pruned from the archived `project.json`. Empty
+  groups are dropped from the pruned schema.
+
+**Quiet-mode group expansion**
+
+- `installer.exe --Quiet <group_name>` expands the group into its
+  default-selected members before running the existing archive-matching
+  logic.
+- A group containing at least one tabbed screen implicitly pulls in the
+  Host (tabbed screens ride inside the Host exe).
+
+**install_log.json**
+
+- Each screen record in the log now carries a `"group"` field (the
+  group name, or `null` for ungrouped / Host). Consumed by the runtime
+  missing-screen detector.
+
+**Runtime missing-screen handling**
+
+- `Host.open()` now calls `VIStk.Structures.is_screen_installed(name)`
+  before routing. When the binary is not present in the current
+  installation, it shows an inline warning banner in the active
+  `InfoRow` (via the new `InfoRow.show_banner(text, duration_ms, level)`)
+  instead of silently failing.
+- `is_screen_installed()` reads `.VIS/install_log.json` first and falls
+  back to a filesystem probe for `.Runtime/<name>.exe` or
+  `Screens/<name>.pyd`. Always returns `True` in dev mode (non-frozen).
+- The banner uses the screen's `warn_message` when available; otherwise
+  a generic "X is not installed. Reinstall and select it to enable this
+  feature." string.
+
+**CLI additions**
+
+- `vis group add/remove/assign/unassign/default/list` — manage groups in
+  `project.json`.
+- `vis release -Groups A,B -Screens X,Y` — subset release.
+- `vis edit <screen> requires "A,B"` / `suggests "C"` / `warn_message "…"`
+  — list-typed attrs accept a comma-separated value; `warn_message`
+  accepts a plain string or `none`/`null`.
+
+**Absorbed from 0.4.5**
+
+The License/EULA page, `\r` quiet-mode progress bar, and
+`metadata.installer_icon` land as part of this release.
 
 ---
 

--- a/docs/source/changelog/0.4.5.rst
+++ b/docs/source/changelog/0.4.5.rst
@@ -1,7 +1,9 @@
 0.4.5 --- Installer Polish
 ==========================
 
-*Upcoming*
+*Absorbed into 0.4.6 --- no standalone PyPI release.* See :doc:`0.4.6`
+for the released version that ships these features alongside screen
+groups and the missing-screen banner.
 
 License / EULA Page
 -------------------

--- a/docs/source/changelog/0.4.6.rst
+++ b/docs/source/changelog/0.4.6.rst
@@ -1,0 +1,147 @@
+0.4.6 --- Screen Groups, Partial Installs & Missing-Screen Banner
+=================================================================
+
+*Released --- current version*
+
+0.4.6 folds in every feature that was drafted for 0.4.5 (License/EULA page,
+``\r`` quiet progress, ``metadata.installer_icon``) together with the new
+0.4.6 scope below. There is no standalone 0.4.5 release on PyPI.
+
+Screen Groups
+-------------
+
+Screens can be bundled under a group label in the installer.
+
+- New ``release_info.groups`` block in ``project.json``:
+
+  .. code-block:: json
+
+     "release_info": {
+         "groups": {
+             "Core": {
+                 "description": "Main screens",
+                 "screens": {
+                     "ScreenA": {"default": true},
+                     "ScreenB": {"default": true},
+                     "ScreenC": {"default": false}
+                 }
+             }
+         }
+     }
+
+- Each member screen has a ``default`` flag controlling whether it starts
+  checked when the group is rendered in the installer GUI.
+- A screen belongs to at most one group; ungrouped screens continue to
+  appear as individual checkboxes.
+- Groups with no standalone member present in the archive are hidden from
+  the GUI (tabbed screens ship with the Host and cannot be independently
+  toggled).
+
+Installer GUI
+-------------
+
+- Group rows render as **checkbox + expand arrow**.  Clicking the arrow
+  reveals indented per-screen sub-checkboxes; clicking the group master
+  toggles every child on or off regardless of ``default`` (defaults only
+  set the initial state).
+- Tri-state indicator (``alternate``) shown when a group has a mix of
+  checked and unchecked children; same for the top-level "All" checkbox.
+- Per-screen version labels continue to appear next to each child.
+
+Per-Screen Dependencies
+-----------------------
+
+New schema keys on ``Screens.<name>``:
+
+- ``requires: [other_screen_name, ...]`` --- hard dependency.
+- ``suggests: [other_screen_name, ...]`` --- soft recommendation.
+- ``warn_message: str`` --- custom message shown alongside the unmet
+  dependencies and by the runtime banner when this screen is missing.
+
+On Next click the installer cross-checks every selected screen against its
+``requires``/``suggests``.  When a required screen is unmet, the user gets
+a 3-button dialog:
+
+- **Yes** --- auto-select the missing required screens and continue.
+- **No** --- continue without them (not recommended).
+- **Cancel** --- stay on the installables page.
+
+Partial Installs (``--Groups`` / ``--Screens`` on ``vis release``)
+-------------------------------------------------------------------
+
+Developers can build an installer that contains only a subset of screens.
+
+.. code-block:: text
+
+   vis release -Groups Core
+   vis release -Screens WorderEditor,FloorView
+   vis release -Groups Core -Screens DashboardA
+
+- The effective screen set is the union of the screens listed under each
+  named group plus any explicitly named screens.  The Host itself is
+  always included.
+- Excluded screens are never compiled; their binaries, ``.pyd`` files and
+  per-screen entries in ``project.json`` are pruned from ``binaries.zip``.
+- Empty groups are dropped from the archived ``project.json``.
+
+Quiet-Mode Group Expansion
+--------------------------
+
+``installer.exe --Quiet <name> [<name>...]`` now accepts group names.
+
+- Group names expand to the group's default-selected member screens.
+- When a group contains tabbed screens, the Host is implicitly added to
+  the install set (tabbed screens ride inside the Host exe).
+- Unknown tokens still produce the existing "no archive entry matches"
+  warning.
+
+install_log.json
+----------------
+
+Each record in the ``screens`` array now includes a ``group`` field (the
+group name or ``null``). The uninstaller, the missing-screen detector and
+external tooling can use it to reason about installed bundles.
+
+Runtime Missing-Screen Banner
+-----------------------------
+
+When the end-user clicks a navigation button that points at a screen whose
+binary was never installed, ``Host.open()`` now shows an inline warning in
+the active window's ``InfoRow`` instead of silently doing nothing.
+
+- New helper ``VIStk.Structures.is_screen_installed(name)`` --- reads
+  ``.VIS/install_log.json`` first, falls back to a filesystem check
+  (``.Runtime/<name>.exe`` or ``Screens/<name>.pyd``).  Always returns
+  ``True`` in dev mode (``sys.frozen`` is falsy).
+- New ``InfoRow.show_banner(text, duration_ms=5000, level="warn")`` ---
+  overlays a colour-coded message across the status bar with a ✕ dismiss
+  button and an auto-dismiss timer.
+- Uses the screen's ``warn_message`` when one is defined, otherwise a
+  generic "X is not installed. Reinstall and select it to enable this
+  feature." fallback.
+
+New CLI: ``vis group``
+----------------------
+
+.. code-block:: text
+
+   vis group add <name> [description]
+   vis group remove <name>
+   vis group assign <screen> <group> [true|false]
+   vis group unassign <screen>
+   vis group default <screen> <true|false>
+   vis group list
+
+All five mutators persist to ``.VIS/project.json``.  ``vis edit`` also
+accepts ``requires``, ``suggests`` and ``warn_message`` as per-screen
+attributes (list values are passed as a comma-separated string).
+
+Absorbed from 0.4.5
+-------------------
+
+The following were drafted for 0.4.5 and are released as part of 0.4.6:
+
+- License / EULA page in the installer.
+- ``\r`` carriage-return progress in ``--Quiet`` mode.
+- ``metadata.installer_icon`` per-project override for the installer exe
+  icon.

--- a/docs/source/changelog/index.rst
+++ b/docs/source/changelog/index.rst
@@ -13,6 +13,9 @@ Released
    * - Version
      - Title
      - Highlights
+   * - :doc:`0.4.6`
+     - Screen Groups & Partial Installs
+     - Installer groups with expand/collapse, per-screen dependencies, ``--Groups``/``--Screens`` release, runtime missing-screen banner
    * - :doc:`0.4.4`
      - Tab Bar & Installer Update
      - Tab bar position, update-in-place installer, rollback, integrity check
@@ -42,9 +45,6 @@ Upcoming
    * - Version
      - Title
      - Planned
-   * - :doc:`0.4.5`
-     - Installer Polish
-     - License/EULA page, silent progress, custom installer icon
    * - :doc:`0.5`
      - VIS Widgets & Upgrade Tool
      - Tooltip, CollapsibleFrame, AutocompleteEntry, DateEntry, ``VIS upgrade``
@@ -68,6 +68,7 @@ Upcoming
    :maxdepth: 1
    :hidden:
 
+   0.4.6
    0.4.4
    0.4.3
    0.4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "VIStk"
-version = "0.4.4"
+version = "0.4.6"
 license = {file="LICENSE"}
 dependencies = [
   "pyinstaller",


### PR DESCRIPTION
## Summary

- **Screen groups** — `release_info.groups` in `project.json` bundles screens under a collapsible checkbox with expand arrow. Per-screen `default` flags control initial selection.
- **Partial install** — `vis release -Groups A,B -Screens X,Y` builds an installer containing only the chosen subset; archived `project.json` is pruned to match.
- **Per-screen deps** — `requires`/`suggests`/`warn_message` on each screen. Installer's Next button runs a cross-check dialog (auto-add / ignore / cancel).
- **Quiet-mode group expansion** — `installer.exe --Quiet GroupName` expands to the group's default members; tabbed groups pull the Host in automatically.
- **Runtime missing-screen banner** — `Host.open()` shows an inline `InfoRow` banner when the user navigates to a screen whose binary was never installed (replaces the previous silent failure).
- **Absorbs 0.4.5** — EULA page, `\r` quiet progress, and `metadata.installer_icon` ride along; version jumps 0.4.4 → 0.4.6, no standalone 0.4.5 on PyPI.

## Key files

- Schema: [VIStk/Structures/_Screen.py](VIStk/Structures/_Screen.py), [_Project.py](VIStk/Structures/_Project.py), [_VINFO.py](VIStk/Structures/_VINFO.py)
- CLI: [VIStk/VIS.py](VIStk/VIS.py)
- Installer GUI: [VIStk/Structures/Installer.py](VIStk/Structures/Installer.py)
- Release subset: [VIStk/Structures/_Release.py](VIStk/Structures/_Release.py)
- Runtime detection: [VIStk/Structures/_Install.py](VIStk/Structures/_Install.py) (new), [VIStk/Objects/_Host.py](VIStk/Objects/_Host.py), [VIStk/Widgets/_InfoRow.py](VIStk/Widgets/_InfoRow.py)
- Docs: [docs/source/changelog/0.4.6.rst](docs/source/changelog/0.4.6.rst) (new), [changelog.md](changelog.md)

## Reviewer-caught bugs already fixed

1. `_on_all_clicked` — use child-state direction instead of `var_all.get()` (tri-state click cycle was unreliable).
2. `InfoRow._dismiss_banner` — guard with `winfo_exists()` so the auto-dismiss `after()` callback doesn't raise `TclError` after the window closes.
3. `_prompt_dependencies` — bounded loop instead of recursion so Cancel at a nested prompt doesn't undo earlier accepted Yes decisions.

## Test plan

- [ ] Load a project with no `release_info.groups` — confirm installer behaves exactly as 0.4.4 (flat list, no regressions)
- [ ] Add a group with mixed default-on / default-off members — confirm group row renders with expand arrow and correct initial tri-state
- [ ] Master "All" click toggles every leaf including groups (in every starting state: all-on, all-off, mixed)
- [ ] Group master click toggles all children regardless of `default`
- [ ] Declare `ScreenA.requires = [ScreenB]`, uncheck B, click Next — verify dialog appears; Yes auto-adds B and proceeds; Cancel stays on page
- [ ] Release subset: `vis release -Groups Core` — inspect `binaries.zip` to confirm only `Core` member binaries and pruned `project.json`
- [ ] Quiet install: `installer.exe --Quiet GroupA` — confirm only GroupA's default members land on disk and in `install_log.json`
- [ ] Runtime banner: subset-install then trigger navigation to an excluded screen — banner appears in `InfoRow`, dismisses on ✕ and auto-dismisses after 5s
- [ ] Close the window within 5s of banner showing — no `TclError`
- [ ] `python -m build` — verify sdist/wheel metadata shows 0.4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)