### PR TITLE
Scaffold VIStk.Bindings module (#69)

### DIFF
--- a/VIStk/Bindings/_RecordBinding.py
+++ b/VIStk/Bindings/_RecordBinding.py
@@ -1,0 +1,17 @@
+"""Stub for RecordBinding. Full implementation lands in subsequent issues."""
+
+
+class RecordBinding:
+    """Links a dict-shaped record to a set of bound widgets.
+
+    Tracks per-field state (equal, modified, diverged, read-only), fires
+    callbacks on transitions, and exposes a clean commit path back to the
+    source. Layout is unconstrained — widgets stay where the screen put
+    them, and the binding manages the dict-widget relationship in parallel.
+
+    This is a stub. Storage shape, bind/unbind, evaluate/refresh, callbacks,
+    and commit are added by later issues in the RecordBinding v1 tracker.
+    """
+
+    def __init__(self, record):
+        self._record = record

--- a/VIStk/Bindings/__init__.py
+++ b/VIStk/Bindings/__init__.py
@@ -1,0 +1,10 @@
+"""VIStk.Bindings — state-management primitives for dict-backed UIs.
+
+This namespace is intended to grow. RecordBinding (single-record editor
+support) lands first; ListBinding (collection editor support) is planned
+as a separate v1 in its own tracker.
+"""
+
+from VIStk.Bindings._RecordBinding import RecordBinding
+
+__all__ = ["RecordBinding"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Changelog = "https://github.com/KarlTheKrazyKat/VIS/blob/master/changelog.md"
 [project.scripts]
 VIS = "VIStk.VIS:__main__"
 [tool.setuptools]
-packages = ["VIStk","VIStk.Widgets","VIStk.Objects","VIStk.Structures"]
+packages = ["VIStk","VIStk.Widgets","VIStk.Objects","VIStk.Structures","VIStk.Bindings"]
 ext-modules = []
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
## Summary
- Creates `VIStk/Bindings/` with an `__init__.py` whose docstring notes the namespace is intended to grow (RecordBinding now, ListBinding later)
- Adds a stub `RecordBinding` class in `_RecordBinding.py` so later issues in the v1 tracker have a place to land
- Registers `VIStk.Bindings` in `[tool.setuptools] packages` so the install picks it up

Closes #69. Part of #40.

## Test plan
- [x] `from VIStk.Bindings import RecordBinding` succeeds in editable install

🤖 Generated with [Claude Code](https://claude.com/claude-code)