### PR TITLE
VIStk 0.5.0 — VIS Widgets, Help Button & Popup Polish

### DIFF
--- a/VIStk/Objects/_Docs.py
+++ b/VIStk/Objects/_Docs.py
@@ -1,0 +1,42 @@
+"""Documentation-URL helpers (0.5.0).
+
+A project author wires a Help button in one line from ``.VIS/Host.py``::
+
+    from VIStk.Widgets import HostMenu
+    from VIStk.Objects import open_active_screen_docs
+
+    host_menu.add_project_command("Help", open_active_screen_docs)
+
+At click time :func:`open_active_screen_docs` reads the currently active
+screen from the Host, consults ``Project.resolve_docs_url`` (active
+screen's ``docs`` -> project ``default_docs`` -> ``None``), and hands the
+URL to :func:`webbrowser.open`.
+
+The URL is passed through verbatim — no path normalisation.  Authors
+write fully-qualified URLs (``https://...``, ``file:///...``) in
+``project.json``.
+"""
+
+import webbrowser
+
+
+def open_active_screen_docs() -> bool:
+    """Open the active screen's docs URL (or the project default) in the
+    system's default web browser.
+
+    Returns:
+        ``True`` when a URL was resolved and handed to ``webbrowser.open``,
+        ``False`` when no URL is configured for the active screen or as a
+        project default (or no screen is active).  Callers may surface a
+        status-line notice on ``False`` if they want to; this helper is
+        silent either way.
+    """
+    from VIStk.Structures._Project import Project
+    url = Project().resolve_docs_url()
+    if not url:
+        return False
+    try:
+        webbrowser.open(url)
+    except Exception:
+        return False
+    return True

--- a/VIStk/Objects/_WindowGeometry.py
+++ b/VIStk/Objects/_WindowGeometry.py
@@ -123,3 +123,37 @@ class WindowGeometry():
 
         self.geometry = [int(width), int(height), int(x-7), int(y)]
         self.window.geometry('%dx%d+%d+%d' % tuple(self.geometry))
+
+    def center_on(self, window_ref: "Tk|Toplevel") -> None:
+        """Center this window on *window_ref* without a visible flicker.
+
+        The canonical *update + getGeometry + setGeometry* pattern makes the
+        popup visible at the OS default position (top-left of screen) before
+        ``setGeometry`` repositions it — a brief but noticeable flash on
+        every open.  ``center_on`` performs the same math inside a
+        ``withdraw()`` / ``deiconify()`` wrap and uses
+        ``update_idletasks()`` (layout-only) instead of ``update()`` (which
+        also processes the map request), so the window is never drawn at
+        its default position.
+
+        Safe to call on a freshly-constructed ``Toplevel`` before any
+        widgets are packed; call it *after* all child widgets are built so
+        that ``winfo_width`` / ``winfo_height`` reflect the final size.
+
+        Not intended for root ``Tk()`` windows — calling ``withdraw()`` on
+        the main application window hides it entirely.
+
+        Args:
+            window_ref: The ``Tk`` or ``Toplevel`` to center on.
+        """
+        self.window.withdraw()
+        self.window.update_idletasks()
+        self.getGeometry(True)
+        self.setGeometry(
+            width=self.window.winfo_width(),
+            height=self.window.winfo_height(),
+            align="center",
+            size_style="window_relative",
+            window_ref=window_ref,
+        )
+        self.window.deiconify()

--- a/VIStk/Objects/__init__.py
+++ b/VIStk/Objects/__init__.py
@@ -6,6 +6,7 @@ from VIStk.Objects._Layout import *
 from VIStk.Objects._TabManager import TabManager, set_tab_info
 from VIStk.Objects._Host import Host
 from VIStk.Objects._DetachedWindow import DetachedWindow
+from VIStk.Objects._Docs import open_active_screen_docs
 
 __all__ = ["WindowGeometry",
            "Root",
@@ -15,4 +16,5 @@ __all__ = ["WindowGeometry",
            "TabManager",
            "set_tab_info",
            "Host",
-           "DetachedWindow"]
+           "DetachedWindow",
+           "open_active_screen_docs"]

--- a/VIStk/Structures/_Project.py
+++ b/VIStk/Structures/_Project.py
@@ -7,10 +7,10 @@ from VIStk.Structures._Screen import *
 _EDITABLE_SCREEN_ATTRS = {
     "script", "release", "icon", "desc", "tabbed",
     "single_instance", "version", "current",
-    "requires", "suggests", "warn_message",
+    "requires", "suggests", "warn_message", "docs",
 }
 _BOOL_ATTRS      = {"release", "tabbed", "single_instance"}
-_NULLABLE_ATTRS  = {"icon", "current", "warn_message"}
+_NULLABLE_ATTRS  = {"icon", "current", "warn_message", "docs"}
 _VERSION_ATTRS   = {"version"}
 _LIST_ATTRS      = {"requires", "suggests"}
 
@@ -40,6 +40,13 @@ class Project(VINFO):
             self.collect_packages:list[str] = info[self.title]["release_info"].get("collect_packages", [])
             self.host_script: str = info[self.title].get("host", {}).get("script", ".VIS/Host.py")
             """Filename of the Host entry-point script"""
+            self.default_docs: str | None = info[self.title].get("defaults", {}).get("docs")
+            """Project-level fallback documentation URL.
+
+            Used by :meth:`resolve_docs_url` when the active screen's own
+            ``Screen.docs`` is ``None``.  Passed verbatim to
+            :func:`webbrowser.open`.
+            """
         self.Screen: Screen = None
         """The Currently Running `Screen`"""
 
@@ -277,6 +284,7 @@ class Project(VINFO):
                 "requires":        lambda: setattr(scr, "requires", list(coerced)),
                 "suggests":        lambda: setattr(scr, "suggests", list(coerced)),
                 "warn_message":    lambda: setattr(scr, "warn_message", coerced),
+                "docs":            lambda: setattr(scr, "docs", coerced),
             }
             attr_map[attribute]()
 
@@ -360,7 +368,7 @@ class Project(VINFO):
 
     def reload(self) -> None:
         """Reloads the current screen
-        
+
         Returns:
             (None): When load fails
         """
@@ -368,6 +376,69 @@ class Project(VINFO):
             self.Screen.load()
         except AttributeError:
             return None
+
+    # ── Active-screen helpers (0.5.0) ──────────────────────────────────────
+
+    @property
+    def active_screen_name(self) -> str | None:
+        """Return the ``base_name`` of the screen whose tab is focused.
+
+        Reads the in-process ``Host`` singleton's ``active_tab_manager``
+        and resolves its active ``tab_id`` back to the screen identity
+        used as a key under ``project.json`` -> ``Screens``.  Returns
+        ``None`` when no Host is running, no pane has focus, or the
+        active pane has no open tab.
+        """
+        from VIStk.Objects._Host import _HOST_INSTANCE
+        if _HOST_INSTANCE is None:
+            return None
+        tm = _HOST_INSTANCE.active_tab_manager
+        if tm is None:
+            return None
+        active_id = getattr(tm, "active", None)
+        if active_id is None:
+            return None
+        entry = tm._tabs.get(active_id)
+        if entry is None:
+            return None
+        return entry.get("base_name") or entry.get("display_name")
+
+    def set_default_docs(self, url: str | None) -> int:
+        """Set or clear the project-level default documentation URL.
+
+        Writes ``defaults.docs`` in ``project.json``.  Pass ``None`` to
+        clear.  Keeps the in-memory ``default_docs`` attribute in sync.
+        """
+        with open(self.p_sinfo, "r") as f:
+            info = json.load(f)
+        old = info[self.title].get("defaults", {}).get("docs")
+        info[self.title].setdefault("defaults", {})["docs"] = url
+        with open(self.p_sinfo, "w") as f:
+            json.dump(info, f, indent=4)
+        self.default_docs = url
+        print(f"  project.defaults.docs: {old!r} → {url!r}")
+        return 1
+
+    def resolve_docs_url(self, screen_name: str | None = None) -> str | None:
+        """Return the documentation URL for a screen, or the project default.
+
+        Resolution order:
+
+        1. The named screen's ``Screen.docs`` (if set)
+        2. ``Project.default_docs`` (if set)
+        3. ``None``
+
+        Args:
+            screen_name: Screen to resolve for.  When ``None`` (default)
+                uses :attr:`active_screen_name`.
+        """
+        if screen_name is None:
+            screen_name = self.active_screen_name
+        if screen_name:
+            scr = self.getScreen(screen_name)
+            if scr is not None and scr.docs:
+                return scr.docs
+        return self.default_docs or None
 
     # ── Screen group management (release_info.groups) ──────────────────────
 

--- a/VIStk/Structures/_Screen.py
+++ b/VIStk/Structures/_Screen.py
@@ -47,6 +47,9 @@ class Screen(VINFO):
 
             info[self.title]["Screens"][self.name]["tabbed"] = tabbed
             info[self.title]["Screens"][self.name]["single_instance"] = False
+            # (0.5.0) Stub the docs field so developers discover it on
+            # inspection.  ``null`` means "fall through to project default".
+            info[self.title]["Screens"][self.name]["docs"] = None
 
             with open(self.p_sinfo,"w") as f:
                 json.dump(info,f,indent=4)
