### PR TITLE
VIStk 0.4.7 — Tab Identity Refactor

### DIFF
--- a/VIStk/Objects/_DetachedWindow.py
+++ b/VIStk/Objects/_DetachedWindow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from tkinter import Toplevel
 
+from VIStk.Objects._Identity import new_id
 from VIStk.Objects._TabManager import TabManager
 from VIStk.Widgets._HostMenu import HostMenu
 from VIStk.Widgets._InfoRow import InfoRow
@@ -39,6 +40,9 @@ class DetachedWindow:
             btn_offset_y: Cursor y offset within the original tab button.
         """
         from VIStk.Objects._Host import _HOST_INSTANCE
+
+        self.id: int = new_id()
+        """Stable process-unique window ID (0.4.7)."""
 
         self.host = host
         self._closing = False
@@ -152,9 +156,9 @@ class DetachedWindow:
             self.win.geometry("1200x800+0+0")
             self.win.update_idletasks()
 
-            tab_names = list(self.tab_manager._tabs.keys())
-            if tab_names:
-                btn = self.tab_manager.tab_bar._tabs[tab_names[0]]["button"]
+            tab_ids = list(self.tab_manager._tabs.keys())
+            if tab_ids:
+                btn = self.tab_manager.tab_bar._tabs[tab_ids[0]]["button"]
                 btn_in_win_x, btn_in_win_y = 0, 0
                 w = btn
                 while True:
@@ -187,22 +191,24 @@ class DetachedWindow:
 
     # ── Lifecycle callbacks (tab events) ──────────────────────────────────────
 
-    def _on_tab_activate(self, name: str, module):
+    def _on_tab_activate(self, tab_id: int, module):
         """Update title, InfoRow, and menu when a tab gains focus."""
         self.HostMenu.restore_defaults()
         self.HostMenu.clear_screen_items()
 
-        info = self.tab_manager._tabs.get(name, {}).get("info", "")
-        self._set_title(name, info)
-        base_name = self.tab_manager._tabs.get(name, {}).get("base_name", name)
+        entry = self.tab_manager._tabs.get(tab_id, {})
+        display = entry.get("display_name", "")
+        info = entry.get("info", "")
+        self._set_title(display, info)
+        base_name = entry.get("base_name", display)
         scr = self.host.Project.getScreen(base_name)
-        self.InfoRow.set_screen(name, str(scr.s_version) if scr else "")
+        self.InfoRow.set_screen(display, str(scr.s_version) if scr else "")
 
         # Route configure_menu through TabManager
-        self.tab_manager._call_configure_menu(name)
+        self.tab_manager._call_configure_menu(tab_id)
 
         # Apply MENU_OVERRIDES if present
-        hooks = self.tab_manager._tabs.get(name, {}).get("hooks")
+        hooks = entry.get("hooks")
         overrides = (getattr(hooks, "MENU_OVERRIDES", None)
                      or getattr(module, "MENU_OVERRIDES", None))
         if overrides:
@@ -211,16 +217,17 @@ class DetachedWindow:
             except Exception:
                 pass
 
-    def _on_tab_deactivate(self, name: str | None):
+    def _on_tab_deactivate(self, tab_id: int | None):
         self.HostMenu.restore_defaults()
         self.HostMenu.clear_screen_items()
-        if name is None:
+        if tab_id is None:
             self.win.title(self.host.Project.title)
             self.InfoRow.set_screen("")
 
-    def _on_tab_info_change(self, name: str, info: str):
-        if self.tab_manager.active == name:
-            self._set_title(name, info)
+    def _on_tab_info_change(self, tab_id: int, info: str):
+        if self.tab_manager.active == tab_id:
+            entry = self.tab_manager._tabs.get(tab_id, {})
+            self._set_title(entry.get("display_name", ""), info)
 
     def _set_title(self, screen: str, info: str = ""):
         base = self.host.Project.title
@@ -231,79 +238,83 @@ class DetachedWindow:
 
     # ── Pop-out, detach, refresh, split ───────────────────────────────────────
 
-    def _on_tab_popout(self, name: str):
+    def _on_tab_popout(self, tab_id: int):
         """Pop out a tab into a new DetachedWindow at cursor position."""
-        pane = self._split_view.find_pane_for_tab(name)
+        pane = self._split_view.find_pane_for_tab(tab_id)
         if pane is None:
             return
-        entry = pane._tabs[name]
+        entry = pane._tabs[tab_id]
+        display = entry["display_name"]
         module = entry.get("module")
         hooks = entry.get("hooks")
         icon = entry.get("icon")
-        base_name = entry.get("base_name", name)
-        pane.close_tab(name, skip_on_quit=True)
+        base_name = entry.get("base_name", display)
+        pane.close_tab(tab_id, skip_on_quit=True)
         x = self.win.winfo_pointerx()
         y = self.win.winfo_pointery()
-        self._create_detached(name, module, hooks, icon, base_name, x, y, 0, 0)
+        self._create_detached(display, module, hooks, icon, base_name, x, y, 0, 0)
 
-    def _on_tab_detach(self, name: str):
+    def _on_tab_detach(self, tab_id: int):
         """Handle drag-to-detach — use pointer position and stored offsets."""
-        pane = self._split_view.find_pane_for_tab(name)
+        pane = self._split_view.find_pane_for_tab(tab_id)
         if pane is None:
             return
-        entry = pane._tabs[name]
+        entry = pane._tabs[tab_id]
+        display = entry["display_name"]
         module = entry.get("module")
         hooks = entry.get("hooks")
         icon = entry.get("icon")
-        base_name = entry.get("base_name", name)
+        base_name = entry.get("base_name", display)
         bx = pane.tab_bar._last_drag_btn_offset_x
         by = pane.tab_bar._last_drag_btn_offset_y
-        pane.close_tab(name, skip_on_quit=True)
+        pane.close_tab(tab_id, skip_on_quit=True)
         x = self.win.winfo_pointerx()
         y = self.win.winfo_pointery()
-        self._create_detached(name, module, hooks, icon, base_name, x, y, bx, by)
+        self._create_detached(display, module, hooks, icon, base_name, x, y, bx, by)
 
-    def _create_detached(self, name, module, hooks, icon, base_name,
+    def _create_detached(self, display, module, hooks, icon, base_name,
                          x_root, y_root, btn_offset_x, btn_offset_y):
         """Create a new DetachedWindow and open a tab in it."""
         dw = DetachedWindow(self.host, module=None, screen_name=None,
                             x_root=x_root, y_root=y_root,
                             btn_offset_x=btn_offset_x,
                             btn_offset_y=btn_offset_y)
-        dw.tab_manager.open_tab(name, module, hooks=hooks, icon=icon,
+        dw.tab_manager.open_tab(display, module, hooks=hooks, icon=icon,
                                 base_name=base_name)
 
-    def _on_tab_refresh(self, name: str):
-        pane = self._split_view.find_pane_for_tab(name)
+    def _on_tab_refresh(self, tab_id: int):
+        pane = self._split_view.find_pane_for_tab(tab_id)
         if pane is None:
             return
-        entry = pane._tabs[name]
-        base_name = entry.get("base_name", name)
+        entry = pane._tabs[tab_id]
+        display = entry["display_name"]
+        base_name = entry.get("base_name", display)
         icon = entry.get("icon")
-        idx = pane.tab_bar.get_tab_idx(name)
+        idx = pane.tab_bar.get_tab_idx(tab_id)
         scr = self.host.Project.getScreen(base_name)
         if scr is None:
-            pane.force_refresh_tab(name)
+            pane.force_refresh_tab(tab_id)
             return
-        pane.close_tab(name, skip_on_quit=True)
+        pane.close_tab(tab_id, skip_on_quit=True)
         module = self.host._import_screen(scr)
         hooks = self.host._import_hooks(scr)
-        pane.open_tab(name, module, hooks=hooks, icon=icon,
+        pane.open_tab(display, module, hooks=hooks, icon=icon,
                       insert_idx=idx, base_name=base_name)
 
-    def _on_tab_split(self, name: str, direction: str, target_pane=None):
+    def _on_tab_split(self, tab_id: int, direction: str, target_pane=None):
         """Handle right-click 'Split right' / 'Split down' or drag-to-split."""
         from VIStk.Widgets._SplitView import SplitView
 
-        source_pane = self._split_view.find_pane_for_tab(name)
+        source_pane = self._split_view.find_pane_for_tab(tab_id)
         if source_pane is None:
             return
         split_pane = target_pane if target_pane is not None else source_pane
-        entry = source_pane._tabs[name]
+        entry = source_pane._tabs[tab_id]
+        display = entry["display_name"]
         module = entry.get("module")
         hooks = entry.get("hooks")
         icon = entry.get("icon")
-        base_name = entry.get("base_name", name)
+        base_name = entry.get("base_name", display)
 
         target_sv = SplitView.find_owner(split_pane)
         if target_sv is None:
@@ -312,20 +323,20 @@ class DetachedWindow:
         if direction == "center":
             if split_pane is source_pane:
                 return
-            source_pane.close_tab(name, skip_on_quit=True)
-            split_pane.open_tab(name, module, hooks=hooks, icon=icon,
+            source_pane.close_tab(tab_id, skip_on_quit=True)
+            split_pane.open_tab(display, module, hooks=hooks, icon=icon,
                                 base_name=base_name)
         elif split_pane is source_pane:
             if len(source_pane._tabs) <= 1:
                 return
             left_pane, right_pane = target_sv.split(
-                split_pane, direction, exclude={name})
-            right_pane.open_tab(name, module, hooks=hooks, icon=icon,
+                split_pane, direction, exclude={tab_id})
+            right_pane.open_tab(display, module, hooks=hooks, icon=icon,
                                 base_name=base_name)
         else:
-            source_pane.close_tab(name, skip_on_quit=True)
+            source_pane.close_tab(tab_id, skip_on_quit=True)
             left_pane, right_pane = target_sv.split(split_pane, direction)
-            right_pane.open_tab(name, module, hooks=hooks, icon=icon,
+            right_pane.open_tab(display, module, hooks=hooks, icon=icon,
                                 base_name=base_name)
 
     # ── SplitView pane callbacks ──────────────────────────────────────────────
@@ -368,10 +379,18 @@ class DetachedWindow:
             return
         self._closing = True
 
-        # Pass 1: collect vetoes
-        vetoed: list[str] = []
-        for tm in list(self.tab_managers):
-            for name, tab in list(tm._tabs.items()):
+        # (0.4.7) Iterate the live SplitView tree rather than
+        # ``self.tab_managers``, which is seeded at init and never
+        # maintained across splits — the seeded-only list misses every
+        # pane created by ``SplitView.split`` and every pane rebuilt by
+        # ``SplitView.remove_pane``, causing on_quit vetoes to be
+        # silently skipped in those panes.
+        live_panes = list(self._split_view.all_tab_managers())
+
+        # Pass 1: collect vetoes (by tab_id)
+        vetoed: set[int] = set()
+        for tm in live_panes:
+            for tab_id, tab in list(tm._tabs.items()):
                 module = tab.get("module")
                 hooks = tab.get("hooks")
                 quit_fn = (getattr(hooks, "on_quit", None)
@@ -379,15 +398,15 @@ class DetachedWindow:
                 if quit_fn:
                     try:
                         if quit_fn() is False:
-                            vetoed.append(name)
+                            vetoed.add(tab_id)
                     except Exception:
                         pass
 
         # Pass 2: destroy tabs that did not veto
-        for tm in list(self.tab_managers):
-            for name in list(tm._tabs.keys()):
-                if name not in vetoed:
-                    tm.close_tab(name, skip_on_quit=True)
+        for tm in live_panes:
+            for tab_id in list(tm._tabs.keys()):
+                if tab_id not in vetoed:
+                    tm.close_tab(tab_id, skip_on_quit=True)
 
         # If nothing vetoed, destroy window
         if vetoed:

--- a/VIStk/Objects/_DetachedWindow.py
+++ b/VIStk/Objects/_DetachedWindow.py
@@ -298,8 +298,11 @@ class DetachedWindow:
         pane.close_tab(tab_id, skip_on_quit=True)
         module = self.host._import_screen(scr)
         hooks = self.host._import_hooks(scr)
+        # Reuse the original tab_id so external references (recorded focus
+        # IDs, _pane_parents look-ups) survive the refresh — mirrors the
+        # identity-preserving behaviour of TabManager.force_refresh_tab.
         pane.open_tab(display, module, hooks=hooks, icon=icon,
-                      insert_idx=idx, base_name=base_name)
+                      insert_idx=idx, base_name=base_name, tab_id=tab_id)
 
     def _on_tab_split(self, tab_id: int, direction: str, target_pane=None):
         """Handle right-click 'Split right' / 'Split down' or drag-to-split."""

--- a/VIStk/Objects/_Host.py
+++ b/VIStk/Objects/_Host.py
@@ -121,10 +121,15 @@ class Host:
         Used by :meth:`_unique_display_name` to avoid visually ambiguous
         duplicate labels; internal bookkeeping relies on tab IDs (0.4.7),
         not on label uniqueness.
+
+        Walks the live SplitView tree rather than ``dw.tab_managers`` so
+        ghost labels from TabManagers destroyed by ``SplitView.remove_pane``
+        (a pre-existing bookkeeping leak) don't trigger spurious ``(2)``
+        suffixes on new tabs.
         """
         labels: set[str] = set()
         for dw in self.detached_windows:
