### PR TITLE
Define RecordBinding internal storage shape (#70)

### DIFF
--- a/VIStk/Bindings/_RecordBinding.py
+++ b/VIStk/Bindings/_RecordBinding.py
@@ -1,17 +1,51 @@
-"""Stub for RecordBinding. Full implementation lands in subsequent issues."""
+"""RecordBinding — links a dict record to a set of Tk widgets."""
 
 
 class RecordBinding:
     """Links a dict-shaped record to a set of bound widgets.
 
     Tracks per-field state (equal, modified, diverged, read-only), fires
-    callbacks on transitions, and exposes a clean commit path back to the
-    source. Layout is unconstrained — widgets stay where the screen put
-    them, and the binding manages the dict-widget relationship in parallel.
+    callbacks on transitions, and exposes a commit path back to the source.
+    Layout is unconstrained — widgets stay where the screen put them, and
+    the binding manages the dict-widget relationship in parallel.
 
-    This is a stub. Storage shape, bind/unbind, evaluate/refresh, callbacks,
-    and commit are added by later issues in the RecordBinding v1 tracker.
+    Storage shape (private — never accessed directly by users; all reads
+    and writes go through binding methods):
+
+        self._record               # the source dict, supplied by the caller
+        self._state = {
+            field_key: {
+                "widget":   <Tk widget>,        # always present
+                "edited":   True,               # absent unless user has edited
+                "readonly": True | callable,    # absent unless field is read-only
+                "getter":   fn(widget) -> value,    # absent unless caller overrode
+                "setter":   fn(widget, value),  # absent unless caller overrode
+            },
+            ...
+        }
+
+    Conventions:
+      - Default entry is one key (`widget`); optional flags are added only
+        when set, so `state.get("edited")` / `state.get("readonly")` are
+        the correct truthiness checks.
+      - Widgets are stored by reference. Callers must `unbind()` before
+        destroying a widget; stale references will raise `TclError` on
+        access.
+      - Fresh widget values are read on demand via the resolved getter —
+        the binding does not cache the widget value.
+
+    Record vs. state coverage:
+      - A record key with no bound widget is carried as-is on the record
+        and ignored by state evaluation.
+      - Binding a key that is not present in the record raises ``KeyError``
+        (decided in #70 to keep `bind()` strict; see #71 acceptance).
+
+    This class is being built incrementally — storage shape lands in #70;
+    bind/unbind/bound_keys in #71; getter/setter dispatch in #72;
+    read-only handling in #73; evaluate/refresh in #74/#75; callbacks
+    in #76; commit in #77.
     """
 
     def __init__(self, record):
         self._record = record
+        self._state = {}


### PR DESCRIPTION
## Summary
- Records the v1 storage shape for `RecordBinding` in the class docstring: a single dict keyed by field name, where each entry is a sub-dict whose only always-present key is `widget`; `edited`, `readonly`, `getter`, and `setter` are absent unless set.
- Widgets are stored by reference (callers must `unbind()` before destroy); fresh values are read on demand via the resolved getter — no caching.
- Records the open decisions: record keys with no bound widget are carried as-is and ignored by state evaluation; binding a key missing from the record will raise `KeyError`.
- Constructor now initializes `self._state = {}`.

No public methods yet — `bind`/`unbind`/`bound_keys` land in #71.

Closes #70. Part of #40.

## Test plan
- [x] `from VIStk.Bindings import RecordBinding; RecordBinding({'a': 1})` succeeds and exposes an empty `_state`

🤖 Generated with [Claude Code](https://claude.com/claude-code)