@@ -86,6 +89,15 @@ class Screen(VINFO):
         """Names of screens recommended alongside this one (soft suggestion)."""
         self.warn_message: str | None = scr_data.get("warn_message")
         """Optional custom message shown by the installer when a dependency is unmet."""
+        self.docs: str | None = scr_data.get("docs")
+        """Optional documentation URL for this screen.
+
+        When ``None`` (the default), the Host's ``open_active_screen_docs``
+        helper falls through to the project-level ``default_docs`` field.
+        The string is passed verbatim to :func:`webbrowser.open` — author is
+        responsible for using a fully-qualified URL (``https://``,
+        ``file:///``, etc.).
+        """
       
     def addElement(self,element:str) -> int:
         if validName(element):

--- a/VIStk/Structures/_VINFO.py
+++ b/VIStk/Structures/_VINFO.py
@@ -45,6 +45,7 @@ _RESERVED_VIS_COMMANDS = {
     "edit", "Edit",
     "release", "Release", "r", "R",
     "group", "Group",
+    "docs", "Docs",
 }
 
 def validName(name:str):

--- a/VIStk/VIS.py
+++ b/VIStk/VIS.py
@@ -137,6 +137,42 @@ def __main__():
                 case _:
                     print(f"Unknown group subcommand: {inp[2]!r}")
 
+        case "docs" | "Docs":
+            # VIS docs set <screen|--default> <url>
+            # VIS docs clear <screen|--default>
+            # VIS docs list
+            if len(inp) < 3:
+                print("Usage: VIS docs <set|clear|list> ...")
+                return
+            project = Project()
+            match inp[2]:
+                case "set":
+                    if len(inp) < 5:
+                        print("Usage: VIS docs set <screen_name|--default> <url>")
+                        return
+                    target, url = inp[3], inp[4]
+                    if target in ("--default", "--Default", "-d", "-D"):
+                        project.set_default_docs(url)
+                    else:
+                        project.edit_screen(target, "docs", url)
+                case "clear":
+                    if len(inp) < 4:
+                        print("Usage: VIS docs clear <screen_name|--default>")
+                        return
+                    target = inp[3]
+                    if target in ("--default", "--Default", "-d", "-D"):
+                        project.set_default_docs(None)
+                    else:
+                        project.edit_screen(target, "docs", "null")
+                case "list":
+                    default = project.default_docs or "(none)"
+                    print(f"  --default: {default}")
+                    for scr in project.screenlist:
+                        url = scr.docs or "(falls through to default)"
+                        print(f"  {scr.name}: {url}")
+                case _:
+                    print(f"Unknown docs subcommand: {inp[2]!r}")
+
         case "release" | "Release" | "r" | "R":
             project=Project()
             flag:str=""

--- a/VIStk/Widgets/_AutocompleteEntry.py
+++ b/VIStk/Widgets/_AutocompleteEntry.py
@@ -1,0 +1,245 @@
+"""AutocompleteEntry widget (0.5.0).
+
+A drop-in :class:`ttk.Entry` that filters a candidate list as the user
+types and shows the matches in a popup ``Listbox``::
+
+    cities = ["Boston", "Chicago", "Cleveland", "Columbus", "Dallas", ...]
+    AutocompleteEntry(parent, values=cities).pack(fill="x")
+
+The candidate list can be a static iterable or a callable returning an
+iterable — use the callable form for dynamic lookups (e.g. database
+prefix queries).
+
+Keyboard:
+
+- ``Down`` / ``Up`` move the highlight in the popup
+- ``Return`` accepts the highlighted entry
+- ``Escape`` closes the popup without changing the entry text
+- ``Tab`` accepts the first match
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+from typing import Callable, Iterable
+
+
+class AutocompleteEntry(ttk.Entry):
+    """``ttk.Entry`` with a filtered dropdown of suggestions."""
+
+    def __init__(self, master, *,
+                 values: Iterable[str] | Callable[[str], Iterable[str]] = (),
+                 max_results: int = 8,
+                 case_sensitive: bool = False,
+                 match: str = "prefix",
+                 **kwargs):
+        """
+        Args:
+            master:         Parent widget.
+            values:         Either an iterable of suggestion strings, or
+                            a callable taking the current entry text and
+                            returning an iterable.
+            max_results:    Cap on the number of suggestions shown.
+            case_sensitive: When ``False`` (default), matching ignores
+                            case.
+            match:          ``"prefix"`` (default) or ``"contains"``.
+            **kwargs:       Forwarded to :class:`ttk.Entry`.  If a
+                            ``textvariable`` is not supplied one is
+                            created and exposed as ``self.var``.
+        """
+        if "textvariable" not in kwargs:
+            kwargs["textvariable"] = tk.StringVar()
+        super().__init__(master, **kwargs)
+        self.var: tk.StringVar = kwargs["textvariable"]
+        self._values_src = values
+        self._max_results = max_results
+        self._case_sensitive = case_sensitive
+        self._match_mode = match if match in ("prefix", "contains") else "prefix"
+
+        self._popup: tk.Toplevel | None = None
+        self._listbox: tk.Listbox | None = None
+        self._suppress_next_show = False
+
+        self.var.trace_add("write", lambda *_: self._on_text_change())
+        self.bind("<Down>",   self._on_down,   add="+")
+        self.bind("<Up>",     self._on_up,     add="+")
+        self.bind("<Return>", self._on_return, add="+")
+        self.bind("<Escape>", self._on_escape, add="+")
+        self.bind("<Tab>",    self._on_tab,    add="+")
+        self.bind("<FocusOut>", self._on_focus_out, add="+")
+        self.bind("<Destroy>",  lambda e: self._hide_popup(), add="+")
+
+    # ── Public API ─────────────────────────────────────────────────────────
+
+    def set_values(self,
+                   values: Iterable[str] | Callable[[str], Iterable[str]]
+                   ) -> None:
+        """Replace the suggestion source."""
+        self._values_src = values
+
+    # ── Filtering ──────────────────────────────────────────────────────────
+
+    def _candidates(self, text: str) -> list[str]:
+        if callable(self._values_src):
+            try:
+                raw = list(self._values_src(text))
+            except Exception:
+                raw = []
+        else:
+            raw = list(self._values_src)
+
+        if not text:
+            return raw[:self._max_results]
+
+        needle = text if self._case_sensitive else text.lower()
+        out: list[str] = []
+        for v in raw:
+            haystack = v if self._case_sensitive else v.lower()
+            if self._match_mode == "prefix":
+                ok = haystack.startswith(needle)
+            else:
+                ok = needle in haystack
+            if ok:
+                out.append(v)
+                if len(out) >= self._max_results:
+                    break
+        return out
+
+    # ── Popup lifecycle ────────────────────────────────────────────────────
+
+    def _on_text_change(self) -> None:
+        if self._suppress_next_show:
+            self._suppress_next_show = False
+            return
+        self._refresh_popup()
+
+    def _refresh_popup(self) -> None:
+        text = self.var.get()
+        matches = self._candidates(text)
+        if not matches:
+            self._hide_popup()
+            return
+        self._show_popup(matches)
+
+    def _show_popup(self, matches: list[str]) -> None:
+        if self._popup is None:
+            self._popup = tk.Toplevel(self)
+            self._popup.overrideredirect(True)
+            self._popup.attributes("-topmost", True)
+            self._listbox = tk.Listbox(
+                self._popup,
+                height=min(len(matches), self._max_results),
+                activestyle="dotbox",
+                exportselection=False,
+            )
+            self._listbox.pack(fill="both", expand=True)
+            self._listbox.bind("<ButtonRelease-1>", self._on_click)
+        else:
+            self._listbox.configure(height=min(len(matches), self._max_results))
+
+        self._listbox.delete(0, "end")
+        for m in matches:
+            self._listbox.insert("end", m)
+        if matches:
+            self._listbox.selection_clear(0, "end")
+            self._listbox.selection_set(0)
+            self._listbox.activate(0)
+
+        # Position just below the entry.
+        try:
+            x = self.winfo_rootx()
+            y = self.winfo_rooty() + self.winfo_height()
+            w = self.winfo_width()
+        except tk.TclError:
+            return
+        self._popup.geometry(f"{max(w, 120)}x{self._listbox.winfo_reqheight()}+{x}+{y}")
+
+    def _hide_popup(self) -> None:
+        if self._popup is not None:
+            try:
+                self._popup.destroy()
+            except tk.TclError:
+                pass
+        self._popup = None
+        self._listbox = None
+
+    # ── Key handlers ───────────────────────────────────────────────────────
+
+    def _selected_index(self) -> int | None:
+        if self._listbox is None:
+            return None
+        sel = self._listbox.curselection()
+        return sel[0] if sel else None
+
+    def _move_selection(self, delta: int) -> None:
+        if self._listbox is None:
+            return
+        n = self._listbox.size()
+        if n == 0:
+            return
+        cur = self._selected_index()
+        new = 0 if cur is None else (cur + delta) % n
+        self._listbox.selection_clear(0, "end")
+        self._listbox.selection_set(new)
+        self._listbox.activate(new)
+        self._listbox.see(new)
+
+    def _accept(self, idx: int | None = None) -> None:
+        if self._listbox is None:
+            return
+        if idx is None:
+            idx = self._selected_index()
+        if idx is None:
+            return
+        value = self._listbox.get(idx)
+        self._suppress_next_show = True
+        self.var.set(value)
+        self.icursor("end")
+        self._hide_popup()
+
+    def _on_down(self, _event):
+        if self._listbox is None:
+            self._refresh_popup()
+            return "break"
+        self._move_selection(+1)
+        return "break"
+
+    def _on_up(self, _event):
+        if self._listbox is None:
+            return
+        self._move_selection(-1)
+        return "break"
+
+    def _on_return(self, _event):
+        if self._listbox is None:
+            return
+        self._accept()
+        return "break"
+
+    def _on_tab(self, _event):
+        if self._listbox is None:
+            return
+        self._accept(0)
+        # Allow normal tab traversal afterwards.
+        return None
+
+    def _on_escape(self, _event):
+        if self._listbox is None:
+            return
+        self._hide_popup()
+        return "break"
+
+    def _on_click(self, _event):
+        self._accept()
+
+    def _on_focus_out(self, _event):
+        # Close on focus-out unless focus moved into the popup itself.
+        try:
+            new_focus = self.focus_get()
+        except tk.TclError:
+            new_focus = None
+        if new_focus is not None and self._listbox is not None and (
+                str(new_focus).startswith(str(self._listbox))):
+            return
+        self._hide_popup()

--- a/VIStk/Widgets/_CollapsibleFrame.py
+++ b/VIStk/Widgets/_CollapsibleFrame.py
@@ -1,0 +1,116 @@
+"""CollapsibleFrame widget (0.5.0).
+
+A frame with a header button that toggles the visibility of its content
+area::
+
+    cf = CollapsibleFrame(parent, text="Advanced options", expanded=False)
+    cf.pack(fill="x", padx=4, pady=4)
+
+    # Pack child widgets into ``cf.body`` (NOT directly into ``cf``):
+    ttk.Checkbutton(cf.body, text="Verbose").pack(anchor="w")
+    ttk.Entry(cf.body).pack(fill="x")
+
+The frame remembers its expanded state in a ``BooleanVar`` (exposed as
+``cf.expanded_var``) so callers can bind it to settings or share it
+across frames.
+
+Geometry: when collapsed only the header is visible; when expanded the
+body is packed below.  Layout is ``pack``-based so the frame plays
+nicely with both ``pack`` and ``grid`` parents.
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+from typing import Callable
+
+
+class CollapsibleFrame(ttk.Frame):
+    """A frame whose body can be collapsed under a header button."""
+
+    _ARROW_EXPANDED = "\u25BC"   # ▼
+    _ARROW_COLLAPSED = "\u25B6"  # ▶
+
+    def __init__(self, master, *, text: str = "",
+                 expanded: bool = True,
+                 on_toggle: Callable[[bool], None] | None = None,
+                 **kwargs):
+        """
+        Args:
+            master:    Parent widget.
+            text:      Header label text.
+            expanded:  Initial state.  Default ``True``.
+            on_toggle: Optional callback invoked with the new expanded
+                       state whenever the user toggles the frame.
+            **kwargs:  Forwarded to :class:`ttk.Frame`.
+        """
+        super().__init__(master, **kwargs)
+        self._on_toggle = on_toggle
+
+        self.expanded_var = tk.BooleanVar(value=bool(expanded))
+        """``BooleanVar`` mirroring the current expanded state.  Bind
+        externally to share state across instances or persist it."""
+
+        self._header = ttk.Frame(self)
+        self._header.pack(fill="x")
+
+        self._toggle_btn = ttk.Button(
+            self._header,
+            text=self._compose_label(text),
+            style="Toolbutton",
+            command=self.toggle,
+        )
+        self._toggle_btn.pack(fill="x")
+
+        self.body = ttk.Frame(self)
+        """The content area.  Pack or grid your widgets into this."""
+
+        self._text = text
+
+        if self.expanded_var.get():
+            self.body.pack(fill="both", expand=True)
+
+    # ── Public API ─────────────────────────────────────────────────────────
+
+    def toggle(self) -> None:
+        """Flip between expanded and collapsed."""
+        self.set_expanded(not self.expanded_var.get())
+
+    def expand(self) -> None:
+        """Show the body."""
+        self.set_expanded(True)
+
+    def collapse(self) -> None:
+        """Hide the body."""
+        self.set_expanded(False)
+
+    def set_expanded(self, value: bool) -> None:
+        """Set state explicitly.  No-ops if already in the requested state."""
+        value = bool(value)
+        if self.expanded_var.get() == value and (
+                value == bool(self.body.winfo_ismapped())):
+            return
+        self.expanded_var.set(value)
+        if value:
+            self.body.pack(fill="both", expand=True)
+        else:
+            self.body.pack_forget()
+        self._toggle_btn.configure(text=self._compose_label(self._text))
+        if self._on_toggle is not None:
+            try:
+                self._on_toggle(value)
+            except Exception:
+                pass
+
+    def set_text(self, text: str) -> None:
+        """Update the header label."""
+        self._text = text
+        self._toggle_btn.configure(text=self._compose_label(text))
+
+    # ── Internals ──────────────────────────────────────────────────────────
+
+    def _compose_label(self, text: str) -> str:
+        arrow = (self._ARROW_EXPANDED if self.expanded_var.get()
+                 else self._ARROW_COLLAPSED)
+        return f"{arrow}  {text}" if text else arrow