-            for tm in dw.tab_managers:
+            for tm in dw._split_view.all_tab_managers():
                 for entry in tm._tabs.values():
                     label = entry.get("display_name")
                     if label:
@@ -138,9 +143,12 @@ class Host:
         With duplicate base names this picks the first match — callers
         wanting a specific instance should hold the tab_id returned by
         :meth:`TabManager.open_tab`.
+
+        Walks the live SplitView tree so ghost entries from destroyed
+        TabManagers (see ``_get_all_tab_labels``) aren't returned.
         """
         for dw in self.detached_windows:
-            for tm in dw.tab_managers:
+            for tm in dw._split_view.all_tab_managers():
                 for tab_id, entry in tm._tabs.items():
                     display = entry.get("display_name", "")
                     if entry.get("base_name", display) == base_name:

--- a/VIStk/Objects/_Host.py
+++ b/VIStk/Objects/_Host.py
@@ -57,9 +57,9 @@ class Host:
         self._fps_acc: float = 0.0
         self._fps_listeners: list = []
 
-        # Multiple-instance tracking: base_name → count of currently open instances
-        self._open_counts: dict[str, int] = {}
-
+        # (0.4.7) Multiple-instance tracking retired — tab IDs now make
+        # every tab uniquely addressable; label uniqueness is only a UX
+        # concern, handled by :meth:`_unique_display_name`.
         self.Active: bool = True
 
         self._opened_default = False
@@ -115,26 +115,42 @@ class Host:
 
     # ── Tabs ───────────────────────────────────────────────────────────────────
 
-    def _get_all_tab_names(self) -> set[str]:
-        """Return all display names currently open in any window."""
-        names: set[str] = set()
+    def _get_all_tab_labels(self) -> set[str]:
+        """Return every display label currently in use across all windows.
+
+        Used by :meth:`_unique_display_name` to avoid visually ambiguous
+        duplicate labels; internal bookkeeping relies on tab IDs (0.4.7),
+        not on label uniqueness.
+        """
+        labels: set[str] = set()
         for dw in self.detached_windows:
             for tm in dw.tab_managers:
-                names.update(tm._tabs.keys())
-        return names
+                for entry in tm._tabs.values():
+                    label = entry.get("display_name")
+                    if label:
+                        labels.add(label)
+        return labels
 
     def _find_tab_by_base(self, base_name: str):
-        """Return (tab_manager, display_name) for the first open tab whose base_name matches."""
+        """Return ``(tab_manager, tab_id)`` for the first open tab whose
+        ``base_name`` matches, else ``(None, None)``.
+
+        With duplicate base names this picks the first match — callers
+        wanting a specific instance should hold the tab_id returned by
+        :meth:`TabManager.open_tab`.
+        """
         for dw in self.detached_windows:
             for tm in dw.tab_managers:
-                for display, entry in tm._tabs.items():
+                for tab_id, entry in tm._tabs.items():
+                    display = entry.get("display_name", "")
                     if entry.get("base_name", display) == base_name:
-                        return tm, display
+                        return tm, tab_id
         return None, None
 
     def _unique_display_name(self, base: str) -> str:
-        """Return a display name that doesn't conflict with open tabs."""
-        existing = self._get_all_tab_names()
+        """Return a display name that doesn't visually collide with an
+        already-open tab label."""
+        existing = self._get_all_tab_labels()
         if base not in existing:
             return base
         n = 2
@@ -144,9 +160,9 @@ class Host:
 
     def _open_tab(self, scr):
         if scr.single_instance:
-            tm, display = self._find_tab_by_base(scr.name)
-            if tm is not None:
-                tm.focus_tab(display)
+            tm, tab_id = self._find_tab_by_base(scr.name)
+            if tm is not None and tab_id is not None:
+                tm.focus_tab(tab_id)
                 # Raise the DetachedWindow that owns the target pane
                 for dw in self.detached_windows:
                     if tm in dw.tab_managers:

--- a/VIStk/Objects/_Identity.py
+++ b/VIStk/Objects/_Identity.py
@@ -1,0 +1,31 @@
+"""Monotonic in-process ID allocator.
+
+VIStk 0.4.7 replaces display-name-based lookups for tabs, panes, and
+windows with stable integer IDs. All IDs come from a single
+module-level counter so they are globally unique for the lifetime of
+the Python process; this makes them safe to move across panes or
+windows without renumbering and easy to grep for in debug logs.
+
+The counter is **not** persistent — IDs reset on process restart.
+Persistent identity for features like "remember open tabs across
+restart" would need UUIDs or a saved highwater mark; that is out of
+scope for 0.4.7.
+"""
+
+from __future__ import annotations
+
+import itertools
+import threading
+
+_counter = itertools.count(1)
+_lock = threading.Lock()
+
+
+def new_id() -> int:
+    """Return a fresh, strictly increasing integer ID.
+
+    Thread-safe; may be called from any thread (tab drag handlers run on
+    the Tk main thread today but future IPC / async work may not).
+    """
+    with _lock:
+        return next(_counter)

--- a/VIStk/Objects/_TabManager.py
+++ b/VIStk/Objects/_TabManager.py
@@ -6,6 +6,7 @@ import queue
 import sys
 from tkinter import Frame
 
+from VIStk.Objects._Identity import new_id
 from VIStk.Widgets._TabBar import TabBar, _BG_BAR
 
 
@@ -26,53 +27,61 @@ def set_tab_info(frame, info):
             set_tab_info(parent, wo_var)
             ...
     """
-    mgr  = getattr(frame, "_vis_tab_manager", None)
-    name = getattr(frame, "_vis_tab_name",    None)
-    if mgr is not None and name is not None:
-        mgr.set_tab_info(name, info)
+    mgr    = getattr(frame, "_vis_tab_manager", None)
+    tab_id = getattr(frame, "_vis_tab_id",      None)
+    if mgr is not None and tab_id is not None:
+        mgr.set_tab_info(tab_id, info)
 
 
 class TabManager(Frame):
-    """Manages the tabbed screen area of the Host window.
+    """Manages the tabbed screen area of a DetachedWindow.
 
-    ``TabManager`` is a ``Frame`` that fills the Host window.  It owns two
-    child frames:
+    ``TabManager`` is a ``Frame`` that fills its parent.  It owns two child
+    frames:
 
     * ``tab_bar`` — a :class:`~VIStk.Widgets._TabBar.TabBar` packed along
       the top edge.
     * The *content frame* (internal) — fills the remaining space.
 
+    Tab identity (0.4.7)
+    --------------------
+    Every opened tab is keyed by a stable integer ``tab_id`` allocated from
+    :func:`VIStk.Objects._Identity.new_id`.  Display labels are mutable
+    (see :meth:`set_tab_info`) and may collide; IDs disambiguate across
+    panes and windows.
+
+    Public methods accept either an ``int`` tab ID or a ``str`` display
+    label.  When a label is passed, the first matching tab is used —
+    lookup is non-deterministic in the presence of duplicate labels.
+    Callers that hold a specific instance should pass the ID.
+
     Hook lookup priority: if ``modules/<screen>/m_<screen>.py`` exists,
     ``TabManager`` checks it first for ``on_focused``, ``on_unfocused``, and
     ``configure_menu``.  The screen module is used as a fallback.
 
-    Callbacks::
+    Callbacks (receive ``tab_id: int`` as the first argument)::
 
-        manager.on_tab_activate    = lambda name, mod: ...
-        manager.on_tab_deactivate  = lambda name: ...
-        manager.on_tab_popout      = lambda name: ...
-        manager.on_tab_detach      = lambda name: ...
-        manager.on_tab_refresh     = lambda name: ...
-        manager.on_tab_info_change = lambda name, info: ...
+        manager.on_tab_activate    = lambda tab_id, mod: ...
+        manager.on_tab_deactivate  = lambda tab_id | None: ...
+        manager.on_tab_popout      = lambda tab_id: ...
+        manager.on_tab_detach      = lambda tab_id: ...
+        manager.on_tab_refresh     = lambda tab_id: ...
+        manager.on_tab_info_change = lambda tab_id, info: ...
+        manager.on_tab_split       = lambda tab_id, direction, target_pane: ...
 
-    Attributes:
-        tab_bar            (TabBar)
-        on_tab_activate    (callable | None) ``(name, module)``
-        on_tab_deactivate  (callable | None) ``(name | None)``
-        on_tab_popout      (callable | None) ``(name)``
-        on_tab_detach      (callable | None) ``(name)``
-        on_tab_refresh     (callable | None) ``(name)``
-        on_tab_info_change (callable | None) ``(name, info)``
-        on_tab_split       (callable | None) ``(name, direction)``
+    Use :meth:`display_name` to resolve a ``tab_id`` back to its label.
     """
 
     def __init__(self, parent, position: str = "top", menubar=None, **kwargs):
         kwargs.setdefault("bg", _BG_BAR)
         super().__init__(parent, **kwargs)
 
-        self._tabs: dict[str, dict] = {}
-        """name → {frame, module, hooks, icon, base_name, info, _info_trace}"""
-        self._active: str | None = None
+        self.id: int = new_id()
+        """Stable process-unique pane ID (0.4.7)."""
+
+        self._tabs: dict[int, dict] = {}
+        """tab_id -> {tab_id, display_name, frame, module, hooks, icon, base_name, info, _info_trace}"""
+        self._active: int | None = None
         self._position: str = position
 
         self._action_queue: queue.SimpleQueue = queue.SimpleQueue()
@@ -156,16 +165,43 @@ class TabManager(Frame):
         self.tab_bar.set_position(position)
         self._repack_layout()
 
+    # ── Identity helpers ───────────────────────────────────────────────────────
+
+    def _resolve_id(self, key) -> int | None:
+        """Resolve *key* (int tab_id or str display label) to a tab_id."""
+        if isinstance(key, int) and not isinstance(key, bool):
+            return key if key in self._tabs else None
+        if isinstance(key, str):
+            return self._id_for_display(key)
+        return None
+
+    def _id_for_display(self, label: str) -> int | None:
+        """Return the first tab_id whose display_name equals *label*, else None.
+
+        Non-deterministic when multiple tabs share *label*.  Prefer holding
+        the tab_id returned by :meth:`open_tab`.
+        """
+        for tab_id, entry in self._tabs.items():
+            if entry.get("display_name") == label:
+                return tab_id
+        return None
+
+    def display_name(self, tab_id: int) -> str | None:
+        """Return the current display name of *tab_id*, or None."""
+        entry = self._tabs.get(tab_id)
+        return entry.get("display_name") if entry else None
+
     # ── Public API ─────────────────────────────────────────────────────────────
 
     @property
-    def active(self) -> str | None:
+    def active(self) -> int | None:
+        """Tab ID of the currently active tab (0.4.7)."""
         return self._active
 
     @property
     def active_module(self):
         """Return the module of the currently active tab, or None."""
-        if self._active and self._active in self._tabs:
+        if self._active is not None and self._active in self._tabs:
             return self._tabs[self._active].get("module")
         return None
 
@@ -193,10 +229,11 @@ class TabManager(Frame):
         if _HOST_INSTANCE is None:
             return
 
-        # 1. Call on_quit on active screen
-        if self._active and self._active in self._tabs:
-            module = self._tabs[self._active].get("module")
-            hooks = self._tabs[self._active].get("hooks")
+        # 1. Call on_quit on active screen and close it
+        if self._active is not None and self._active in self._tabs:
+            entry = self._tabs[self._active]
+            module = entry.get("module")
+            hooks = entry.get("hooks")
             quit_fn = (getattr(hooks, "on_quit", None)
                        or getattr(module, "on_quit", None))
             if quit_fn:
@@ -205,7 +242,7 @@ class TabManager(Frame):
                         return  # vetoed
                 except Exception:
                     pass
-            base_name = self._tabs[self._active].get("base_name", self._active)
+            base_name = entry.get("base_name", entry.get("display_name", name))
             self.close_tab(self._active)
             self._cleanup_screen_modules(base_name)
 
@@ -241,44 +278,66 @@ class TabManager(Frame):
 
     def _cleanup_all_modules(self):
         """Clean up all screen modules owned by this TabManager."""
-        for name, entry in list(self._tabs.items()):
-            base_name = entry.get("base_name", name)
-            self._cleanup_screen_modules(base_name)
+        for entry in list(self._tabs.values()):
+            base_name = entry.get("base_name", entry.get("display_name", ""))
+            if base_name:
+                self._cleanup_screen_modules(base_name)
 
     def open_tab(self, name: str, module, hooks=None, icon=None,
-                 insert_idx: int = -1, base_name: str = None) -> bool:
-        """Open a new tab for *name* and build its screen UI.
+                 insert_idx: int = -1, base_name: str = None,
+                 tab_id: int | None = None) -> int | None:
+        """Open a new tab and build its screen UI.
 
         Args:
-            name:       Display name / tab label.
+            name:       Display label shown on the tab button.
             module:     Imported screen module.
             hooks:      Optional hooks module from ``modules/<name>/m_<name>.py``.
             icon:       Optional ``PIL.ImageTk.PhotoImage``.
             insert_idx: 0-based insertion position; -1 appends.
             base_name:  Screen registry name (same as *name* if no suffix).
