### PR TITLE
Force MSVC for Nuitka builds on Windows

### DIFF
--- a/VIStk/Structures/_Release.py
+++ b/VIStk/Structures/_Release.py
@@ -73,6 +73,19 @@ class Release(Project):
 
     _LINE_WIDTH = 70
 
+    def _compiler_args(self) -> list:
+        """Return Nuitka compiler-selection flags for the current platform.
+
+        Forces MSVC on Windows so Nuitka does not silently fall back to its
+        bundled zig toolchain, which has produced corrupt frozen-bytecode
+        binaries on Python 3.13 (see #35).  On Linux and macOS, Nuitka's
+        auto-detection picks the platform-native compiler (gcc / clang),
+        which is what we want — no flag needed.
+        """
+        if sys.platform == "win32":
+            return ["--msvc=latest"]
+        return []
+
     def _status(self, text: str, newline: bool = False):
         """Overwrite the single progress line. Pads to _LINE_WIDTH."""
         end = "\n" if newline else ""
@@ -146,6 +159,7 @@ class Release(Project):
         mode = "--onefile" if onefile else "--standalone"
 
         parts = [sys.executable, "-m", "nuitka", mode]
+        parts.extend(self._compiler_args())
         parts.append("--follow-imports")
         parts.append("--enable-plugin=tk-inter")
 
@@ -252,6 +266,7 @@ class Release(Project):
                 stem = os.path.splitext(scr.script)[0]
                 parts = [
                     sys.executable, "-m", "nuitka", "--module",
+                    *self._compiler_args(),
                     f"--output-dir={self.location}",
                     "--assume-yes-for-downloads",
                     scr.script,
@@ -274,6 +289,7 @@ class Release(Project):
 
                 parts = [
                     sys.executable, "-m", "nuitka", "--standalone",
+                    *self._compiler_args(),
                     "--enable-plugin=tk-inter",
                     f"--output-dir={self.location}",
                     f"--output-filename={scr.name}.exe",
@@ -353,6 +369,7 @@ class Release(Project):
 
             parts = [
                 sys.executable, "-m", "nuitka", "--module",
+                *self._compiler_args(),
                 f"--output-dir={self.location}",
                 "--assume-yes-for-downloads",
                 pkg_path,


### PR DESCRIPTION
## Summary

Adds a per-platform C compiler selection helper (`_compiler_args`) in `VIStk/Structures/_Release.py`. On Windows the helper returns `["--msvc=latest"]`, ensuring Nuitka uses MSVC instead of falling back to its bundled zig toolchain. On Linux and macOS the helper returns `[]` and Nuitka's auto-detection picks gcc / clang as before.

## Why

Zig 0.15.2 + Nuitka 4.0.8 + Python 3.13 has been producing corrupt frozen bytecode in standalone builds. The compiled apps fail at Python interpreter bootstrap with `Fatal Python error: init_fs_encoding` or `EOFError: marshal data too short`. Tracked as #35.

Verified by rebuilding the same minimal repro under MSVC instead of zig: clean exit, no errors.

```
Nuitka-Scons: Compiled 6 C files using clcache with 0 cache hits and 6 cache misses.
Nuitka: Successfully created '...host_msvc.exe'.
```

## Closes

Closes #83.

May also resolve #35 — currently re-running a test `VIS release` end-to-end to confirm. Will update #35 with results.

## Test plan

- [x] Helper returns `['--msvc=latest']` on Windows, `[]` elsewhere
- [x] Minimal Nuitka standalone repro that crashed under zig now exits cleanly under MSVC
- [ ] Full `VIS release` of PYWOM produces a `WOM.exe` that actually launches (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)