--- a/VIStk/Widgets/_DateEntry.py
+++ b/VIStk/Widgets/_DateEntry.py
@@ -1,0 +1,241 @@
+"""DateEntry widget (0.5.0).
+
+A date input widget with format validation and an optional calendar
+picker popup, with no third-party dependencies.
+
+Usage::
+
+    from VIStk.Widgets import DateEntry
+    de = DateEntry(parent, date_format="%Y-%m-%d")
+    de.pack()
+
+    de.get()                 # -> datetime.date | None
+    de.set(date(2026, 4, 23))
+    de.var.get()             # -> "2026-04-23"
+
+The widget is a small composite: a :class:`ttk.Entry` for direct typing
+plus a calendar button that pops up a month grid.  Typing into the
+entry is validated against ``date_format`` on focus-out; an invalid
+string is reverted to the last valid value (or cleared if none).
+"""
+
+from __future__ import annotations
+
+import calendar
+import tkinter as tk
+from datetime import date, datetime
+from tkinter import ttk
+from typing import Callable
+
+from VIStk.Objects._WindowGeometry import WindowGeometry
+
+
+class DateEntry(ttk.Frame):
+    """Entry + calendar-picker for selecting a date."""
+
+    _CAL_ICON = "☰"   # ☰ — kept ASCII-safe; users can override
+
+    def __init__(self, master, *,
+                 date_format: str = "%Y-%m-%d",
+                 initial: date | None = None,
+                 on_change: Callable[[date | None], None] | None = None,
+                 entry_width: int | None = None,
+                 **kwargs):
+        """
+        Args:
+            date_format:  ``strftime``/``strptime`` pattern.  Default
+                          ``"%Y-%m-%d"``.
+            initial:      Optional starting date.
+            on_change:    Optional callback fired with the new
+                          ``date | None`` whenever the value changes via
+                          the entry, the picker, or :meth:`set`.
+            entry_width:  Width passed to the inner ``ttk.Entry``.
+                          Defaults to ``len(today.strftime(fmt)) + 2``.
+            **kwargs:     Forwarded to :class:`ttk.Frame`.
+        """
+        super().__init__(master, **kwargs)
+        self._fmt = date_format
+        self._on_change = on_change
+        self._last_valid: date | None = initial
+        self._popup: tk.Toplevel | None = None
+
+        if entry_width is None:
+            entry_width = len(date.today().strftime(self._fmt)) + 2
+
+        self.var = tk.StringVar(value=initial.strftime(self._fmt) if initial else "")
+        """``StringVar`` holding the entry text.  Mutating it directly
+        bypasses validation; prefer :meth:`set`."""
+
+        self._entry = ttk.Entry(self, textvariable=self.var, width=entry_width)
+        self._entry.pack(side="left", fill="x", expand=True)
+        self._entry.bind("<FocusOut>", self._on_entry_commit, add="+")
+        self._entry.bind("<Return>",   self._on_entry_commit, add="+")
+
+        self._btn = ttk.Button(self, text=self._CAL_ICON, width=3,
+                               command=self._open_picker)
+        self._btn.pack(side="left", padx=(2, 0))
+
+        self.bind("<Destroy>", lambda e: self._close_picker(), add="+")
+
+    # ── Public API ─────────────────────────────────────────────────────────
+
+    def get(self) -> date | None:
+        """Return the current date, or ``None`` when the field is empty
+        / invalid."""
+        text = self.var.get().strip()
+        if not text:
+            return None
+        try:
+            return datetime.strptime(text, self._fmt).date()
+        except ValueError:
+            return None
+
+    def set(self, value: date | None) -> None:
+        """Set the date programmatically.  ``None`` clears the field."""
+        self._last_valid = value
+        self.var.set(value.strftime(self._fmt) if value else "")
+        self._fire_change(value)
+
+    # ── Entry validation ───────────────────────────────────────────────────
+
+    def _on_entry_commit(self, _event=None):
+        text = self.var.get().strip()
+        if not text:
+            if self._last_valid is not None:
+                self._last_valid = None
+                self._fire_change(None)
+            return
+        try:
+            parsed = datetime.strptime(text, self._fmt).date()
+        except ValueError:
+            # Revert to last valid value.
+            self.var.set(self._last_valid.strftime(self._fmt)
+                         if self._last_valid else "")
+            return
+        if parsed != self._last_valid:
+            self._last_valid = parsed
+            self._fire_change(parsed)
+        # Re-canonicalise the displayed text (e.g. zero-pad).
+        self.var.set(parsed.strftime(self._fmt))
+
+    def _fire_change(self, value: date | None) -> None:
+        if self._on_change is None:
+            return
+        try:
+            self._on_change(value)
+        except Exception:
+            pass
+
+    # ── Calendar picker ────────────────────────────────────────────────────
+
+    def _open_picker(self) -> None:
+        if self._popup is not None and bool(self._popup.winfo_exists()):
+            self._close_picker()
+            return
+
+        seed = self.get() or date.today()
+        self._popup = tk.Toplevel(self)
+        self._popup.withdraw()
+        self._popup.overrideredirect(True)
+        self._popup.attributes("-topmost", True)
+
+        self._cal_year = seed.year
+        self._cal_month = seed.month
+        self._cal_selected = seed if self.get() is not None else None
+
+        self._build_calendar()
+
+        # Position just below the entry; nudge up if it would clip.
+        self._popup.update_idletasks()
+        x = self._entry.winfo_rootx()
+        y = self._entry.winfo_rooty() + self._entry.winfo_height() + 2
+        self._popup.geometry(f"+{x}+{y}")
+        self._popup.deiconify()
+
+        # Close popup on click outside.
+        self._popup.bind("<FocusOut>", self._on_popup_focus_out, add="+")
+        self._popup.focus_set()
+
+    def _close_picker(self) -> None:
+        if self._popup is not None:
+            try:
+                self._popup.destroy()
+            except tk.TclError:
+                pass
+        self._popup = None
+
+    def _on_popup_focus_out(self, _event):
+        # Defer so click-on-button doesn't bounce open.
+        self._popup.after(50, self._maybe_close)
+
+    def _maybe_close(self):
+        if self._popup is None:
+            return
+        try:
+            f = self._popup.focus_displayof()
+        except tk.TclError:
+            f = None
+        if f is None or str(f).startswith(str(self._popup)) is False:
+            self._close_picker()
+
+    def _build_calendar(self) -> None:
+        for child in list(self._popup.children.values()):
+            child.destroy()
+
+        outer = ttk.Frame(self._popup, padding=4, relief="solid", borderwidth=1)
+        outer.pack(fill="both", expand=True)
+
+        # Header row: ◀ / Month YYYY / ▶
+        hdr = ttk.Frame(outer)
+        hdr.pack(fill="x")
+        ttk.Button(hdr, text="◀", width=3,
+                   command=lambda: self._shift_month(-1)).pack(side="left")
+        month_label = f"{calendar.month_name[self._cal_month]} {self._cal_year}"
+        ttk.Label(hdr, text=month_label, anchor="center").pack(
+            side="left", fill="x", expand=True, padx=4)
+        ttk.Button(hdr, text="▶", width=3,
+                   command=lambda: self._shift_month(+1)).pack(side="left")
+
+        # Day-of-week row.
+        dow = ttk.Frame(outer)
+        dow.pack(fill="x")
+        for i, name in enumerate(["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]):
+            ttk.Label(dow, text=name, anchor="center", width=4).grid(
+                row=0, column=i, padx=1, pady=1)
+
+        # Day grid — calendar.monthcalendar returns weeks of length 7,
+        # zero-padded to align with Mon-first.
+        grid = ttk.Frame(outer)
+        grid.pack(fill="both", expand=True)
+        weeks = calendar.Calendar(firstweekday=0).monthdayscalendar(
+            self._cal_year, self._cal_month)
+        for r, week in enumerate(weeks):
+            for c, day in enumerate(week):
+                if day == 0:
+                    ttk.Label(grid, text="", width=4).grid(
+                        row=r, column=c, padx=1, pady=1)
+                    continue
+                d = date(self._cal_year, self._cal_month, day)
+                style = "Toolbutton"
+                btn = ttk.Button(grid, text=str(day), width=4, style=style,
+                                 command=lambda dd=d: self._pick(dd))
+                btn.grid(row=r, column=c, padx=1, pady=1)
+                if self._cal_selected == d:
+                    btn.state(["pressed"])
+                if d == date.today():
+                    btn.configure(text=f"[{day}]")
+
+    def _shift_month(self, delta: int) -> None:
+        m = self._cal_month + delta
+        y = self._cal_year
+        while m < 1:
+            m += 12; y -= 1
+        while m > 12:
+            m -= 12; y += 1
+        self._cal_month = m
+        self._cal_year = y
+        self._build_calendar()
+
+    def _pick(self, d: date) -> None:
+        self.set(d)
+        self._close_picker()

--- a/VIStk/Widgets/_Dialogs.py
+++ b/VIStk/Widgets/_Dialogs.py
@@ -1,0 +1,181 @@
+"""Standard confirmation dialogs (0.5.0).
+
+Helpers that keep screens from re-implementing the ``tkinter.messagebox``
+dance every time they need to veto ``on_quit`` or confirm a destructive
+action.  Both dialogs are modal, centred on their parent via
+:meth:`WindowGeometry.center_on` (so they never flash at the OS default
+position), and return a plain ``bool``.
+
+Typical usage inside ``on_quit``::
+
+    from VIStk.Widgets import confirm_discard
+
+    def on_quit() -> bool:
+        if not _dirty:
+            return True
+        result = confirm_discard(name="Work Order #12345")
+        if result == "cancel":
+            return False
+        if result == "save":
+            _save()
+        return True
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+from typing import Literal
+
+from VIStk.Objects._WindowGeometry import WindowGeometry
+
+
+def _get_parent():
+    """Return the current default root, falling back to ``None``."""
+    try:
+        return tk._default_root
+    except Exception:
+        return None
+
+
+class _ModalDialog(tk.Toplevel):
+    """Shared Toplevel used by :func:`confirm` and :func:`confirm_discard`.
+
+    Centres on the parent and grabs input until a button is pressed or
+    the window is closed.
+    """
+
+    def __init__(self, parent, title: str, message: str,
+                 buttons: list[tuple[str, object]], *,
+                 default_value=None, escape_value=None):
+        super().__init__(parent)
+        # Hide immediately so only the centred, fully-built window is
+        # ever shown (no flicker at OS default position).
+        self.withdraw()
+        self.title(title)
+        self.resizable(False, False)
+
+        self._result = default_value if default_value is not None else escape_value
+
+        body = ttk.Frame(self, padding=(16, 14, 16, 10))
+        body.pack(fill="both", expand=True)
+
+        ttk.Label(body, text=message, wraplength=360, justify="left").pack(
+            fill="x", pady=(0, 14))
+
+        btn_row = ttk.Frame(body)
+        btn_row.pack(fill="x")
+        btn_row.columnconfigure(0, weight=1)
+
+        spacer = ttk.Frame(btn_row)
+        spacer.grid(row=0, column=0, sticky="ew")
+
+        for i, (label, value) in enumerate(buttons, start=1):
+            b = ttk.Button(btn_row, text=label,
+                           command=lambda v=value: self._finish(v))
+            b.grid(row=0, column=i, padx=(6, 0))
+            if default_value is not None and value == default_value:
+                b.focus_set()
+                self.bind("<Return>", lambda e, v=value: self._finish(v))
+
+        if escape_value is not None:
+            self.bind("<Escape>", lambda e: self._finish(escape_value))
+        self.protocol("WM_DELETE_WINDOW",
+                      lambda: self._finish(escape_value))
+
+        # Geometry + modality.
+        WindowGeometry(self)
+        if parent is not None and int(parent.winfo_viewable()):
+            self.WindowGeometry.center_on(parent)
+        else:
+            self.WindowGeometry.getGeometry(True)
+            self.WindowGeometry.setGeometry(
+                width=self.winfo_width(),
+                height=self.winfo_height(),
+                align="center",
+                size_style="screen_relative")
+            self.deiconify()
+
+        self.transient(parent) if parent is not None else None
+        self.grab_set()
+        self.wait_window()
+
+    def _finish(self, value):
+        self._result = value
+        try:
+            self.grab_release()
+        except tk.TclError:
+            pass
+        self.destroy()
+
+
+def confirm(parent=None, *, title: str, message: str,
+            yes: str = "Yes", no: str = "No") -> bool:
+    """Generic two-button Yes/No confirmation dialog.
+
+    Returns ``True`` when the user clicks *yes*, ``False`` when they
+    click *no*, press Escape, or close the window.
+
+    Args:
+        parent:  Window to centre the dialog on.  ``None`` uses the
+            current default root; if there isn't one the dialog centres
+            on the screen.
+        title:   Window title.
+        message: Body text.  Wraps at ~360 px.
+        yes:     Label for the affirmative button.  Default ``"Yes"``.
+        no:      Label for the negative button.  Default ``"No"``.
+    """
+    parent = parent if parent is not None else _get_parent()
+    dlg = _ModalDialog(
+        parent, title=title, message=message,
+        buttons=[(no, False), (yes, True)],
+        default_value=True, escape_value=False)
+    return bool(dlg._result)
+
+
+def confirm_discard(parent=None, *, title: str | None = None,
+                    message: str | None = None,
+                    name: str | None = None
+                    ) -> Literal["save", "discard", "cancel"]:
+    """Three-button *Save / Discard / Cancel* dialog.
+
+    Drop-in helper for ``on_quit``::
+
+        def on_quit() -> bool:
+            if not _dirty:
+                return True
+            choice = confirm_discard(name="Work Order #12345")
+            if choice == "cancel":
+                return False
+            if choice == "save":
+                _save()
+            return True
+
+    Args:
+        parent:  Window to centre the dialog on.  ``None`` uses the
+            current default root.
+        title:   Window title.  Defaults to ``"Unsaved changes"``.
+        message: Body text.  When ``None`` a default is built from *name*.
+        name:    Optional item identifier (e.g. ``"Work Order #12345"``)
+            spliced into the default message when *message* is ``None``.
+
+    Returns:
+        One of ``"save"``, ``"discard"``, or ``"cancel"``.  Escape or
+        closing the window both return ``"cancel"``.
+    """
+    parent = parent if parent is not None else _get_parent()
+    if title is None:
+        title = "Unsaved changes"
+    if message is None:
+        target = name or "this item"
+        message = (f"Save changes to {target} before closing?\n\n"
+                   f"Choose Discard to close without saving, or Cancel "
+                   f"to keep it open.")
+    dlg = _ModalDialog(
+        parent, title=title, message=message,
+        buttons=[("Cancel", "cancel"),
+                 ("Discard", "discard"),
+                 ("Save", "save")],
+        default_value="save",
+        escape_value="cancel")
+    return dlg._result

--- a/VIStk/Widgets/_HostMenu.py
+++ b/VIStk/Widgets/_HostMenu.py
@@ -89,6 +89,24 @@ class HostMenu:
         self.menubar.add_cascade(label=label, menu=cascade)
         self._project_labels.append(label)
 
+    def add_project_command(self, label: str, command) -> None:
+        """Add one leaf command directly to the menubar (project layer).
+
+        Unlike :meth:`set_project_items` which adds a cascade (a dropdown),
+        this adds a single clickable menubar entry whose label *is* the
+        action — e.g. a top-level ``Help`` button.  Persists across all
+        tab changes; only removed by :meth:`clear_project_items`.
+
+        May be called multiple times to add more than one top-level
+        command, side by side, in call order.
+
+        Args:
+            label:   Top-level label shown on the menubar.
+            command: Zero-arg callable invoked when the user clicks.
+        """
+        self.menubar.add_command(label=label, command=command)
+        self._project_labels.append(label)
+
     def clear_project_items(self):
         """Remove all project-layer cascades.
 

--- a/VIStk/Widgets/_Tooltip.py
+++ b/VIStk/Widgets/_Tooltip.py
@@ -1,0 +1,147 @@
+"""Tooltip widget (0.5.0).
+
+Tkinter has no native tooltip.  ``Tooltip`` attaches one to any widget
+with a single line::
+
+    from VIStk.Widgets import Tooltip
+    Tooltip(my_button, text="Save the current document")
+
+Behaviour:
+
+- Appears after a hover delay (default 500 ms).
+- Disappears on ``<Leave>``, on click, on focus loss, and when the
+  bound widget is destroyed.
+- The popup itself never steals focus and is excluded from window
+  manager decoration via ``overrideredirect``.
+- ``text`` may be a plain ``str`` *or* a callable returning ``str`` —
+  use the callable form for tooltips that change with state.
+- Cleanly stops scheduling and hides the popup when the host widget is
+  destroyed (no ``after`` callback leaks).
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+from typing import Callable
+
+
+class Tooltip:
+    """Hover tooltip bound to a single widget."""
+
+    def __init__(self, widget: tk.Widget, text: str | Callable[[], str],
+                 *, delay_ms: int = 500,
+                 wraplength: int = 240,
+                 background: str = "#FFFFE0",
+                 foreground: str = "#000000",
+                 borderwidth: int = 1):
+        """
+        Args:
+            widget:      The widget to attach to.
+            text:        Tooltip text, or a zero-arg callable returning
+                         the text (re-evaluated each time the tip is
+                         shown — useful for state-dependent tooltips).
+            delay_ms:    Hover delay before showing.  Default 500 ms.
+            wraplength:  Pixel width at which the tooltip wraps.
+            background:  Tooltip background colour.
+            foreground:  Tooltip foreground colour.
+            borderwidth: Border thickness in pixels.
+        """
+        self.widget = widget
+        self._text = text
+        self._delay_ms = delay_ms
+        self._wraplength = wraplength
+        self._bg = background
+        self._fg = foreground
+        self._bd = borderwidth
+
+        self._tip: tk.Toplevel | None = None
+        self._after_id: str | None = None
+
+        widget.bind("<Enter>",     self._on_enter,    add="+")
+        widget.bind("<Leave>",     self._on_leave,    add="+")
+        widget.bind("<ButtonPress>", self._on_leave,  add="+")
+        widget.bind("<Destroy>",   self._on_destroy,  add="+")
+
+    # ── Public mutators ────────────────────────────────────────────────────
+
+    def set_text(self, text: str | Callable[[], str]) -> None:
+        """Replace the tooltip text (or the callable producing it)."""
+        self._text = text
+
+    def hide(self) -> None:
+        """Cancel any pending show and destroy the popup if visible."""
+        self._cancel()
+        self._destroy_tip()
+
+    # ── Event handlers ─────────────────────────────────────────────────────
+
+    def _on_enter(self, _event=None) -> None:
+        self._cancel()
+        self._after_id = self.widget.after(self._delay_ms, self._show)
+
+    def _on_leave(self, _event=None) -> None:
+        self.hide()
+
+    def _on_destroy(self, _event=None) -> None:
+        self.hide()
+
+    # ── Internals ──────────────────────────────────────────────────────────
+
+    def _cancel(self) -> None:
+        if self._after_id is not None:
+            try:
+                self.widget.after_cancel(self._after_id)
+            except tk.TclError:
+                pass
+            self._after_id = None
+
+    def _resolve_text(self) -> str:
+        if callable(self._text):
+            try:
+                return str(self._text())
+            except Exception:
+                return ""
+        return str(self._text)
+
+    def _show(self) -> None:
+        self._after_id = None
+        text = self._resolve_text()
+        if not text:
+            return
+        # Position just below-right of the cursor.
+        try:
+            x = self.widget.winfo_pointerx() + 12
+            y = self.widget.winfo_pointery() + 16
+        except tk.TclError:
+            return
+
+        tip = tk.Toplevel(self.widget)
+        tip.overrideredirect(True)
+        tip.attributes("-topmost", True)
+        try:
+            tip.attributes("-toolwindow", True)  # Win32 only — ignored elsewhere
+        except tk.TclError:
+            pass
+        tip.geometry(f"+{x}+{y}")
+
+        lbl = tk.Label(tip,
+                       text=text,
+                       background=self._bg,
+                       foreground=self._fg,
+                       borderwidth=self._bd,
+                       relief="solid",
+                       wraplength=self._wraplength,
+                       justify="left",
+                       padx=6, pady=3)
+        lbl.pack()
+
+        self._tip = tip
+
+    def _destroy_tip(self) -> None:
+        if self._tip is not None:
+            try:
+                self._tip.destroy()
+            except tk.TclError:
+                pass
+            self._tip = None

--- a/VIStk/Widgets/__init__.py
+++ b/VIStk/Widgets/__init__.py
@@ -8,6 +8,11 @@ from VIStk.Widgets._TabBar import TabBar
 from VIStk.Widgets._HostMenu import HostMenu
 from VIStk.Widgets._InfoRow import InfoRow
 from VIStk.Widgets._SplitView import SplitView
+from VIStk.Widgets._Dialogs import confirm, confirm_discard
+from VIStk.Widgets._Tooltip import Tooltip
+from VIStk.Widgets._CollapsibleFrame import CollapsibleFrame
+from VIStk.Widgets._AutocompleteEntry import AutocompleteEntry
+from VIStk.Widgets._DateEntry import DateEntry
 
 
 __all__ = ["VISMenu",
@@ -20,4 +25,10 @@ __all__ = ["VISMenu",
            "HostMenu",
            "InfoRow",
            "SplitView",
+           "confirm",
+           "confirm_discard",
+           "Tooltip",
+           "CollapsibleFrame",
+           "AutocompleteEntry",
+           "DateEntry",
            ]

--- a/changelog.md
+++ b/changelog.md
@@ -735,21 +735,57 @@ The License/EULA page, `\r` quiet-mode progress bar, and
 
 ---
 
-### 0.5.X VIS Widgets
+### 0.5.0 VIS Widgets, Help Button & Popup Polish
 
-Widgets that Tkinter does not provide natively. General-purpose and usable in any VIStk app.
+**Released.**  Adds general-purpose widgets, a one-line Help-button hookup, standard confirmation dialogs, and a flicker-free popup centring helper.
 
-- `Tooltip` — hover tooltip bound to any widget; Tkinter has no native tooltip
-- `CollapsibleFrame` — frame with a header button that toggles content visibility
-- `AutocompleteEntry` — Entry with a filtered dropdown suggestion list
-- `DateEntry` — date input widget with format validation and optional calendar picker popup
-- Expand custom frames
-- More menu options
-- Color palette feature — recolor default VIStk widgets; accessible throughout user code
+**VIS Widgets** — all exported from `VIStk.Widgets`:
+
+- `Tooltip` — hover tooltip bound to any widget; `text` may be a `str` or zero-arg callable for state-dependent tooltips; cleans up its `after` callback on widget destroy
+- `CollapsibleFrame` — frame whose body is hidden under a header button; pack children into `cf.body`; `cf.expanded_var` is a shared `BooleanVar`
+- `AutocompleteEntry` — `ttk.Entry` with a filtered dropdown `Listbox`; `values` may be iterable or callable; `match="prefix"` (default) or `"contains"`
+- `DateEntry` — entry + calendar-picker popup, no third-party dependencies; `get()` returns `date | None`; invalid manual input reverts on focus-out
+
+**Confirmation dialogs:**
+
+- `confirm(parent, *, title, message, yes="Yes", no="No") -> bool` — two-button Yes/No
+- `confirm_discard(parent, *, title=None, message=None, name=None) -> "save" | "discard" | "cancel"` — three-button Save / Discard / Cancel; closing the window or pressing Escape returns `"cancel"`
+- Both are modal, transient, and centred via `WindowGeometry.center_on` (no flicker)
+
+**Help button & per-screen `docs` URL:**
+
+- `HostMenu.add_project_command(label, command)` — adds a clickable leaf entry directly on the menubar (not a cascade); persists across all tab changes
+- `Screen.docs: str | None` — per-screen URL field on `project.json` `Screens.<name>.docs`
+- `Project.default_docs: str | None` — project-wide fallback (`defaults.docs`)
+- `Project.resolve_docs_url(screen_name=None)` — runs the resolution chain (per-screen → project default → `None`)
+- `Project.active_screen_name` property — returns the active tab's `base_name` (resolved via the 0.4.7 tab IDs)
+- `VIStk.Objects.open_active_screen_docs()` — looks up the active screen's URL and hands it to `webbrowser.open`; returns `True` on dispatch
+- `VIS docs` CLI:
+  ```
+  VIS docs set <screen_name> <url>
+  VIS docs set --default <url>
+  VIS docs clear <screen_name>
+  VIS docs clear --default
+  VIS docs list
+  ```
+- `VIS add screen` scaffolder writes `"docs": null` so the field is discoverable
+- URLs are passed verbatim to `webbrowser.open` — no path normalisation; authors write fully-qualified URLs
+
+**Popup flicker fix:**
+
+- `WindowGeometry.center_on(window_ref)` — performs the canonical centre-on-parent math inside a `withdraw()` / `deiconify()` wrap and uses `update_idletasks()` (layout-only) instead of `update()` (which also processes the map request); the popup is never drawn at the OS default position
+- Existing `setGeometry` is unchanged — no behavioural change for root-window callers
+- `objects.rst` "Center a popup on its parent window" example updated
+
+**Out of scope (deferred):**
+
+- **Project Upgrade Tool** (`VIS upgrade`) — moved to 0.7 (already titled "Defaults & Navigation, update tools")
+- **Color palette feature** — tracked separately for a later 0.5.x or 0.6.x
+- **`is_dirty` auto-generated `on_quit`** — `confirm_discard` covers the manual case; the auto-wrapper can land later without an API break
 
 ---
 
-### 0.5.X Project Upgrade Tool
+### 0.7.X Project Upgrade Tool *(moved from 0.5)*
 
 # this kinda seems like a bad idea looking at it now
 

--- a/docs/source/changelog/0.5.rst
+++ b/docs/source/changelog/0.5.rst
@@ -1,74 +1,161 @@
-0.5 --- VIS Widgets & Project Upgrade Tool
-==========================================
+0.5.0 --- VIS Widgets, Help Button & Popup Polish
+==================================================
 
-*Upcoming*
+*Released --- current version*
+
+Adds general-purpose widgets, a one-line Help-button hookup, standard
+confirmation dialogs, and a flicker-free popup centring helper.  The
+project-upgrade-tool work originally planned for 0.5 has been deferred
+(see "Out of scope" below).
 
 VIS Widgets
 -----------
 
-General-purpose widgets that Tkinter does not provide natively.
+General-purpose widgets that Tkinter does not provide natively.  All
+exported from :mod:`VIStk.Widgets`.
 
-- ``Tooltip`` --- hover tooltip bound to any widget
-- ``CollapsibleFrame`` --- frame with a header button that toggles content visibility
-- ``AutocompleteEntry`` --- Entry with a filtered dropdown suggestion list
-- ``DateEntry`` --- date input widget with format validation and optional calendar picker
-  popup
-- Expanded custom frames
-- Additional menu options
-- **Color palette feature** --- recolor default VIStk widgets; accessible throughout user
-  code
+- ``Tooltip`` --- hover tooltip bound to any widget.  ``text`` may be a
+  ``str`` or a zero-arg callable for state-dependent tooltips.  Cleans
+  up its ``after`` callback on widget destroy::
 
-Project Upgrade Tool
+      from VIStk.Widgets import Tooltip
+      Tooltip(my_button, text="Save the current document")
+
+- ``CollapsibleFrame`` --- frame whose body is hidden under a header
+  button.  Pack children into ``cf.body``; ``cf.expanded_var`` is a
+  ``BooleanVar`` callers can bind for shared state::
+
+      cf = CollapsibleFrame(parent, text="Advanced", expanded=False)
+      cf.pack(fill="x")
+      ttk.Entry(cf.body).pack()
+
+- ``AutocompleteEntry`` --- :class:`ttk.Entry` with a filtered dropdown
+  ``Listbox``.  ``values`` is either an iterable or a callable
+  ``(text) -> iterable``.  Keyboard: ``Up``/``Down`` move,
+  ``Return`` accepts, ``Tab`` accepts the first match, ``Escape``
+  closes.  ``match="prefix"`` (default) or ``"contains"``.
+
+- ``DateEntry`` --- :class:`ttk.Entry` + calendar-picker button.  No
+  third-party dependencies.  ``get()`` returns ``date | None``,
+  ``set(date)`` sets programmatically, invalid manual input reverts to
+  the last valid value on focus-out.
+
+Confirmation Dialogs
 --------------------
 
-``VIS upgrade`` --- bring an existing VIS project forward to the installed version of
-VIStk without touching user-written code.
+Drop-in helpers so screens stop reimplementing the
+:mod:`tkinter.messagebox` dance::
 
-What Gets Updated
-~~~~~~~~~~~~~~~~~
+    from VIStk.Widgets import confirm, confirm_discard
 
-Three things are replaced or patched; user screen scripts, ``Screens/``, and ``modules/``
-are never touched:
+    if confirm(parent, title="Delete?", message="Really delete?"):
+        ...
 
-- **``.VIS/Host.py``** --- regenerated from the current ``host.txt`` template; the icon
-  name is read from ``project.json`` before overwriting
-- **``.VIS/Templates/``** --- overwritten from the VIStk install directory; ensures
-  templates match the installed version
-- **``project.json`` schema migration** --- new keys required by newer VIStk versions are
-  added with default values; existing keys are never changed or removed
+    choice = confirm_discard(parent, name="Work Order #12345")
+    if choice == "cancel":
+        return False                # veto on_quit
+    if choice == "save":
+        _save()
+    return True
 
-Compatibility Tracking
-~~~~~~~~~~~~~~~~~~~~~~
+- ``confirm(...) -> bool`` --- two-button Yes/No.
+- ``confirm_discard(...) -> "save" | "discard" | "cancel"`` --- three-
+  button Save / Discard / Cancel.  Closing the window or pressing
+  Escape both return ``"cancel"``.
 
-- ``vis_version`` field added to ``metadata`` at first upgrade (and at project creation
-  going forward)
-- The upgrade tool reads this to determine which migrations have been applied
-- On success the field is updated to the current VIStk version
+Both dialogs are modal, transient over their parent, centred via
+:meth:`WindowGeometry.center_on`, and never flash at the OS default
+position before centring.
 
-Migration Registry
-~~~~~~~~~~~~~~~~~~
+Help Button & Per-Screen ``docs`` URL
+-------------------------------------
 
-Migrations live in ``VIStk/Structures/_Upgrade.py`` as an ordered list of
-``(version_string, step_fn)`` pairs. Each ``step_fn(info: dict)`` receives the raw
-``project.json`` dict and adds or coerces a single field. Upgrading across multiple
-releases applies every migration in order.
+Wiring a top-level Help button is a one-liner from ``.VIS/Host.py``::
 
-``VIS upgrade`` Command
-~~~~~~~~~~~~~~~~~~~~~~~
+    from VIStk.Widgets import HostMenu
+    from VIStk.Objects import open_active_screen_docs
+
+    host_menu.add_project_command("Help", open_active_screen_docs)
+
+``HostMenu.add_project_command(label, command)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+New companion to ``set_project_items``.  Adds a clickable leaf entry
+**directly** on the menubar (not a cascade).  Survives all tab changes;
+removed only by ``clear_project_items``.
+
+Per-screen ``docs`` field
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each entry under ``Screens.<name>`` in ``project.json`` may carry a
+``docs`` URL::
+
+    "Screens": {
+      "Home":     {"...": "...", "docs": null},
+      "Settings": {"...": "...", "docs": "https://example.com/docs/settings"}
+    },
+    "defaults": {
+      "icon": "...",
+      "docs": "https://example.com/docs"
+    }
+
+- ``Screen.docs: str | None`` --- per-screen URL.  ``None`` means
+  "fall through to project default".
+- ``Project.default_docs: str | None`` --- project-level fallback.
+- ``Project.resolve_docs_url(screen_name=None)`` --- runs the fallback
+  chain (screen ``docs`` -> ``default_docs`` -> ``None``).
+- ``Project.active_screen_name`` --- property returning the active tab's
+  ``base_name`` (resolved from the live tab ID introduced in 0.4.7).
+- ``VIStk.Objects.open_active_screen_docs()`` --- looks up the active
+  screen's URL via ``Project().resolve_docs_url()`` and hands it to
+  :func:`webbrowser.open`.  Returns ``True`` on dispatch, ``False`` if
+  no URL was configured.
+
+URLs are passed verbatim to :func:`webbrowser.open`.  No path
+normalisation --- authors write fully-qualified URLs (``https://``,
+``file:///``, etc.).
+
+``VIS docs`` CLI
+~~~~~~~~~~~~~~~~
 
 .. code-block:: text
 
-   VIS upgrade
-   VIS upgrade --dry-run
+   VIS docs set <screen_name> <url>      # set a per-screen URL
+   VIS docs set --default <url>          # set the project default
+   VIS docs clear <screen_name>          # clear a per-screen URL
+   VIS docs clear --default              # clear the project default
+   VIS docs list                         # show all configured URLs
 
-Steps:
+The scaffolder (``VIS add screen``) writes ``"docs": null`` into new
+entries so the field is discoverable.
 
-1. Load ``project.json`` and read ``metadata.vis_version`` (missing treated as ``0.0.0``)
-2. Run all pending schema migrations in version order
-3. Regenerate ``.VIS/Host.py`` from the current template
-4. Overwrite ``.VIS/Templates/`` from the VIStk install
-5. Create any missing directories (``Screens/``, ``modules/``, ``Icons/``, ``Images/``)
-6. Write updated ``project.json`` with ``vis_version`` set to current VIStk version
-7. Print per-step summary
+Popup Flicker Fix --- ``WindowGeometry.center_on``
+--------------------------------------------------
 
-``--dry-run`` prints what would change without writing files.
+The canonical *update + getGeometry + setGeometry* pattern made every
+centred popup flash at the OS default position before jumping to the
+final centred coordinates.  ``center_on`` does the same math inside a
+``withdraw()`` / ``deiconify()`` wrap and uses ``update_idletasks()``
+(layout-only) instead of ``update()`` (which also processes the map
+request)::
+
+    popup = Toplevel(root)
+    # ... build child widgets ...
+    WindowGeometry(popup)
+    popup.WindowGeometry.center_on(root)
+
+Not intended for the root ``Tk()`` window --- ``withdraw()`` on the
+main application window hides it entirely.  ``setGeometry`` itself is
+unchanged.
+
+Out of Scope (deferred)
+-----------------------
+
+- **Project Upgrade Tool** (``VIS upgrade``) --- the originally planned
+  0.5 epic is deferred to 0.7 (which is already titled "Defaults &
+  Navigation, update tools" --- a better fit).
+- **Color palette feature** --- deferred; tracked separately for a
+  later 0.5.x or 0.6.x.
+- **``is_dirty`` auto-generated ``on_quit``** --- the
+  ``confirm_discard`` helper covers the manual case; the auto-wrapper
+  can land later without an API break.

--- a/docs/source/changelog/index.rst
+++ b/docs/source/changelog/index.rst
@@ -13,6 +13,9 @@ Released
    * - Version
      - Title
      - Highlights
+   * - :doc:`0.5`
+     - VIS Widgets, Help Button & Popup Polish
+     - Tooltip / CollapsibleFrame / AutocompleteEntry / DateEntry; ``HostMenu.add_project_command``; per-screen ``docs`` URL + ``VIS docs`` CLI; ``confirm`` / ``confirm_discard``; ``WindowGeometry.center_on``
    * - :doc:`0.4.7`
      - Tab Identity Refactor
      - Every tab, pane, and window gets a stable integer ID; fixes focus restoration after ``SplitView.remove_pane`` with duplicate screen names
@@ -48,9 +51,6 @@ Upcoming
    * - Version
      - Title
      - Planned
-   * - :doc:`0.5`
-     - VIS Widgets & Upgrade Tool
-     - Tooltip, CollapsibleFrame, AutocompleteEntry, DateEntry, ``VIS upgrade``
    * - :doc:`0.6`
      - Application Settings
      - Per-project settings, settings UI, remember window state and open tabs
@@ -71,6 +71,7 @@ Upcoming
    :maxdepth: 1
    :hidden:
 
+   0.5
    0.4.7
    0.4.6
    0.4.4
@@ -80,7 +81,6 @@ Upcoming
    0.4.0
    0.3
    0.4.5
-   0.5
    0.6
    0.7
    0.8

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -305,6 +305,36 @@ Examples:
    VIS group assign Diagnostics Core false
    VIS group list
 
+Manage documentation URLs
+-------------------------
+
+.. code-block:: text
+
+   VIS docs set <screen_name> <url>
+   VIS docs set --default <url>
+   VIS docs clear <screen_name>
+   VIS docs clear --default
+   VIS docs list
+
+Maintains the per-screen ``docs`` field and the project-level
+``defaults.docs`` field in ``project.json``.  Used by the built-in
+:func:`VIStk.Objects.open_active_screen_docs` helper to drive a Help
+button.  URLs are passed verbatim to :func:`webbrowser.open` --- the
+author writes a fully-qualified URL (``https://``, ``file:///``, etc.).
+
+Resolution order at click-time is: active screen's ``docs`` →
+``defaults.docs`` → no-op.  ``--default`` is the project-wide
+fallback.
+
+Examples:
+
+.. code-block:: text
+
+   VIS docs set --default https://example.com/docs
+   VIS docs set Settings   https://example.com/docs/settings
+   VIS docs clear Settings
+   VIS docs list
+
 Stop the Host
 -------------
 

--- a/docs/source/objects.rst
+++ b/docs/source/objects.rst
@@ -419,16 +419,43 @@ Positions and sizes the window.
     # Center an 800x600 window on screen
     root.WindowGeometry.setGeometry(width=800, height=600, align="center")
 
-    # Center a popup on its parent window
-    popup.update()
-    popup.WindowGeometry.getGeometry(True)
-    popup.WindowGeometry.setGeometry(
-        width=popup.winfo_width(),
-        height=popup.winfo_height(),
-        align="center",
-        size_style="window_relative",
-        window_ref=root
-    )
+    # Center a popup on its parent window — flicker-free (0.5.0+)
+    from VIStk.Objects import WindowGeometry
+    WindowGeometry(popup)
+    # ... build all child widgets first ...
+    popup.WindowGeometry.center_on(root)
+
+.. note::
+
+   The pre-0.5.0 multi-call pattern (``popup.update()`` →
+   ``getGeometry(True)`` → ``setGeometry(align="center", ...)``) made the
+   popup briefly visible at the OS default position before jumping to
+   the centred position.  :meth:`center_on` performs the same math
+   inside a ``withdraw()`` / ``deiconify()`` wrap and uses
+   ``update_idletasks()`` (layout-only) instead of ``update()``, so the
+   window is never drawn at its default position.
+
+   Do not call ``center_on`` on the root ``Tk()`` window — ``withdraw()``
+   on the main application window hides it entirely.
+
+center_on (0.5.0)
+~~~~~~~~~~~~~~~~~
+
+``center_on(window_ref)``
+
+Centre this window on *window_ref* without a visible flicker.  Drop-in
+replacement for the multi-call ``update + getGeometry + setGeometry``
+pattern.  Call after all child widgets are built so ``winfo_width`` /
+``winfo_height`` reflect the final size.
+
+.. code-block:: python
+
+    popup = Toplevel(root)
+    Button(popup, text="OK", command=popup.destroy).pack(padx=50, pady=50)
+
+    from VIStk.Objects import WindowGeometry
+    WindowGeometry(popup)
+    popup.WindowGeometry.center_on(root)
 
 stripGeometry
 ~~~~~~~~~~~~~
@@ -636,3 +663,26 @@ with a keyword and a callback function. Flags are passed with ``--`` on the comm
 
 The ``ArgHandler`` on ``Root.Project`` is used internally by the CLI for screen loading with
 arguments.
+
+
+open_active_screen_docs (0.5.0)
+-------------------------------
+
+Reads the active screen from the in-process Host singleton, runs
+``Project.resolve_docs_url()`` (active screen ``docs`` -> project
+``defaults.docs`` -> ``None``), and hands the URL to
+:func:`webbrowser.open`.  Returns ``True`` on dispatch, ``False`` if no
+URL is configured.
+
+Intended to be wired into ``HostMenu.add_project_command`` for a
+one-line top-level Help button:
+
+.. code-block:: python
+
+    from VIStk.Widgets import HostMenu
+    from VIStk.Objects import open_active_screen_docs
+
+    host_menu.add_project_command("Help", open_active_screen_docs)
+
+The URL is taken verbatim from ``project.json``; configure entries via
+``VIS docs set ...`` (see :doc:`cli`).

--- a/docs/source/widgets.rst
+++ b/docs/source/widgets.rst
@@ -590,3 +590,110 @@ WarningWindow
 The window is automatically made modal (``modalize()``), blocking input to the parent until
 dismissed. Use for non-recoverable error messages where the user must acknowledge before
 continuing.
+
+
+----
+
+Tooltip (0.5.0)
+---------------
+
+Hover tooltip bound to any widget. Tkinter has no native tooltip.
+
+.. code-block:: python
+
+    from VIStk.Widgets import Tooltip
+    Tooltip(my_button, text="Save the current document")
+
+``text`` may be a string or a zero-arg callable for state-dependent
+tooltips (re-evaluated each show). Cleans up its ``after`` callback on
+widget destroy.
+
+Keyword args: ``delay_ms=500``, ``wraplength=240``, ``background``,
+``foreground``, ``borderwidth``.
+
+----
+
+CollapsibleFrame (0.5.0)
+------------------------
+
+Frame whose body is hidden under a header button. Pack children into
+``cf.body`` (NOT directly into the frame).
+
+.. code-block:: python
+
+    from VIStk.Widgets import CollapsibleFrame
+    cf = CollapsibleFrame(parent, text="Advanced", expanded=False)
+    cf.pack(fill="x")
+    ttk.Entry(cf.body).pack()
+
+``cf.expanded_var`` is a ``BooleanVar`` callers can bind to share state
+or persist it. Methods: ``expand()``, ``collapse()``, ``toggle()``,
+``set_expanded(bool)``, ``set_text(str)``.
+
+----
+
+AutocompleteEntry (0.5.0)
+-------------------------
+
+``ttk.Entry`` with a filtered dropdown ``Listbox`` of suggestions.
+
+.. code-block:: python
+
+    from VIStk.Widgets import AutocompleteEntry
+    AutocompleteEntry(parent, values=["Boston", "Chicago", ...]).pack()
+
+``values`` may be an iterable or a callable ``(text) -> iterable``
+(use the callable form for dynamic lookups).
+
+Keyword args: ``max_results=8``, ``case_sensitive=False``,
+``match="prefix"`` (or ``"contains"``).
+
+Keyboard: ``Up``/``Down`` move, ``Return`` accepts, ``Tab`` accepts the
+first match, ``Escape`` closes the popup.
+
+----
+
+DateEntry (0.5.0)
+-----------------
+
+Date input with format validation and a calendar-picker popup. No
+third-party dependencies.
+
+.. code-block:: python
+
+    from VIStk.Widgets import DateEntry
+    de = DateEntry(parent, date_format="%Y-%m-%d")
+    de.pack()
+
+``de.get()`` returns ``date | None``. ``de.set(d)`` sets
+programmatically. Invalid manual input reverts to the last valid value
+on focus-out. Keyword args include ``initial: date | None``,
+``on_change: callable``, ``entry_width: int``.
+
+----
+
+confirm / confirm_discard (0.5.0)
+---------------------------------
+
+Drop-in modal helpers so screens stop reimplementing
+:mod:`tkinter.messagebox`.
+
+.. code-block:: python
+
+    from VIStk.Widgets import confirm, confirm_discard
+
+    if confirm(parent, title="Delete?", message="Really delete?"):
+        ...
+
+    choice = confirm_discard(parent, name="Work Order #12345")
+    if choice == "cancel":
+        return False                # veto on_quit
+    if choice == "save":
+        _save()
+    return True
+
+Both dialogs centre on the parent via ``WindowGeometry.center_on``
+(no flicker), are modal/transient, and return plain values
+(``bool`` for ``confirm``; ``"save" | "discard" | "cancel"`` for
+``confirm_discard``). Closing the window or pressing Escape returns
+the negative outcome.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "VIStk"
-version = "0.4.7"
+version = "0.5.0"
 license = {file="LICENSE"}
 dependencies = [
   "pyinstaller",


### PR DESCRIPTION
## Summary

Ships **VIStk 0.5.0**: four general-purpose widgets, a one-line Help-button hookup, standard confirmation dialogs, and a flicker-free popup centring helper.  Closes the two bug reports from PYWOM 0.3.0 (`VIStk-popup-flicker-bug.md`, `VIStk-help-button-support.md`).

## What's in

### VIS Widgets (`VIStk.Widgets`)
- **`Tooltip`** — hover tooltip bound to any widget; ``text`` may be a string or zero-arg callable; cleans up its ``after`` callback on widget destroy
- **`CollapsibleFrame`** — frame whose body is hidden under a header button; pack children into ``cf.body``; ``cf.expanded_var`` is a shared ``BooleanVar``
- **`AutocompleteEntry`** — ``ttk.Entry`` with a filtered ``Listbox`` dropdown; ``values`` may be iterable or callable ``(text) -> iterable``; ``match="prefix"`` (default) or ``"contains"``
- **`DateEntry`** — entry + month-grid calendar-picker popup, no third-party dependencies; invalid manual input reverts on focus-out

### Confirmation dialogs
- ``confirm(parent, *, title, message, yes, no) -> bool``
- ``confirm_discard(parent, *, title, message, name) -> "save" | "discard" | "cancel"``
- Both modal, transient, centred via ``WindowGeometry.center_on`` (no flicker); Escape and window-close return the negative outcome

### Help button & per-screen ``docs`` URL
- ``HostMenu.add_project_command(label, command)`` — leaf menubar entry (not a cascade); persists across tab changes
- ``Screen.docs`` / ``Project.default_docs`` / ``Project.resolve_docs_url()`` — per-screen and project-level documentation URLs in ``project.json``
- ``Project.active_screen_name`` property — resolves the active tab's ``base_name`` via the 0.4.7 tab IDs
- ``VIStk.Objects.open_active_screen_docs()`` — looks up the active screen's URL and hands it **verbatim** to ``webbrowser.open``
- ``VIS docs`` CLI — ``set`` / ``clear`` / ``list`` for per-screen URLs and ``--default``
- ``VIS add screen`` scaffolder writes ``"docs": null`` so the field is discoverable

URLs are passed verbatim to ``webbrowser.open`` — no path normalisation; authors write fully-qualified URLs.

### Popup flicker fix
- ``WindowGeometry.center_on(window_ref)`` performs the canonical centre-on-parent math inside ``withdraw()`` / ``deiconify()`` and uses ``update_idletasks()`` (layout-only) instead of ``update()`` (which also processes the map request); the popup is never drawn at its OS default position
- ``setGeometry`` itself is **unchanged** — root-window callers see no behavioural difference
- ``objects.rst`` "Center a popup on its parent window" example updated; previous multi-call pattern is now called out as legacy

## What's deferred

- **`VIS upgrade`** project upgrade tool — moved from 0.5 → **0.7** ("Defaults & Navigation, update tools" — better fit). The "this kinda seems like a bad idea looking at it now" comment from `changelog.md:754` carried with the move.
- **Color palette** — tracked separately for a later 0.5.x / 0.6.x.
- **`is_dirty` auto-generated `on_quit`** — `confirm_discard` covers the manual case; the auto-wrapper can land later without an API break.

## Test plan

- [x] Imports clean: `from VIStk.Widgets import (Tooltip, CollapsibleFrame, AutocompleteEntry, DateEntry, confirm, confirm_discard)` + `from VIStk.Objects import open_active_screen_docs, WindowGeometry`
- [x] Sphinx build passes with `-W --keep-going` (no warnings)
- [ ] Manual: open a popup with `WindowGeometry.center_on(root)` — no flicker at OS default position
- [ ] Manual: register `host_menu.add_project_command("Help", open_active_screen_docs)` — switch tabs, click Help, correct per-screen URL opens; for screens with `docs=null` falls through to `defaults.docs`
- [ ] Manual: `confirm_discard()` — Save / Discard / Cancel buttons return the right strings; Escape returns `"cancel"`
- [ ] Manual: `Tooltip(button, text="...")` shows after hover delay, hides on `<Leave>` and on click
- [ ] Manual: `AutocompleteEntry` keyboard nav — `Down/Up/Return/Tab/Escape` all behave
- [ ] Manual: `DateEntry` calendar picker selects a date; invalid manual input reverts to last valid; `<` / `>` shift months
- [ ] CLI: `VIS docs set --default <url>`, `VIS docs set <screen> <url>`, `VIS docs list`, `VIS docs clear --default`

## Files

| Group | Files |
|---|---|
| New widgets | `VIStk/Widgets/_Tooltip.py`, `_CollapsibleFrame.py`, `_AutocompleteEntry.py`, `_DateEntry.py`, `_Dialogs.py` |
| New helper | `VIStk/Objects/_Docs.py` |
| Modified | `VIStk/Objects/_WindowGeometry.py` (`center_on`), `Objects/__init__.py`, `Widgets/_HostMenu.py` (`add_project_command`), `Widgets/__init__.py`, `Structures/_Screen.py` (`docs` field + scaffold stub), `Structures/_Project.py` (`docs` editable / `default_docs` / `active_screen_name` / `resolve_docs_url` / `set_default_docs`), `Structures/_VINFO.py` (`docs` reserved), `VIS.py` (`VIS docs` CLI), `pyproject.toml` (0.4.7→0.5.0) |
| Docs | `docs/source/changelog/0.5.rst` (planned→released), `changelog/index.rst`, `cli.rst`, `objects.rst`, `widgets.rst`, `changelog.md` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)