+            tab_id:     Optional existing tab_id to reuse (for SplitView
+                rebuilds that must preserve tab identity across pane
+                destruction). When ``None`` a fresh ID is allocated.
 
         Returns:
-            ``True`` if a new tab was created, ``False`` if it already existed.
+            The tab's ``tab_id`` on success, ``None`` if a tab with this
+            exact display name already exists in *this* pane (callers with
+            the same label across panes are fine).
         """
-        if name in self._tabs:
-            self.tab_bar.focus_tab(name)
-            return False
+        # Reject only if the same ``tab_id`` is already registered —
+        # SplitView rebuilds call with an explicit ``tab_id`` and require
+        # the call to succeed even when a tab with a matching display
+        # label is in the pane (it shouldn't be, because the pane is
+        # fresh, but defensive ID-based gating is safer).
+        if tab_id is not None and tab_id in self._tabs:
+            return None
+
+        # For fresh-ID callers: suppress duplicate labels in the same pane
+        # by focusing the existing tab instead of creating a visual clone.
+        if tab_id is None:
+            existing = self._id_for_display(name)
+            if existing is not None:
+                self.tab_bar.focus_tab(existing)
+                return None
+            tab_id = new_id()
 
         frame = Frame(self._content)
         frame.place(relx=0, rely=0, relwidth=1, relheight=1)
 
         # Let screens call set_tab_info(parent, ...) from inside setup()
-        frame._vis_tab_name    = name
+        frame._vis_tab_id      = tab_id
         frame._vis_tab_manager = self
 
-        self._tabs[name] = {
-            "frame":      frame,
-            "module":     module,
-            "hooks":      hooks,
-            "icon":       icon,
-            "base_name":  base_name if base_name is not None else name,
-            "info":       "",
-            "_info_trace": None,   # (StringVar, trace_id) | None
+        self._tabs[tab_id] = {
+            "tab_id":        tab_id,
+            "display_name":  name,
+            "frame":         frame,
+            "module":        module,
+            "hooks":         hooks,
+            "icon":          icon,
+            "base_name":     base_name if base_name is not None else name,
+            "info":          "",
+            "_info_trace":   None,   # (StringVar, trace_id) | None
         }
 
         if module and hasattr(module, "setup"):
@@ -287,24 +346,27 @@ class TabManager(Frame):
             except Exception:
                 pass
 
-        self.tab_bar.open_tab(name, icon=icon, insert_idx=insert_idx)
-        return True
+        self.tab_bar.open_tab(tab_id, name, icon=icon, insert_idx=insert_idx)
+        return tab_id
 
-    def close_tab(self, name: str, skip_on_quit: bool = False) -> bool:
-        """Close the named tab, running ``on_unfocused`` first.
+    def close_tab(self, key, skip_on_quit: bool = False) -> bool:
+        """Close the tab identified by *key* (tab_id or display label).
 
         Args:
-            name: Display name of the tab.
+            key:          Tab ID (int) or display label (str).
             skip_on_quit: If True, skip the on_quit hook (used when
                 DetachedWindow has already checked it).
         """
-        if name not in self._tabs:
+        tab_id = self._resolve_id(key)
+        if tab_id is None:
             return False
+
+        entry = self._tabs[tab_id]
 
         # Call on_quit unless skipped (e.g. window close already checked)
         if not skip_on_quit:
-            module = self._tabs[name].get("module")
-            hooks = self._tabs[name].get("hooks")
+            module = entry.get("module")
+            hooks = entry.get("hooks")
             quit_fn = (getattr(hooks, "on_quit", None)
                        or getattr(module, "on_quit", None))
             if quit_fn:
@@ -315,7 +377,7 @@ class TabManager(Frame):
                     pass
 
         # Clean up StringVar trace if present
-        trace_info = self._tabs[name].get("_info_trace")
+        trace_info = entry.get("_info_trace")
         if trace_info is not None:
             var, tid = trace_info
             try:
@@ -323,69 +385,88 @@ class TabManager(Frame):
             except Exception:
                 pass
 
-        if self._active == name:
-            self._deactivate(name)
+        if self._active == tab_id:
+            self._deactivate(tab_id)
             self._active = None
 
-        self._tabs[name]["frame"].destroy()
-        del self._tabs[name]
-        self.tab_bar.close_tab(name)
+        entry["frame"].destroy()
+        del self._tabs[tab_id]
+        self.tab_bar.close_tab(tab_id)
         return True
 
-    def focus_tab(self, name: str) -> bool:
-        return self.tab_bar.focus_tab(name)
-
-    def has_tab(self, name: str) -> bool:
-        return name in self._tabs
-
-    def force_refresh_tab(self, name: str) -> bool:
-        """Close and reopen *name* at its current position, re-running ``setup``."""
-        if name not in self._tabs:
+    def focus_tab(self, key) -> bool:
+        """Focus the tab identified by *key* (tab_id or display label)."""
+        tab_id = self._resolve_id(key)
+        if tab_id is None:
             return False
-        idx       = self.tab_bar.get_tab_idx(name)
-        entry     = self._tabs[name]
+        return self.tab_bar.focus_tab(tab_id)
+
+    def has_tab(self, key) -> bool:
+        """Return whether *key* identifies an open tab."""
+        return self._resolve_id(key) is not None
+
+    def force_refresh_tab(self, key) -> bool:
+        """Close and reopen the identified tab at its current position, re-running ``setup``.
+
+        Preserves the same ``tab_id`` across the refresh so external
+        references (``_pane_parents`` look-ups, recorded focus IDs, etc.)
+        remain valid.
+        """
+        tab_id = self._resolve_id(key)
+        if tab_id is None:
+            return False
+        idx       = self.tab_bar.get_tab_idx(tab_id)
+        entry     = self._tabs[tab_id]
+        display   = entry["display_name"]
         module    = entry.get("module")
         hooks     = entry.get("hooks")
         icon      = entry.get("icon")
-        base_name = entry.get("base_name", name)
-        if not self.close_tab(name):
-            return False
-        self.open_tab(name, module, hooks=hooks, icon=icon,
-                      insert_idx=idx, base_name=base_name)
-        return True
+        base_name = entry.get("base_name", display)
 
-    def set_tab_info(self, name: str, info) -> None:
-        """Set or trace the characteristic info for tab *name*.
+        # Tear down without calling on_quit
+        if not self.close_tab(tab_id, skip_on_quit=True):
+            return False
+
+        # Re-open reusing the original tab_id so any external reference to
+        # this tab (e.g. focus tracking in SplitView) survives the refresh.
+        new_tab_id = self.open_tab(display, module, hooks=hooks, icon=icon,
+                                    insert_idx=idx, base_name=base_name,
+                                    tab_id=tab_id)
+        return new_tab_id is not None
+
+    def set_tab_info(self, key, info) -> None:
+        """Set or trace the characteristic info for the identified tab.
 
         ``info`` may be a plain ``str`` or a ``tkinter.StringVar``.
         Replaces any previously registered trace.
         """
-        if name not in self._tabs:
+        tab_id = self._resolve_id(key)
+        if tab_id is None:
             return
         # Remove existing trace if any
-        old = self._tabs[name].get("_info_trace")
+        old = self._tabs[tab_id].get("_info_trace")
         if old is not None:
             old_var, old_tid = old
             try:
                 old_var.trace_remove("write", old_tid)
             except Exception:
                 pass
-            self._tabs[name]["_info_trace"] = None
+            self._tabs[tab_id]["_info_trace"] = None
 
         # Detect StringVar by duck-typing
         if hasattr(info, "trace_add") and callable(info.trace_add):
             var = info
             tid = var.trace_add("write",
-                                lambda *_: self._update_tab_info(name, var.get()))
-            self._tabs[name]["_info_trace"] = (var, tid)
-            self._update_tab_info(name, var.get())
+                                lambda *_: self._update_tab_info(tab_id, var.get()))
+            self._tabs[tab_id]["_info_trace"] = (var, tid)
+            self._update_tab_info(tab_id, var.get())
         else:
-            self._update_tab_info(name, str(info))
+            self._update_tab_info(tab_id, str(info))
 
     # ── Hook lookup ────────────────────────────────────────────────────────────
 
-    def _get_hook(self, name: str, hook_name: str):
-        entry = self._tabs.get(name, {})
+    def _get_hook(self, tab_id: int, hook_name: str):
+        entry = self._tabs.get(tab_id, {})
         fn = getattr(entry.get("hooks"), hook_name, None)
         if fn is None:
             fn = getattr(entry.get("module"), hook_name, None)
@@ -393,38 +474,39 @@ class TabManager(Frame):
 
     # ── Internal ───────────────────────────────────────────────────────────────
 
-    def _update_tab_info(self, name: str, info: str):
+    def _update_tab_info(self, tab_id: int, info: str):
         """Update the stored info string and propagate to tab label + callback."""
-        if name not in self._tabs:
+        if tab_id not in self._tabs:
             return
-        self._tabs[name]["info"] = info
+        self._tabs[tab_id]["info"] = info
+        name = self._tabs[tab_id]["display_name"]
         # Update tab button text
         display = f"{name} \u2014 {info}" if info else name
-        self.tab_bar.update_tab_label(name, display)
+        self.tab_bar.update_tab_label(tab_id, display)
         # Notify interested parties (Host, DetachedWindow)
         if self.on_tab_info_change:
-            self.on_tab_info_change(name, info)
+            self.on_tab_info_change(tab_id, info)
 
-    def _deactivate(self, name: str):
-        if name not in self._tabs:
+    def _deactivate(self, tab_id: int):
+        if tab_id not in self._tabs:
             return
-        self._tabs[name]["frame"].lower()
-        fn = self._get_hook(name, "on_unfocused")
+        self._tabs[tab_id]["frame"].lower()
+        fn = self._get_hook(tab_id, "on_unfocused")
         if fn:
             try:
                 fn()
             except Exception:
                 pass
         if self.on_tab_deactivate:
-            self.on_tab_deactivate(name)
+            self.on_tab_deactivate(tab_id)
 
-    def _call_configure_menu(self, name: str):
+    def _call_configure_menu(self, tab_id: int):
         """Call configure_menu on the active tab's hooks or module.
 
         Supports both new signature (tabmanager) and old signature (menubar)
         for backwards compatibility.
         """
-        cfg = self._get_hook(name, "configure_menu")
+        cfg = self._get_hook(tab_id, "configure_menu")
         if cfg is None:
             return
         try:
@@ -439,72 +521,77 @@ class TabManager(Frame):
         except Exception:
             pass
 
-    def _on_focus_change(self, name: str | None):
+    def _on_focus_change(self, tab_id: int | None):
         prev = self._active
-        if prev and prev != name:
+        if prev is not None and prev != tab_id:
             self._deactivate(prev)
 
-        self._active = name
+        self._active = tab_id
 
-        if name and name in self._tabs:
-            self._tabs[name]["frame"].lift()
-            fn = self._get_hook(name, "on_focused")
+        if tab_id is not None and tab_id in self._tabs:
+            self._tabs[tab_id]["frame"].lift()
+            fn = self._get_hook(tab_id, "on_focused")
             if fn:
                 try:
                     fn()
                 except Exception:
                     pass
             if self.on_tab_activate:
-                self.on_tab_activate(name, self._tabs[name].get("module"))
-        elif name is None and self.on_tab_deactivate:
+                self.on_tab_activate(tab_id, self._tabs[tab_id].get("module"))
+        elif tab_id is None and self.on_tab_deactivate:
             self.on_tab_deactivate(None)
 
-    def _on_close_request(self, name: str):
-        fn = self._get_hook(name, "has_unsaved")
+    def _on_close_request(self, tab_id: int):
+        entry = self._tabs.get(tab_id)
+        if entry is None:
+            return
+        fn = self._get_hook(tab_id, "has_unsaved")
         if fn:
             try:
                 if fn():
                     from tkinter import messagebox
                     if not messagebox.askyesno(
                         "Close tab",
-                        f'"{name}" has unsaved changes.\nClose anyway?',
+                        f'"{entry["display_name"]}" has unsaved changes.\nClose anyway?',
                     ):
                         return
             except Exception:
                 pass
-        self.close_tab(name)
+        self.close_tab(tab_id)
 
-    def _on_popout_request(self, name: str):
+    def _on_popout_request(self, tab_id: int):
         if self.on_tab_popout:
-            self.on_tab_popout(name)
+            self.on_tab_popout(tab_id)
 
-    def _on_refresh_request(self, name: str):
+    def _on_refresh_request(self, tab_id: int):
         if self.on_tab_refresh:
-            self.on_tab_refresh(name)
+            self.on_tab_refresh(tab_id)
         else:
-            self.force_refresh_tab(name)
+            self.force_refresh_tab(tab_id)
 
-    def _on_detach_request(self, name: str):
+    def _on_detach_request(self, tab_id: int):
         if self.on_tab_detach:
-            self.on_tab_detach(name)
+            self.on_tab_detach(tab_id)
 
-    def _on_split_request(self, name: str, direction: str, target_pane=None):
+    def _on_split_request(self, tab_id: int, direction: str, target_pane=None):
         if self.on_tab_split:
-            self.on_tab_split(name, direction, target_pane)
+            self.on_tab_split(tab_id, direction, target_pane)
 
-    def _on_merge_request(self, name: str, source_bar: "TabBar", insert_idx: int = -1):
+    def _on_merge_request(self, tab_id: int, source_bar: "TabBar",
+                          insert_idx: int = -1):
         """A drag from *source_bar* was released over this bar at *insert_idx*."""
         source_mgr = source_bar.owner
         if source_mgr is None or source_mgr is self:
             return
-        if not source_mgr.has_tab(name):
+        if not source_mgr.has_tab(tab_id):
             return
-        entry     = source_mgr._tabs[name]
+        entry     = source_mgr._tabs[tab_id]
+        display   = entry["display_name"]
         module    = entry.get("module")
         hooks     = entry.get("hooks")
         icon      = entry.get("icon")
-        base_name = entry.get("base_name", name)
-        if not source_mgr.close_tab(name):
+        base_name = entry.get("base_name", display)
+        if not source_mgr.close_tab(tab_id, skip_on_quit=True):
             return
-        self.open_tab(name, module, hooks=hooks, icon=icon,
+        self.open_tab(display, module, hooks=hooks, icon=icon,
                       insert_idx=insert_idx, base_name=base_name)

--- a/VIStk/Structures/_Screen.py
+++ b/VIStk/Structures/_Screen.py
@@ -295,14 +295,19 @@ class Screen(VINFO):
     def close(self) -> bool:
         """Ask the Host to close this screen's tab.
 
-        Returns ``True`` if the tab was found and closed, ``False`` otherwise.
+        Closes the first open instance matching ``self.name``.  Screen code
+        that has opened multiple instances and wants to close a specific
+        one should hold the tab_id returned by ``TabManager.open_tab`` and
+        call ``tm.close_tab(tab_id)`` directly.
+
+        Returns ``True`` if a tab was found and closed, ``False`` otherwise.
         """
         from VIStk.Objects._Host import _HOST_INSTANCE
         if _HOST_INSTANCE is None:
             return False
-        tm, display = _HOST_INSTANCE._find_tab_by_base(self.name)
-        if tm is not None and display is not None:
-            tm.close_tab(display)
+        tm, tab_id = _HOST_INSTANCE._find_tab_by_base(self.name)
+        if tm is not None and tab_id is not None:
+            tm.close_tab(tab_id)
             return True
         return False
 

--- a/VIStk/Widgets/_SplitView.py
+++ b/VIStk/Widgets/_SplitView.py
@@ -37,7 +37,7 @@ class SplitView(Frame):
 
         # Map each TabManager to its parent _SplitNode (None for root leaf)
         self._pane_parents: dict[int, _SplitNode | None] = {
-            id(self._root_widget): None
+            self._root_widget.id: None
         }
 
         self._wire_pane(self._root_widget)
@@ -67,7 +67,7 @@ class SplitView(Frame):
     def find_owner(cls, pane) -> "SplitView | None":
         """Return the SplitView that owns *pane*, or ``None``."""
         for sv in cls._registry:
-            if id(pane) in sv._pane_parents:
+            if pane.id in sv._pane_parents:
                 return sv
         return None
 
@@ -195,7 +195,7 @@ class SplitView(Frame):
     def focused_pane(self):
         """The :class:`TabManager` the user last interacted with."""
         # Ensure the focused pane is still alive
-        if self._focused_pane is not None and id(self._focused_pane) in self._pane_parents:
+        if self._focused_pane is not None and self._focused_pane.id in self._pane_parents:
             return self._focused_pane
         # Fallback to first available pane
         panes = self.all_tab_managers()
@@ -229,10 +229,10 @@ class SplitView(Frame):
             merged.update(pane._tabs)
         return merged
 
-    def find_pane_for_tab(self, name: str):
-        """Return the :class:`TabManager` that owns *name*, or ``None``."""
+    def find_pane_for_tab(self, tab_id: int):
+        """Return the :class:`TabManager` that owns *tab_id*, or ``None``."""
         for pane in self.all_tab_managers():
-            if name in pane._tabs:
+            if tab_id in pane._tabs:
                 return pane
         return None
 
@@ -308,7 +308,7 @@ class SplitView(Frame):
             ox, oy, ow, oh = cx, cy, cw, ch
         else:
             return
-        info = (id(pane), direction)
+        info = (pane.id, direction)
         if self._drop_zone_info == info and self._drop_overlay is not None:
             return  # already showing the right overlay
         self.hide_drop_overlay()
@@ -374,7 +374,7 @@ class SplitView(Frame):
         from VIStk.Objects._TabManager import TabManager
 
         orient = "horizontal" if direction == "right" else "vertical"
-        parent_node = self._pane_parents.get(id(pane))
+        parent_node = self._pane_parents.get(pane.id)
 
         # Create a _SplitNode to replace the pane
         if parent_node is None:
@@ -407,50 +407,54 @@ class SplitView(Frame):
         node.set_slot1(left_pane)
         node.set_slot2(right_pane)
 
-        self._pane_parents[id(node)] = parent_node
-        self._pane_parents[id(left_pane)] = node
-        self._pane_parents[id(right_pane)] = node
+        self._pane_parents[node.id] = parent_node
+        self._pane_parents[left_pane.id] = node
+        self._pane_parents[right_pane.id] = node
         self._wire_pane(left_pane)
         self._wire_pane(right_pane)
 
-        # Transfer existing tabs from old pane to left_pane (re-runs setup)
+        # Transfer existing tabs from old pane to left_pane, preserving
+        # their tab_ids so callers holding an ID still resolve correctly.
         _exclude = exclude or set()
-        for tab_name in list(pane._tabs.keys()):
-            if tab_name in _exclude:
+        for tab_id in list(pane._tabs.keys()):
+            if tab_id in _exclude:
                 continue
-            entry = pane._tabs[tab_name]
+            entry = pane._tabs[tab_id]
+            display   = entry.get("display_name", "")
             module    = entry.get("module")
             hooks     = entry.get("hooks")
             icon      = entry.get("icon")
-            base_name = entry.get("base_name", tab_name)
+            base_name = entry.get("base_name", display)
             info_data = entry.get("_info_trace")  # (StringVar, tid) or None
             info_str  = entry.get("info", "")
 
-            left_pane.open_tab(tab_name, module, hooks=hooks, icon=icon,
-                               base_name=base_name)
+            left_pane.open_tab(display, module, hooks=hooks, icon=icon,
+                               base_name=base_name, tab_id=tab_id)
 
             # Restore tab info (prefer StringVar if traced)
             if info_data is not None:
                 var, _ = info_data
-                left_pane.set_tab_info(tab_name, var)
+                left_pane.set_tab_info(tab_id, var)
             elif info_str:
-                left_pane.set_tab_info(tab_name, info_str)
+                left_pane.set_tab_info(tab_id, info_str)
 
-        # Clean up old pane without triggering callbacks
-        for tab_name in list(pane._tabs.keys()):
-            trace_info = pane._tabs[tab_name].get("_info_trace")
+        # Clean up old pane without triggering callbacks. Tabs that were
+        # transferred now live in left_pane; we still need to tear down
+        # any excluded tabs' frames here.
+        for tab_id in list(pane._tabs.keys()):
+            trace_info = pane._tabs[tab_id].get("_info_trace")
             if trace_info is not None:
-                var, tid = trace_info
+                var, trace_tid = trace_info
                 try:
-                    var.trace_remove("write", tid)
+                    var.trace_remove("write", trace_tid)
                 except TclError:
                     pass
             try:
-                pane._tabs[tab_name]["frame"].destroy()
+                pane._tabs[tab_id]["frame"].destroy()
             except TclError:
                 pass
         pane._tabs.clear()
-        del self._pane_parents[id(pane)]
+        del self._pane_parents[pane.id]
         try:
             pane.destroy()
         except TclError:
@@ -485,13 +489,13 @@ class SplitView(Frame):
         """
         from VIStk.Objects._TabManager import TabManager
 
-        parent_node = self._pane_parents.get(id(pane))
+        parent_node = self._pane_parents.get(pane.id)
         if parent_node is None:
             # This is the root — can't remove the last pane
             return
 
         sibling = parent_node.other_child(pane)
-        grandparent_node = self._pane_parents.get(id(parent_node))
+        grandparent_node = self._pane_parents.get(parent_node.id)
 
         # Determine the Tk parent for the rebuilt sibling
         if grandparent_node is None:
@@ -507,10 +511,18 @@ class SplitView(Frame):
             else:
                 grandparent_slot = 2
 
-        # Track whether the focused pane was the one being removed
-        # or lives inside the sibling subtree
+        # Track the tab_id that was focused in the focused pane so we can
+        # restore focus to the *same specific tab* after the sibling subtree
+        # is rebuilt — this is the 0.4.7 fix for multi-split focus restore
+        # with duplicate screen names (changelog.md:660).
         old_focused = self._focused_pane
         focused_was_removed = (old_focused is pane)
+        focused_tab_id: int | None = None
+        if old_focused is not None and not focused_was_removed:
+            try:
+                focused_tab_id = old_focused._active
+            except Exception:
+                focused_tab_id = None
 
         # Collect tab data from sibling subtree BEFORE destroying anything
         sibling_snapshot = self._snapshot_subtree(sibling)
@@ -542,7 +554,7 @@ class SplitView(Frame):
         if grandparent_node is None:
             self._root_widget = rebuilt
             rebuilt.pack(fill="both", expand=True)
-            self._pane_parents[id(rebuilt)] = None
+            self._pane_parents[rebuilt.id] = None
             if isinstance(rebuilt, _SplitNode):
                 self._update_parent_tracking(rebuilt, None)
         else:
@@ -553,16 +565,25 @@ class SplitView(Frame):
                 grandparent_node.slot2 = rebuilt
             # Re-add both slots to the PanedWindow in correct order
             grandparent_node.replace_child_fresh(rebuilt)
-            self._pane_parents[id(rebuilt)] = grandparent_node
+            self._pane_parents[rebuilt.id] = grandparent_node
             if isinstance(rebuilt, _SplitNode):
                 self._update_parent_tracking(rebuilt, grandparent_node)
 
-        # Restore focus
-        # The rebuilt subtree contains all surviving panes; pick the first one.
-        # Name-based matching is avoided here — that is deferred to the tab-ID
-        # refactor planned for 0.4.6.
+        # Restore focus via tab_id (0.4.7).  If the previously focused pane
+        # lived inside the surviving sibling subtree, its tab IDs were
+        # preserved across the rebuild — find whichever new pane now owns
+        # the old active tab and focus it there.  If the focused pane was
+        # the one removed (or we couldn't recover a tab_id), fall back to
+        # the first surviving pane.
         panes = self.all_tab_managers()
-        self._focused_pane = panes[0] if panes else None
+        target_pane = None
+        if focused_tab_id is not None:
+            for p in panes:
+                if focused_tab_id in p._tabs:
+                    target_pane = p
+                    p.tab_bar.focus_tab(focused_tab_id)
+                    break
+        self._focused_pane = target_pane or (panes[0] if panes else None)
 
         # Update visual focus indicators (single pane = always focused)
         self._update_focused_styles()
@@ -585,6 +606,9 @@ class SplitView(Frame):
 
     def _focus_from_click(self, event):
         """Walk up from clicked widget to find the owning pane and focus it."""
+        # Use Python's ``id(w)`` (object identity) to look up the containing
+        # TabManager as we climb the widget tree — this is a transient map,
+        # not a persistent identifier, so object identity is fine here.
         panes = {id(tm): tm for tm in self.all_tab_managers()}
         w = event.widget
         try:
@@ -629,7 +653,7 @@ class SplitView(Frame):
                 orig(name)
             # If name is None, all tabs are gone — collapse this pane
             if name is None and len(_pane._tabs) == 0:
-                parent_node = self._pane_parents.get(id(_pane))
+                parent_node = self._pane_parents.get(_pane.id)
                 if parent_node is not None:
                     # Schedule collapse to avoid modifying widget tree mid-callback
                     _pane.after_idle(lambda: self.remove_pane(_pane))
@@ -700,7 +724,7 @@ class SplitView(Frame):
         ``_skip_activate`` flag is set by ``_activate_and_focus`` which
         fires the callback itself to avoid a double-fire.
         """
-        if id(pane) not in self._pane_parents:
+        if pane.id not in self._pane_parents:
             return
         old = self._focused_pane
         if pane is old and SplitView._global_focused_pane is pane:
@@ -747,15 +771,17 @@ class SplitView(Frame):
 
         if isinstance(widget, TabManager):
             tabs = []
-            for tab_name in list(widget._tabs.keys()):
-                entry = widget._tabs[tab_name]
+            for tab_id in list(widget._tabs.keys()):
+                entry = widget._tabs[tab_id]
+                display = entry.get("display_name", "")
                 tab_data = {
-                    "name": tab_name,
-                    "module": entry.get("module"),
-                    "hooks": entry.get("hooks"),
-                    "icon": entry.get("icon"),
-                    "base_name": entry.get("base_name", tab_name),
-                    "info_str": entry.get("info", ""),
+                    "tab_id":    tab_id,
+                    "name":      display,
+                    "module":    entry.get("module"),
+                    "hooks":     entry.get("hooks"),
+                    "icon":      entry.get("icon"),
+                    "base_name": entry.get("base_name", display),
+                    "info_str":  entry.get("info", ""),
                 }
                 # Capture StringVar value if traced (can't keep the var across destroy)
                 info_trace = entry.get("_info_trace")
@@ -770,7 +796,7 @@ class SplitView(Frame):
                 "type": "leaf",
                 "tabs": tabs,
                 "is_focused": widget is self._focused_pane,
-                "active": widget._active,
+                "active_tab_id": widget._active,
             }
         elif isinstance(widget, _SplitNode):
             return {
@@ -779,11 +805,11 @@ class SplitView(Frame):
                 "slot1": self._snapshot_subtree(widget.slot1) if widget.slot1 else None,
                 "slot2": self._snapshot_subtree(widget.slot2) if widget.slot2 else None,
             }
-        return {"type": "leaf", "tabs": [], "is_focused": False, "active": None}
+        return {"type": "leaf", "tabs": [], "is_focused": False, "active_tab_id": None}
 
     def _remove_tracking(self, widget):
         """Recursively remove all _pane_parents entries for a subtree."""
-        self._pane_parents.pop(id(widget), None)
+        self._pane_parents.pop(widget.id, None)
         if isinstance(widget, _SplitNode):
             if widget.slot1 is not None:
                 self._remove_tracking(widget.slot1)
@@ -800,17 +826,25 @@ class SplitView(Frame):
         if snapshot["type"] == "leaf":
             pane = TabManager(tk_parent, position=self._tab_position)
             self._wire_pane(pane)
-            # Re-open all tabs
+            # Re-open all tabs, preserving their stable tab_id so external
+            # references survive the destroy/rebuild (fixes 0.4.7 focus
+            # restore after remove_pane).
             for tab_data in snapshot["tabs"]:
+                tab_id = tab_data.get("tab_id")
                 pane.open_tab(
                     tab_data["name"],
                     tab_data["module"],
                     hooks=tab_data.get("hooks"),
                     icon=tab_data.get("icon"),
                     base_name=tab_data.get("base_name", tab_data["name"]),
+                    tab_id=tab_id,
                 )
                 if tab_data.get("info_str"):
-                    pane.set_tab_info(tab_data["name"], tab_data["info_str"])
+                    pane.set_tab_info(tab_id, tab_data["info_str"])
+            # Restore the previously active tab within this pane
+            active_id = snapshot.get("active_tab_id")
+            if active_id is not None and active_id in pane._tabs:
+                pane.tab_bar.focus_tab(active_id)
             # Track focus
             if snapshot.get("is_focused"):
                 self._focused_pane = pane
@@ -822,13 +856,13 @@ class SplitView(Frame):
             if snapshot["slot1"] is not None:
                 child1 = self._rebuild_from_snapshot(snapshot["slot1"], node.paned)
                 node.set_slot1(child1)
-                self._pane_parents[id(child1)] = node
+                self._pane_parents[child1.id] = node
                 if isinstance(child1, _SplitNode):
                     self._update_parent_tracking(child1, node)
             if snapshot["slot2"] is not None:
                 child2 = self._rebuild_from_snapshot(snapshot["slot2"], node.paned)
                 node.set_slot2(child2)
-                self._pane_parents[id(child2)] = node
+                self._pane_parents[child2.id] = node
                 if isinstance(child2, _SplitNode):
                     self._update_parent_tracking(child2, node)
             # Set sash to 50/50
@@ -841,9 +875,9 @@ class SplitView(Frame):
         """Update _pane_parents for *widget* and its subtree."""
         from VIStk.Objects._TabManager import TabManager
         if isinstance(widget, TabManager):
-            self._pane_parents[id(widget)] = parent_node
+            self._pane_parents[widget.id] = parent_node
         elif isinstance(widget, _SplitNode):
-            self._pane_parents[id(widget)] = parent_node
+            self._pane_parents[widget.id] = parent_node
             if widget.slot1 is not None:
                 self._update_parent_tracking(widget.slot1, widget)
             if widget.slot2 is not None:
@@ -872,6 +906,9 @@ class _SplitNode(Frame):
 
     def __init__(self, parent, orient: str = "horizontal", **kwargs):
         super().__init__(parent, **kwargs)
+        from VIStk.Objects._Identity import new_id
+        self.id: int = new_id()
+        """Stable process-unique split-node ID (0.4.7)."""
         self.orient = orient
         self.paned = ttk.PanedWindow(self, orient=orient)
         self.paned.pack(fill="both", expand=True)

--- a/VIStk/Widgets/_TabBar.py
+++ b/VIStk/Widgets/_TabBar.py
@@ -26,6 +26,11 @@ _TABBAR_REGISTRY: list["TabBar"] = []
 class TabBar(Frame):
     """A row of clickable tabs displayed at the top of a ``TabManager``.
 
+    Keyed by tab ID (0.4.7): every tab opened via ``open_tab(tab_id, label,
+    ...)`` is tracked by a stable integer allocated by the owning
+    ``TabManager``.  Display labels are mutable (``update_tab_label``) and
+    may collide with labels in other bars — IDs disambiguate.
+
     During a drag a semi-transparent ghost Toplevel follows the cursor.  Tabs
     do not slide until the mouse is released.  A coloured insertion indicator
     appears in the hovered bar.  On release: reorder in the same bar / merge
@@ -37,14 +42,15 @@ class TabBar(Frame):
     Right-click: "Open in new window", "Force refresh", "Close".
 
     Attributes:
-        active            (str | None)
-        owner             (TabManager | None)  set by TabManager after init
-        on_focus_change   (callable | None)   ``(name: str | None)``
-        on_tab_close      (callable | None)   ``(name: str)``
-        on_tab_popout     (callable | None)   ``(name: str)``
-        on_tab_refresh    (callable | None)   ``(name: str)``
-        on_drag_detach    (callable | None)   ``(name: str)``
-        on_drag_merge     (callable | None)   ``(name: str, source: TabBar, idx: int)``
+        active            (int | None)            tab ID of the active tab
+        owner             (TabManager | None)     set by TabManager after init
+        on_focus_change   (callable | None)       ``(tab_id: int | None)``
+        on_tab_close      (callable | None)       ``(tab_id: int)``
+        on_tab_popout     (callable | None)       ``(tab_id: int)``
+        on_tab_refresh    (callable | None)       ``(tab_id: int)``
+        on_drag_detach    (callable | None)       ``(tab_id: int)``
+        on_drag_merge     (callable | None)       ``(tab_id: int, source: TabBar, idx: int)``
+        on_tab_split      (callable | None)       ``(tab_id: int, direction: str, pane)``
 
     After every drag ends ``_last_drag_btn_offset_x`` / ``_last_drag_btn_offset_y``
     hold the cursor's pixel offset within the dragged tab button.  External
@@ -54,9 +60,9 @@ class TabBar(Frame):
     def __init__(self, parent, position: str = "top", **kwargs):
         kwargs.setdefault("bg", _BG_BAR)
         super().__init__(parent, **kwargs)
-        self._tabs: dict[str, dict] = {}
-        """name → {"button": Button, "close": Button, "sep": Frame|None, "icon": image|None}"""
-        self.active: str | None = None
+        self._tabs: dict[int, dict] = {}
+        """tab_id -> {"label": str, "button": Button, "close": Button, "sep": Frame|None, "icon": image|None}"""
+        self.active: int | None = None
         self.owner = None               # set by TabManager
         self._position: str = position  # "top" | "bottom" | "left" | "right"
 
@@ -66,13 +72,13 @@ class TabBar(Frame):
         self.on_tab_popout   = None
         self.on_tab_refresh  = None
         self.on_drag_detach  = None
-        self.on_drag_merge   = None     # (name, source_bar, insert_idx)
-        self.on_tab_split    = None     # (name, direction)  "right" or "down"
-        self.on_drag_zone    = None     # (x_root, y_root) → (pane, direction) | None
+        self.on_drag_merge   = None     # (tab_id, source_bar, insert_idx)
+        self.on_tab_split    = None     # (tab_id, direction, pane=None)
+        self.on_drag_zone    = None     # (x_root, y_root) -> (pane, direction) | None
         self._focused: bool  = True     # visual focused state (set by set_focused_style)
 
         # Drag state
-        self._drag_name: str | None = None
+        self._drag_id: int | None = None
         self._drag_start_x: int = 0
         self._drag_start_y: int = 0
         self._drag_btn_offset_x: int = 0    # cursor x relative to tab button left
@@ -94,7 +100,7 @@ class TabBar(Frame):
         self._insert_idx: int = -1
 
         # Natural populated size, captured once and reused for the empty state
-        # so 0→1 transitions don't grow the bar by a few pixels.
+        # so 0->1 transitions don't grow the bar by a few pixels.
         self._natural_height: int = 0
         self._natural_width: int = 0
 
@@ -108,26 +114,29 @@ class TabBar(Frame):
         return self._position in ("left", "right")
 
     def set_position(self, position: str):
-        """Change tab bar orientation and rebuild tab packing."""
+        """Change tab bar position. Called by TabManager when layout changes."""
         self._position = position
-        if self._tabs:
-            self._rebuild_packing(list(self._tabs.keys()))
+        # Repack all tabs under the new orientation
+        ids = list(self._tabs.keys())
+        self._rebuild_packing(ids)
         self._update_empty_state()
 
     # ── Public API ─────────────────────────────────────────────────────────────
 
-    def open_tab(self, name: str, icon=None, insert_idx: int = -1) -> bool:
-        """Add a tab for *name*.  Does nothing if it already exists.
+    def open_tab(self, tab_id: int, label: str, icon=None,
+                 insert_idx: int = -1) -> bool:
+        """Add a tab button identified by *tab_id* with text *label*.
 
         Args:
-            name:       Label shown on the tab button.
+            tab_id:     Stable integer ID allocated by the owning TabManager.
+            label:      Text shown on the tab button.
             icon:       Optional ``PIL.ImageTk.PhotoImage`` shown left of label.
             insert_idx: 0-based position to insert at; -1 appends.
 
         Returns:
-            ``True`` if a new tab was created, ``False`` if already existed.
+            ``True`` if a new tab was created, ``False`` if *tab_id* already existed.
         """
-        if name in self._tabs:
+        if tab_id in self._tabs:
             return False
 
         sep = None
@@ -141,7 +150,7 @@ class TabBar(Frame):
 
         btn = Button(
             self,
-            text=name,
+            text=label,
             image=icon,
             compound="left" if icon else "none",
             relief="flat",
@@ -150,17 +159,17 @@ class TabBar(Frame):
             takefocus=0,
             bg=_BG_INACTIVE,
             activebackground=_BG_HOVER_TAB,
-            command=lambda n=name: self._btn_click(n),
+            command=lambda i=tab_id: self._btn_click(i),
         )
         if self._is_vertical():
             btn.pack(side="top", fill="x", padx=2, pady=(4, 0))
         else:
             btn.pack(side="left", padx=(4, 0), pady=2)
 
-        btn.bind("<ButtonPress-1>",   lambda e, n=name: self._on_drag_start(e, n))
-        btn.bind("<B1-Motion>",       lambda e, n=name: self._on_drag_motion(e, n))
+        btn.bind("<ButtonPress-1>",   lambda e, i=tab_id: self._on_drag_start(e, i))
+        btn.bind("<B1-Motion>",       lambda e, i=tab_id: self._on_drag_motion(e, i))
         btn.bind("<ButtonRelease-1>", lambda e: self._on_drag_release(e))
-        btn.bind("<Button-3>",        lambda e, n=name: self._on_right_click(e, n))
+        btn.bind("<Button-3>",        lambda e, i=tab_id: self._on_right_click(e, i))
 
         close_btn = Button(
             self,
@@ -172,31 +181,34 @@ class TabBar(Frame):
             width=2,
             bg=_BG_INACTIVE,
             activebackground=_BG_HOVER_CLOSE,
-            command=lambda n=name: self._close(n),
+            command=lambda i=tab_id: self._close(i),
         )
         if self._is_vertical():
             close_btn.pack(side="top", fill="x", padx=2, pady=(0, 4))
         else:
             close_btn.pack(side="left", padx=(0, 4), pady=2)
 
-        btn.bind("<Enter>",       lambda e, n=name: self._on_tab_enter(n))
-        btn.bind("<Leave>",       lambda e, n=name: self._on_tab_leave(n))
-        close_btn.bind("<Enter>", lambda e, n=name: self._on_close_enter(n))
-        close_btn.bind("<Leave>", lambda e, n=name: self._on_close_leave(n))
+        btn.bind("<Enter>",       lambda e, i=tab_id: self._on_tab_enter(i))
+        btn.bind("<Leave>",       lambda e, i=tab_id: self._on_tab_leave(i))
+        close_btn.bind("<Enter>", lambda e, i=tab_id: self._on_close_enter(i))
+        close_btn.bind("<Leave>", lambda e, i=tab_id: self._on_close_leave(i))
 
-        self._tabs[name] = {"button": btn, "close": close_btn, "sep": sep, "icon": icon}
-        self.focus_tab(name)
+        self._tabs[tab_id] = {
+            "label": label, "button": btn, "close": close_btn,
+            "sep": sep, "icon": icon,
+        }
+        self.focus_tab(tab_id)
 
         if insert_idx >= 0:
-            names = list(self._tabs.keys())
-            if name in names and len(names) > 1:
-                self._reorder_to_idx(name, insert_idx)
+            ids = list(self._tabs.keys())
+            if tab_id in ids and len(ids) > 1:
+                self._reorder_to_idx(tab_id, insert_idx)
 
         self._update_empty_state()
         return True
 
-    def close_tab(self, name: str) -> bool:
-        """Remove the tab for *name*.
+    def close_tab(self, tab_id: int) -> bool:
+        """Remove the tab identified by *tab_id*.
 
         If the first tab is closed, the new first tab's orphaned separator is
         also removed.
@@ -204,25 +216,25 @@ class TabBar(Frame):
         Returns:
             ``True`` if removed, ``False`` if not found.
         """
-        if name not in self._tabs:
+        if tab_id not in self._tabs:
             return False
 
-        tab_names = list(self._tabs.keys())
-        tab_idx   = tab_names.index(name)
+        ids = list(self._tabs.keys())
+        tab_idx = ids.index(tab_id)
 
-        if self._tabs[name]["sep"]:
-            self._tabs[name]["sep"].destroy()
-        self._tabs[name]["button"].destroy()
-        self._tabs[name]["close"].destroy()
-        del self._tabs[name]
+        if self._tabs[tab_id]["sep"]:
+            self._tabs[tab_id]["sep"].destroy()
+        self._tabs[tab_id]["button"].destroy()
+        self._tabs[tab_id]["close"].destroy()
+        del self._tabs[tab_id]
 
         if tab_idx == 0 and self._tabs:
-            new_first = list(self._tabs.keys())[0]
+            new_first = next(iter(self._tabs))
             if self._tabs[new_first]["sep"]:
                 self._tabs[new_first]["sep"].destroy()
                 self._tabs[new_first]["sep"] = None
 
-        if self.active == name:
+        if self.active == tab_id:
             self.active = None
             remaining = list(self._tabs.keys())
             if remaining:
@@ -233,29 +245,35 @@ class TabBar(Frame):
         self._update_empty_state()
         return True
 
-    def focus_tab(self, name: str) -> bool:
-        """Set *name* as the active tab and invoke ``on_focus_change``."""
-        if name not in self._tabs:
+    def focus_tab(self, tab_id: int) -> bool:
+        """Set *tab_id* as the active tab and invoke ``on_focus_change``."""
+        if tab_id not in self._tabs:
             return False
-        self.active = name
+        self.active = tab_id
         self._update_styles()
         if self.on_focus_change:
-            self.on_focus_change(name)
+            self.on_focus_change(tab_id)
         return True
 
-    def has_tab(self, name: str) -> bool:
-        """Return whether a tab with *name* is currently open."""
-        return name in self._tabs
+    def has_tab(self, tab_id: int) -> bool:
+        """Return whether a tab with *tab_id* is currently open."""
+        return tab_id in self._tabs
 
-    def get_tab_idx(self, name: str) -> int:
-        """Return the 0-based position of *name*, or -1 if not present."""
-        names = list(self._tabs.keys())
-        return names.index(name) if name in names else -1
+    def get_tab_idx(self, tab_id: int) -> int:
+        """Return the 0-based position of *tab_id*, or -1 if not present."""
+        ids = list(self._tabs.keys())
+        return ids.index(tab_id) if tab_id in ids else -1
 
-    def update_tab_label(self, name: str, display: str):
-        """Update the displayed text of tab *name*'s button."""
-        if name in self._tabs:
-            self._tabs[name]["button"].config(text=display)
+    def get_tab_label(self, tab_id: int) -> str | None:
+        """Return the current display label of *tab_id*, or None."""
+        entry = self._tabs.get(tab_id)
+        return entry.get("label") if entry else None
+
+    def update_tab_label(self, tab_id: int, label: str):
+        """Update the displayed text of *tab_id*'s button."""
+        if tab_id in self._tabs:
+            self._tabs[tab_id]["label"] = label
+            self._tabs[tab_id]["button"].config(text=label)
 
     def set_focused_style(self, focused: bool):
         """Toggle the visual focused/unfocused state of the bar.
@@ -270,15 +288,15 @@ class TabBar(Frame):
         self.configure(bg=bg)
         inactive_bg = _BG_INACTIVE if focused else _BG_UNFOCUSED
         active_bg = _BG_ACTIVE if focused else _BG_ACTIVE_UNFOC
-        for name, entry in self._tabs.items():
-            if name == self.active:
+        for tab_id, entry in self._tabs.items():
+            if tab_id == self.active:
                 entry["button"].configure(bg=active_bg)
                 entry["close"].configure(bg=active_bg)
             else:
                 entry["button"].configure(bg=inactive_bg)
                 entry["close"].configure(bg=inactive_bg)
 
-    def set_insert_indicator(self, idx: int, drag_name: str = None):
+    def set_insert_indicator(self, idx: int, drag_id: int | None = None):
         """Show the insertion indicator for a drop at position *idx*."""
         if not self._tabs:
             # Empty bar — expand highlight and show horizontal indicator at bottom
@@ -290,7 +308,7 @@ class TabBar(Frame):
             self._insert_indicator.place(x=0, y=h - 3, width=w, height=3)
             self._insert_indicator.lift()
         else:
-            x = self._get_insert_x(idx, drag_name)
+            x = self._get_insert_x(idx, drag_id)
             h = self.winfo_height() or 24
             if self._insert_indicator is None:
                 self._insert_indicator = Frame(self, width=3, bg=_INDICATOR_COLOR)
@@ -348,43 +366,45 @@ class TabBar(Frame):
 
     # ── Right-click context menu ───────────────────────────────────────────────
 
-    def _on_right_click(self, event, name: str):
+    def _on_right_click(self, event, tab_id: int):
         menu = Menu(self, tearoff=0)
         menu.add_command(label="Open in new window",
-                         command=lambda: self._do_popout(name))
+                         command=lambda: self._do_popout(tab_id))
         menu.add_command(label="Split right",
-                         command=lambda: self._do_split(name, "right"))
+                         command=lambda: self._do_split(tab_id, "right"))
         menu.add_command(label="Split down",
-                         command=lambda: self._do_split(name, "down"))
+                         command=lambda: self._do_split(tab_id, "down"))
         menu.add_command(label="Force refresh",
-                         command=lambda: self._do_refresh(name))
+                         command=lambda: self._do_refresh(tab_id))
         menu.add_separator()
         menu.add_command(label="Close",
-                         command=lambda: self._close(name))
+                         command=lambda: self._close(tab_id))
         try:
             menu.tk_popup(event.x_root, event.y_root)
         finally:
             menu.grab_release()
 
-    def _do_popout(self, name: str):
+    def _do_popout(self, tab_id: int):
         if self.on_tab_popout:
-            self.on_tab_popout(name)
+            self.on_tab_popout(tab_id)
 
-    def _do_split(self, name: str, direction: str):
+    def _do_split(self, tab_id: int, direction: str):
         if self.on_tab_split:
-            self.on_tab_split(name, direction)
+            self.on_tab_split(tab_id, direction)
 
-    def _do_refresh(self, name: str):
+    def _do_refresh(self, tab_id: int):
         if self.on_tab_refresh:
-            self.on_tab_refresh(name)
+            self.on_tab_refresh(tab_id)
 
     # ── Ghost window helpers ───────────────────────────────────────────────────
 
-    def _create_ghost(self, name: str, x: int, y: int):
+    def _create_ghost(self, tab_id: int, x: int, y: int):
         """Create the semi-transparent drag ghost positioned at cursor."""
         if self._ghost is not None:
             return
-        icon = self._tabs[name].get("icon")
+        entry = self._tabs.get(tab_id, {})
+        icon = entry.get("icon")
+        label = entry.get("label", "")
         ghost = Toplevel()
         ghost.overrideredirect(True)
         ghost.attributes("-alpha", 0.75)
@@ -392,7 +412,7 @@ class TabBar(Frame):
         ghost.configure(bg=_BG_ACTIVE)
         lbl = Label(
             ghost,
-            text=name,
+            text=label,
             image=icon,
             compound="left" if icon else "none",
             bg=_BG_ACTIVE,
@@ -406,9 +426,9 @@ class TabBar(Frame):
         ghost.geometry(f"+{x - self._drag_btn_offset_x}+{y - self._drag_btn_offset_y}")
         self._ghost = ghost
         # Dim the dragged tab while ghost is live
-        if name in self._tabs:
-            self._tabs[name]["button"].config(bg="grey45")
-            self._tabs[name]["close"].config(bg="grey45")
+        if tab_id in self._tabs:
+            self._tabs[tab_id]["button"].config(bg="grey45")
+            self._tabs[tab_id]["close"].config(bg="grey45")
 
     def _update_ghost(self, x: int, y: int):
         if self._ghost is None:
@@ -420,53 +440,53 @@ class TabBar(Frame):
         except TclError:
             pass
 
-    def _destroy_ghost(self, name: str | None = None):
+    def _destroy_ghost(self, tab_id: int | None = None):
         if self._ghost is not None:
             try:
                 self._ghost.destroy()
             except TclError:
                 pass
             self._ghost = None
-        n = name or self._drag_name
-        if n and n in self._tabs:
+        n = tab_id if tab_id is not None else self._drag_id
+        if n is not None and n in self._tabs:
             bg = self._tab_bg(n)
             self._tabs[n]["button"].config(bg=bg)
             self._tabs[n]["close"].config(bg=bg)
 
     # ── Insertion indicator helpers ────────────────────────────────────────────
 
-    def _get_insert_idx_at(self, x_root: int, drag_name: str = None) -> int:
+    def _get_insert_idx_at(self, x_root: int, drag_id: int | None = None) -> int:
         """Return the insertion index for a drop at screen x *x_root*."""
-        names = [n for n in self._tabs.keys() if n != drag_name]
-        for i, name in enumerate(names):
+        ids = [i for i in self._tabs.keys() if i != drag_id]
+        for i, tid in enumerate(ids):
             try:
-                bx = self._tabs[name]["button"].winfo_rootx()
-                bw = self._tabs[name]["button"].winfo_width()
+                bx = self._tabs[tid]["button"].winfo_rootx()
+                bw = self._tabs[tid]["button"].winfo_width()
             except TclError:
                 continue
             if x_root < bx + bw // 2:
                 return i
-        return len(names)
+        return len(ids)
 
-    def _get_insert_x(self, idx: int, drag_name: str = None) -> int:
+    def _get_insert_x(self, idx: int, drag_id: int | None = None) -> int:
         """Return the bar-relative x where the vertical indicator should appear."""
-        names = [n for n in self._tabs.keys() if n != drag_name]
-        if not names:
+        ids = [i for i in self._tabs.keys() if i != drag_id]
+        if not ids:
             return 0
         if idx <= 0:
             try:
-                return self._tabs[names[0]]["button"].winfo_x()
+                return self._tabs[ids[0]]["button"].winfo_x()
             except TclError:
                 return 0
-        if idx >= len(names):
+        if idx >= len(ids):
             try:
-                c = self._tabs[names[-1]]["close"]
+                c = self._tabs[ids[-1]]["close"]
                 return c.winfo_x() + c.winfo_width() + 2
             except TclError:
                 return max(0, self.winfo_width() - 4)
         try:
-            prev_c = self._tabs[names[idx - 1]]["close"]
-            cur_b  = self._tabs[names[idx]]["button"]
+            prev_c = self._tabs[ids[idx - 1]]["close"]
+            cur_b  = self._tabs[ids[idx]]["button"]
             px = prev_c.winfo_x() + prev_c.winfo_width()
             cx = cur_b.winfo_x()
             return (px + cx) // 2
@@ -475,14 +495,14 @@ class TabBar(Frame):
 
     # ── Drag-to-reorder / detach / merge ──────────────────────────────────────
 
-    def _on_drag_start(self, event, name: str):
-        self._drag_name    = name
+    def _on_drag_start(self, event, tab_id: int):
+        self._drag_id     = tab_id
         self._drag_start_x = event.x_root
         self._drag_start_y = event.y_root
         self._drag_active  = False
         # Cursor offset within the tab button — persisted so Host can read after drag ends
         try:
-            btn = self._tabs[name]["button"]
+            btn = self._tabs[tab_id]["button"]
             self._drag_btn_offset_x = event.x_root - btn.winfo_rootx()
             self._drag_btn_offset_y = event.y_root - btn.winfo_rooty()
         except TclError:
@@ -496,8 +516,8 @@ class TabBar(Frame):
         self._insert_bar = None
         self._insert_idx = -1
 
-    def _on_drag_motion(self, event, name: str):
-        if not self._drag_name:
+    def _on_drag_motion(self, event, tab_id: int):
+        if self._drag_id is None:
             return
 
         dx = abs(event.x_root - self._drag_start_x)
@@ -510,7 +530,7 @@ class TabBar(Frame):
 
         # Create ghost on first motion past threshold
         if self._ghost is None:
-            self._create_ghost(name, event.x_root, event.y_root)
+            self._create_ghost(tab_id, event.x_root, event.y_root)
         else:
             self._update_ghost(event.x_root, event.y_root)
 
@@ -530,7 +550,7 @@ class TabBar(Frame):
                 break
 
         if target_bar is not None:
-            drag = self._drag_name if target_bar is self else None
+            drag = self._drag_id if target_bar is self else None
             idx  = target_bar._get_insert_idx_at(x, drag)
             if self._insert_bar is not None and self._insert_bar is not target_bar:
                 self._insert_bar.clear_insert_indicator()
@@ -550,47 +570,47 @@ class TabBar(Frame):
                 self.on_drag_zone("check", x, y)
 
     def _on_drag_release(self, event):
-        drag_name  = self._drag_name
+        drag_id    = self._drag_id
         insert_bar = self._insert_bar
         insert_idx = self._insert_idx
 
-        self._drag_name  = None
+        self._drag_id    = None
         self._insert_bar = None
         self._insert_idx = -1
 
         if insert_bar is not None:
             insert_bar.clear_insert_indicator()
 
-        if not self._drag_active or drag_name is None:
-            self._destroy_ghost(drag_name)
+        if not self._drag_active or drag_id is None:
+            self._destroy_ghost(drag_id)
             if self.on_drag_zone:
                 self.on_drag_zone("hide", 0, 0)
             return
 
         if insert_bar is self:
-            self._destroy_ghost(drag_name)
-            self._reorder_to_idx(drag_name, insert_idx)
+            self._destroy_ghost(drag_id)
+            self._reorder_to_idx(drag_id, insert_idx)
         elif insert_bar is not None:
-            self._destroy_ghost(drag_name)
+            self._destroy_ghost(drag_id)
             if insert_bar.on_drag_merge:
-                insert_bar.on_drag_merge(drag_name, self, insert_idx)
+                insert_bar.on_drag_merge(drag_id, self, insert_idx)
         else:
             # Check if dropping on a split zone
             drop_info = None
             if self.on_drag_zone:
                 drop_info = self.on_drag_zone("drop", event.x_root, event.y_root)
             if drop_info is not None:
-                self._destroy_ghost(drag_name)
+                self._destroy_ghost(drag_id)
                 pane, direction = drop_info
                 if self.on_tab_split:
-                    self.on_tab_split(drag_name, direction, pane)
+                    self.on_tab_split(drag_id, direction, pane)
             else:
                 # Transfer ghost ownership — keep alive while DetachedWindow is created
                 # and positioned, so the user sees no gap between ghost and window.
                 ghost = self._ghost
                 self._ghost = None
                 if self.on_drag_detach:
-                    self.on_drag_detach(drag_name)
+                    self.on_drag_detach(drag_id)
                 if ghost is not None:
                     try:
                         ghost.destroy()
@@ -603,17 +623,17 @@ class TabBar(Frame):
         if insert_bar is not self:
             self._drag_active = False
 
-    def _reorder_to_idx(self, dragged: str, idx: int):
+    def _reorder_to_idx(self, dragged: int, idx: int):
         """Move *dragged* to 0-based position *idx* (in the without-dragged space)."""
-        names = list(self._tabs.keys())
-        if dragged not in names:
+        ids = list(self._tabs.keys())
+        if dragged not in ids:
             return
-        names.remove(dragged)
-        idx = max(0, min(idx, len(names)))
-        names.insert(idx, dragged)
-        self._rebuild_packing(names)
+        ids.remove(dragged)
+        idx = max(0, min(idx, len(ids)))
+        ids.insert(idx, dragged)
+        self._rebuild_packing(ids)
 
-    def _rebuild_packing(self, new_order: list[str]):
+    def _rebuild_packing(self, new_order: list[int]):
         """Repack all tab widgets in *new_order*, rebuilding separators."""
         for w in self._tabs.values():
             if w["sep"]:
@@ -621,9 +641,9 @@ class TabBar(Frame):
             w["button"].pack_forget()
             w["close"].pack_forget()
 
-        new_tabs: dict[str, dict] = {}
-        for i, name in enumerate(new_order):
-            w = self._tabs[name]
+        new_tabs: dict[int, dict] = {}
+        for i, tab_id in enumerate(new_order):
+            w = self._tabs[tab_id]
             if i == 0:
                 if w["sep"]:
                     w["sep"].destroy()
@@ -644,53 +664,53 @@ class TabBar(Frame):
             else:
                 w["button"].pack(side="left", padx=(4, 0), pady=2)
                 w["close"].pack(side="left", padx=(0, 4), pady=2)
-            new_tabs[name] = w
+            new_tabs[tab_id] = w
         self._tabs = new_tabs
 
     # ── Internal ───────────────────────────────────────────────────────────────
 
-    def _btn_click(self, name: str):
+    def _btn_click(self, tab_id: int):
         """Focus the tab only when the press was a genuine click (not a drag)."""
         was_drag = self._drag_active
         self._drag_active = False
         if not was_drag:
-            self.focus_tab(name)
+            self.focus_tab(tab_id)
 
-    def _tab_bg(self, name: str) -> str:
-        if name == self.active:
+    def _tab_bg(self, tab_id: int) -> str:
+        if tab_id == self.active:
             return _BG_ACTIVE if self._focused else _BG_ACTIVE_UNFOC
         return _BG_INACTIVE if self._focused else _BG_UNFOCUSED
 
-    def _close(self, name: str):
+    def _close(self, tab_id: int):
         if self.on_tab_close:
-            self.on_tab_close(name)
+            self.on_tab_close(tab_id)
         else:
-            self.close_tab(name)
+            self.close_tab(tab_id)
 
-    def _on_tab_enter(self, name: str):
-        if name not in self._tabs:
+    def _on_tab_enter(self, tab_id: int):
+        if tab_id not in self._tabs:
             return
         # Always highlight inactive tabs; highlight active tab only in unfocused panes
-        if name != self.active or not self._focused:
-            self._tabs[name]["button"].config(bg=_BG_HOVER_TAB)
-            self._tabs[name]["close"].config(bg=_BG_HOVER_TAB)
+        if tab_id != self.active or not self._focused:
+            self._tabs[tab_id]["button"].config(bg=_BG_HOVER_TAB)
+            self._tabs[tab_id]["close"].config(bg=_BG_HOVER_TAB)
 
-    def _on_tab_leave(self, name: str):
-        if name in self._tabs:
-            bg = self._tab_bg(name)
-            self._tabs[name]["button"].config(bg=bg)
-            self._tabs[name]["close"].config(bg=bg)
+    def _on_tab_leave(self, tab_id: int):
+        if tab_id in self._tabs:
+            bg = self._tab_bg(tab_id)
+            self._tabs[tab_id]["button"].config(bg=bg)
+            self._tabs[tab_id]["close"].config(bg=bg)
 
-    def _on_close_enter(self, name: str):
-        if name in self._tabs:
-            self._tabs[name]["close"].config(bg=_BG_HOVER_CLOSE)
+    def _on_close_enter(self, tab_id: int):
+        if tab_id in self._tabs:
+            self._tabs[tab_id]["close"].config(bg=_BG_HOVER_CLOSE)
 
-    def _on_close_leave(self, name: str):
-        if name in self._tabs:
-            self._tabs[name]["close"].config(bg=self._tab_bg(name))
+    def _on_close_leave(self, tab_id: int):
+        if tab_id in self._tabs:
+            self._tabs[tab_id]["close"].config(bg=self._tab_bg(tab_id))
 
     def _update_styles(self):
-        for name, widgets in self._tabs.items():
-            bg = self._tab_bg(name)
+        for tab_id, widgets in self._tabs.items():
+            bg = self._tab_bg(tab_id)
             widgets["button"].config(relief="flat", bg=bg)
             widgets["close"].config(relief="flat", bg=bg)

--- a/changelog.md
+++ b/changelog.md
@@ -652,12 +652,86 @@ The License/EULA page, `\r` quiet-mode progress bar, and
 
 ### 0.4.7 Tab Identity Refactor
 
-**Per-instance tab IDs**
+*Released.*
 
-- Every tab opened by `TabManager.open_tab` is assigned a unique ID (UUID or integer) at creation time
-- All internal operations (close, focus restore, merge, popout, IPC `__VIS_CLOSE__`) reference the ID rather than the display name
-- Display names remain mutable and non-unique; IDs are stable for the lifetime of the tab
-- Fixes focus restoration after `SplitView.remove_pane` in multi-split layouts with duplicate screen names
+**Identity module**
+
+- New `VIStk/Objects/_Identity.py` provides `new_id()`, a monotonic
+  integer allocator used for every tab, pane, and window.
+- IDs are process-unique but **not** persisted across runs; persistence
+  (for features like "remember open tabs on restart") is out of scope.
+
+**Tab IDs**
+
+- `TabManager.open_tab(name, ...)` now returns the new `tab_id: int`
+  (was `bool`) — hold this to address a specific instance.
+- `TabManager._tabs` is keyed by `tab_id` (was the display label); each
+  entry carries its own `display_name`, `base_name`, and `tab_id`.
+- `TabManager` public methods (`close_tab`, `focus_tab`, `has_tab`,
+  `force_refresh_tab`, `set_tab_info`) accept **either** a `tab_id`
+  (`int`) or a display label (`str`). Label lookups are
+  non-deterministic when duplicates exist.
+- `TabManager.active` is now `int | None` (was `str | None`); use the
+  new `TabManager.display_name(tab_id)` helper to resolve back to a
+  label.
+- `TabManager` ⇄ Host callbacks now pass `tab_id` instead of the
+  display name: `on_tab_activate(tab_id, module)`,
+  `on_tab_deactivate(tab_id | None)`, `on_tab_popout(tab_id)`,
+  `on_tab_detach(tab_id)`, `on_tab_refresh(tab_id)`,
+  `on_tab_info_change(tab_id, info)`,
+  `on_tab_split(tab_id, direction, target_pane)`.
+- `TabBar._tabs` is keyed by `tab_id` with the label stored in
+  `entry["label"]`; `update_tab_label(tab_id, new_label)` replaces it.
+
+**Pane and window IDs**
+
+- `TabManager` gains `self.id: int` at construction.
+- `_SplitNode` gains `self.id: int` so `SplitView._pane_parents` is now
+  keyed by `.id` instead of Python's `id(...)` — stable across the
+  object's lifetime, no risk of address reuse collisions.
+- `DetachedWindow` gains `self.id: int` (currently used only for
+  debug/logging; no lookups yet).
+
+**`SplitView.remove_pane` focus restore — the bug fix**
+
+- Before removing a pane, the SplitView records which `tab_id` was
+  focused in the surviving pane subtree.
+- `_snapshot_subtree` / `_rebuild_from_snapshot` preserve each tab's
+  `tab_id` across destroy-and-rebuild by passing the original ID
+  through the new `TabManager.open_tab(..., tab_id=...)` kwarg.
+- After the rebuild the SplitView finds the new pane that now owns the
+  recorded `tab_id` and restores focus there. Previously focus fell
+  back to the first pane in left-to-right order, which failed when
+  multiple panes held tabs with the same base name.
+- `SplitView.find_pane_for_tab(tab_id)` replaces the former
+  name-based helper.
+
+**`Host`**
+
+- `_find_tab_by_base(base_name)` now returns `(tm, tab_id)` instead of
+  `(tm, display_name)`.
+- `_get_all_tab_names` → `_get_all_tab_labels` (collects labels for
+  `_unique_display_name` only; internal tracking uses IDs).
+- `_open_counts` retired — tab IDs make multi-instance tracking
+  trivial; label collisions stay a UX concern only.
+- `Screen.close()` routes through the new ID-based
+  `close_tab(tab_id)`.
+
+**IPC**
+
+- The original 0.4.7 scope mentioned `__VIS_CLOSE__` IPC. IPC is not
+  being reintroduced — in-process `_HOST_INSTANCE` singleton stays the
+  only navigation path. If IPC ever comes back it will use IDs
+  natively.
+
+**Out of scope**
+
+- UUIDs for cross-process persistence — deferred to 0.6.X application
+  settings when "remember open tabs" lands.
+- Deregistering stale TabManager references from
+  `Host.registered_tab_managers` / `DetachedWindow.tab_managers` after
+  `remove_pane` — pre-existing bookkeeping leak, not part of this
+  refactor.
 
 ---
 

--- a/docs/source/changelog/0.4.7.rst
+++ b/docs/source/changelog/0.4.7.rst
@@ -1,0 +1,135 @@
+0.4.7 --- Tab Identity Refactor
+===============================
+
+*Released --- current version*
+
+Every tab, pane, and window now carries a stable integer ID allocated at
+creation time from a single process-wide counter. Internal operations
+that previously looked up tabs by display label now key off ``tab_id``,
+so multi-split layouts with duplicate screen names no longer confuse
+focus restoration, merge, or refresh.
+
+Identity Module
+---------------
+
+- New ``VIStk.Objects._Identity.new_id()`` returns a fresh,
+  strictly-increasing ``int``; thread-safe.
+- IDs are unique for the lifetime of the Python process but **not**
+  persisted across runs. Persistence (for "remember open tabs") will use
+  UUIDs when it lands in 0.6.X settings.
+
+Tab IDs
+-------
+
+- ``TabManager.open_tab(name, module, ...)`` now returns the new
+  ``tab_id: int`` (was ``bool``). Hold the ID to address a specific
+  tab instance.
+- ``TabManager._tabs`` is keyed by ``tab_id`` (was the display label).
+  Each entry carries its own ``display_name``, ``base_name``, and
+  ``tab_id``.
+- Public methods — ``close_tab``, ``focus_tab``, ``has_tab``,
+  ``force_refresh_tab``, ``set_tab_info`` — accept **either** a
+  ``tab_id`` (``int``) or a display label (``str``). Label lookups
+  return the first match; prefer the ``tab_id`` returned by
+  ``open_tab``.
+- ``TabManager.active`` is now ``int | None`` (was ``str | None``). Use
+  ``TabManager.display_name(tab_id)`` to resolve back to a label.
+- Callbacks now pass ``tab_id`` first::
+
+      manager.on_tab_activate    = lambda tab_id, module: ...
+      manager.on_tab_deactivate  = lambda tab_id | None: ...
+      manager.on_tab_popout      = lambda tab_id: ...
+      manager.on_tab_detach      = lambda tab_id: ...
+      manager.on_tab_refresh     = lambda tab_id: ...
+      manager.on_tab_info_change = lambda tab_id, info: ...
+      manager.on_tab_split       = lambda tab_id, direction, pane: ...
+
+- ``TabBar._tabs`` is keyed by ``tab_id`` with the label in
+  ``entry["label"]``. ``TabBar.update_tab_label(tab_id, new_label)``
+  replaces it.
+
+Pane and Window IDs
+-------------------
+
+- ``TabManager`` gains ``self.id: int``.
+- ``_SplitNode`` gains ``self.id: int``; ``SplitView._pane_parents``
+  is now keyed by ``.id`` rather than ``id(object)``, avoiding any
+  theoretical memory-address reuse collisions.
+- ``DetachedWindow`` gains ``self.id: int`` (attribute only — no
+  lookups are keyed off it yet; future "remember open windows" will
+  consume it).
+
+``SplitView.remove_pane`` --- Focus Restore Fix
+-----------------------------------------------
+
+This is the primary bug fix for 0.4.7.
+
+Previously, when a pane was removed the SplitView rebuilt the surviving
+subtree under a fresh Tk parent (because ``ttk.PanedWindow`` requires
+direct Tk children). After the rebuild, focus fell back to
+``panes[0]`` — the first pane in left-to-right order. In multi-split
+layouts where multiple panes contained tabs with the same base name
+(for example two ``Dashboard`` tabs), the user's focused pane could be
+silently lost.
+
+Now:
+
+- Before destroying the old subtree, the SplitView records the
+  ``tab_id`` of the currently active tab inside the surviving pane.
+- ``_snapshot_subtree`` captures each tab's ``tab_id`` alongside its
+  module, hooks, icon and info.
+- ``_rebuild_from_snapshot`` passes ``tab_id=...`` to
+  ``TabManager.open_tab``, so the reopened tabs keep their identities.
+- After rebuild, the SplitView finds whichever new pane now owns the
+  recorded ``tab_id`` and restores focus there. If the focused pane
+  was the one removed (or the ID could not be recovered), it falls
+  back to the first surviving pane as before.
+
+``SplitView.find_pane_for_tab(tab_id)`` replaces the former name-based
+lookup.
+
+Host
+----
+
+- ``_find_tab_by_base(base_name)`` now returns ``(tab_manager, tab_id)``
+  instead of ``(tab_manager, display_name)``.
+- ``_get_all_tab_names`` is renamed ``_get_all_tab_labels``; it still
+  collects display labels for ``_unique_display_name`` only.
+- ``_open_counts`` is retired — tab IDs make multi-instance tracking
+  trivial, label uniqueness is purely a UX concern handled by
+  ``_unique_display_name``.
+- ``Screen.close()`` routes through the ID-based
+  ``close_tab(tab_id)``.
+
+IPC
+---
+
+IPC is **not** being reintroduced. The draft 0.4.7 spec in the
+changelog mentioned ``__VIS_CLOSE__`` but the in-process
+``_HOST_INSTANCE`` singleton remains the sole navigation path. If IPC
+is added later it will use tab IDs natively.
+
+Backward Compatibility
+----------------------
+
+- ``TabManager`` public methods still accept display labels (``str``)
+  as the ``key`` argument, so existing screen code calling
+  ``tm.close_tab("Work Orders")`` continues to work. Prefer holding
+  the ``tab_id`` returned by ``open_tab`` for deterministic lookup in
+  the presence of duplicates.
+- The ``TabManager.open_tab`` return type changed from ``bool`` to
+  ``int | None``. Falsy ``None`` still indicates failure (tab already
+  exists); non-``None`` truthy ``int`` still indicates success — the
+  ``if tm.open_tab(...):`` idiom keeps working.
+- ``TabManager.active`` is now ``int | None``. Code comparing
+  ``tm.active == "ScreenName"`` will need to call
+  ``tm.display_name(tm.active)`` for the label.
+
+Out of Scope
+------------
+
+- Persistent (UUID / cross-process) IDs — deferred to 0.6.X.
+- Deregistering stale ``TabManager`` references from
+  ``Host.registered_tab_managers`` and ``DetachedWindow.tab_managers``
+  after ``remove_pane`` — pre-existing bookkeeping leak, orthogonal to
+  this refactor.

--- a/docs/source/changelog/index.rst
+++ b/docs/source/changelog/index.rst
@@ -13,6 +13,9 @@ Released
    * - Version
      - Title
      - Highlights
+   * - :doc:`0.4.7`
+     - Tab Identity Refactor
+     - Every tab, pane, and window gets a stable integer ID; fixes focus restoration after ``SplitView.remove_pane`` with duplicate screen names
    * - :doc:`0.4.6`
      - Screen Groups & Partial Installs
      - Installer groups with expand/collapse, per-screen dependencies, ``--Groups``/``--Screens`` release, runtime missing-screen banner
@@ -68,6 +71,7 @@ Upcoming
    :maxdepth: 1
    :hidden:
 
+   0.4.7
    0.4.6
    0.4.4
    0.4.3

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -112,6 +112,24 @@ compiles them to native binaries, bundles required assets (``Icons``, ``Images``
    * - ``-Note``
      - ``-n``
      - Release note (informational)
+   * - ``-Groups``
+     - ``-g``
+     - Comma-separated group names (from ``release_info.groups``). Build an
+       installer containing only the union of the listed groups' members.
+   * - ``-Screens``
+     -
+     - Comma-separated screen names. Build an installer containing only the
+       listed screens. May be combined with ``-Groups``; the Host is always
+       included. Excluded screens are pruned from the archived
+       ``project.json`` and empty groups are dropped.
+
+Examples:
+
+.. code-block:: text
+
+   VIS release -Groups Core
+   VIS release -Screens WorderEditor,FloorView
+   VIS release -Groups Core -Screens DashboardA
 
 Release a single screen
 -----------------------
@@ -209,6 +227,17 @@ Directly sets any attribute in a screen's ``project.json`` entry.
    * - ``current``
      - string / none
      - ``none`` or ``null`` clears the value
+   * - ``requires``
+     - list
+     - Comma-separated screen names that must be installed alongside this
+       one. Use ``none`` / ``null`` / ``""`` / ``[]`` to clear.
+   * - ``suggests``
+     - list
+     - Comma-separated screen names recommended alongside this one.
+   * - ``warn_message``
+     - string / none
+     - Custom message shown by the installer's dependency dialog and by the
+       runtime missing-screen banner.
 
 Examples:
 
@@ -217,6 +246,64 @@ Examples:
    VIS edit WorkOrders single_instance true
    VIS edit Dashboard tabbed false
    VIS edit Settings version 2.0.0
+   VIS edit Dashboard requires "WorkOrders,TimeClock"
+   VIS edit Dashboard warn_message "Dashboard needs the WorkOrders screen to load data."
+
+Manage screen groups
+--------------------
+
+.. code-block:: text
+
+   VIS group add <group_name> [description]
+   VIS group remove <group_name>
+   VIS group assign <screen> <group_name> [true|false]
+   VIS group unassign <screen>
+   VIS group default <screen> <true|false>
+   VIS group list
+
+Maintains the ``release_info.groups`` block in ``project.json``. Screen
+groups bundle related screens under a single checkbox in the installer
+GUI; the expand arrow reveals indented sub-checkboxes so end-users can
+pick individual members. Each member carries a ``default`` flag
+controlling whether it is initially checked.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Subcommand
+     - Description
+   * - ``add``
+     - Creates an empty group with an optional description. The name must
+       be a valid identifier, not clash with any screen name, and not
+       collide with a reserved VIS command.
+   * - ``remove``
+     - Removes a group. Member screens themselves are left intact; they
+       simply become ungrouped.
+   * - ``assign``
+     - Places a screen in a group. A screen belongs to at most one group;
+       assigning reassigns and removes the screen from any previous group.
+       The optional ``true|false`` argument sets the member's ``default``
+       flag (defaults to ``true``).
+   * - ``unassign``
+     - Removes a screen from whichever group currently contains it.
+   * - ``default``
+     - Flips the ``default`` flag for a screen already inside a group.
+       ``false`` means the screen starts **unchecked** when the group
+       checkbox is checked — users can still tick it manually.
+   * - ``list``
+     - Prints every group with its description and members (including
+       each member's default flag).
+
+Examples:
+
+.. code-block:: text
+
+   VIS group add Core "Main application screens"
+   VIS group assign WorkOrders Core
+   VIS group assign FloorView Core
+   VIS group assign Diagnostics Core false
+   VIS group list
 
 Stop the Host
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "VIStk"
-version = "0.4.6"
+version = "0.4.7"
 license = {file="LICENSE"}
 dependencies = [
   "pyinstaller",


### PR DESCRIPTION
## Summary

Brings **VIStk 0.4.7** to master, plus the late 0.4.6 CLI doc addition that missed PR #30.

Every tab, TabManager (pane), and DetachedWindow now carries a stable integer ID allocated from a single process-wide counter (``VIStk.Objects._Identity.new_id``). Internal bookkeeping previously keyed on display labels now keys on ``tab_id``, so multi-split layouts with duplicate screen names no longer confuse focus restoration, merges, or refreshes.

### What's in this PR

- **3 commits** on top of master:
  - ``2bf36f8`` — Document 0.4.6 CLI additions in ``cli.rst`` *(landed on the integration branch after PR #30 merged)*
  - ``fe9bad4`` — 0.4.7 Tab Identity Refactor (the main body of work)
  - ``0bdfa6a`` — Two follow-up bug fixes from code review:
    1. ``DetachedWindow._on_tab_refresh`` now reuses the original ``tab_id`` on refresh, matching ``TabManager.force_refresh_tab``
    2. ``Host._get_all_tab_labels`` / ``_find_tab_by_base`` walk the live SplitView tree so ghost entries from TabManagers destroyed by ``SplitView.remove_pane`` (pre-existing bookkeeping leak) don't contribute ghost labels or dead-manager lookups

### Why a separate PR to master?

PR #31 merged 0.4.7 into ``claude/exciting-davinci-0c83d7`` on Apr 22, but PR #30 had already merged that branch into master on Apr 21. The 0.4.7 commits never reached master. This PR closes that gap in one shot.

### Primary bug fixed by 0.4.7

``SplitView.remove_pane`` previously rebuilt the surviving subtree under a fresh Tk parent and fell back to ``panes[0]`` for focus. In multi-split layouts with duplicate screen names (e.g. two ``Dashboard`` tabs), the user's focused pane could silently be lost. Now the focused ``tab_id`` is snapshotted across the rebuild and focus lands on whichever new pane owns it.

### Key API changes

- ``TabManager.open_tab`` returns ``int | None`` (was ``bool``).
- ``TabManager._tabs`` / ``TabBar._tabs`` keyed by ``tab_id`` (was display label).
- Public methods (``close_tab``, ``focus_tab``, ``has_tab``, ``force_refresh_tab``, ``set_tab_info``) accept either an ``int`` ID or a ``str`` display label via ``_resolve_id``.
- ``TabManager.active`` is ``int | None`` (was ``str | None``).
- Callbacks now pass ``tab_id`` first (see ``docs/source/changelog/0.4.7.rst``).
- ``Host._find_tab_by_base`` returns ``(tab_manager, tab_id)`` instead of ``(tab_manager, display_name)``.

### Backward compatibility

- Public methods still accept display labels as strings, so ``tm.close_tab("Work Orders")`` keeps working.
- ``if tm.open_tab(...):`` still works — non-``None`` int is truthy.
- IPC is **not** being reintroduced; the in-process ``_HOST_INSTANCE`` singleton remains the sole navigation path.

### Out of scope

- Persistent (UUID / cross-process) IDs — deferred to 0.6.X
- Deregistering stale ``TabManager`` refs from ``Host.registered_tab_managers`` / ``DetachedWindow.tab_managers`` after ``remove_pane`` — pre-existing bookkeeping leak, orthogonal to the refactor

## Test plan

- [ ] Build a multi-split layout with two ``Dashboard`` tabs; close a pane that isn't the focused one; focus lands on the correct remaining ``Dashboard``
- [ ] ``tm.close_tab("LabelName")`` still closes by label (back-compat)
- [ ] ``tm.open_tab(...)`` truthy/falsy check (``if`` idiom) still works
- [ ] Refreshing a tab via the tab bar context menu keeps the same ``tab_id`` (e.g. focus tracking survives)
- [ ] Multi-instance single-instance screens: closing one leaves the other intact
- [ ] Standalone screen (``tabbed=false``) via DetachedWindow still launches & closes cleanly
- [ ] Docs build: ``sphinx-build -W --keep-going docs/source docs/build``

🤖 Generated with [Claude Code](https://claude.com/claude-code)