### PR TITLE
Honor sys.argv in Host startup; cascade standalone windows

### DIFF
--- a/VIStk/Objects/_DetachedWindow.py
+++ b/VIStk/Objects/_DetachedWindow.py
@@ -115,13 +115,15 @@ class DetachedWindow:
         if x_root is not None and y_root is not None:
             self._position_window(x_root, y_root, btn_offset_x, btn_offset_y)
         else:
-            # Default: center on screen
+            # Default: center on screen, with a cascade offset so additional
+            # windows don't sit exactly on top of the first one.
             self.win.geometry("1200x800")
             self.win.update_idletasks()
             sw = self.win.winfo_screenwidth()
             sh = self.win.winfo_screenheight()
-            x = (sw - 1200) // 2
-            y = (sh - 800) // 2
+            cascade = max(0, len(host.detached_windows) - 1) * 30
+            x = (sw - 1200) // 2 + cascade
+            y = (sh - 800) // 2 + cascade
             self.win.geometry(f"+{x}+{y}")
 
     # ── Property shim ─────────────────────────────────────────────────────────

--- a/VIStk/Objects/_Host.py
+++ b/VIStk/Objects/_Host.py
@@ -6,6 +6,7 @@ import os
 import queue
 import sys
 import time
+from pathlib import Path
 from tkinter import Tk
 
 from VIStk.Structures._Project import Project
@@ -64,7 +65,31 @@ class Host:
 
         self._opened_default = False
 
+        # When invoked as ``VIS <Project> <ScreenName>`` the screen name is
+        # forwarded as ``sys.argv[1]`` (or ``argv[0]`` for a frozen Host
+        # exe).  Override the default screen so the requested screen opens
+        # at startup instead of the project default.
+        self._startup_screen: str | None = self._resolve_startup_screen()
+
         _HOST_INSTANCE = self
+
+    def _resolve_startup_screen(self) -> str | None:
+        """Return the screen name passed on the command line, or None.
+
+        Walks ``sys.argv[1:]`` (Python skips ``argv[0]`` = script path in
+        dev mode; frozen builds get the exe path as ``argv[0]``).  Only
+        returns a name that matches a registered screen — unknown args
+        fall through and the project's ``default_screen`` is used.
+        """
+        for arg in sys.argv[1:]:
+            if arg.startswith("-"):
+                continue
+            # Ignore the host script path itself if it appears in argv
+            if arg.endswith(".py") and Path(arg).name.lower() == "host.py":
+                continue
+            if self.Project.getScreen(arg) is not None:
+                return arg
+        return None
 
     # ── Navigation ─────────────────────────────────────────────────────────────
 
@@ -299,13 +324,16 @@ class Host:
     def update(self):
         """Process all pending Tk events for the root and its Toplevels.
 
-        On the first call, opens the default screen so that Host.py has
+        On the first call, opens the startup screen so that Host.py has
         time to configure ``default_menu_setup`` before any window is created.
+        Prefers the screen passed on the command line (``VIS <Project>
+        <ScreenName>``) and falls back to ``Project.default_screen``.
         """
         if not self._opened_default:
             self._opened_default = True
-            if self.Project.default_screen:
-                self.open(self.Project.default_screen)
+            startup = self._startup_screen or self.Project.default_screen
+            if startup:
+                self.open(startup)
         self.root.update()
 
     def quit_host(self):


### PR DESCRIPTION
Closes #92.

## Summary
- `Host.__init__` resolves a startup screen from `sys.argv[1:]` (skipping flags and the host script path) and `Host.update()` prefers it over `Project.default_screen`. `VIS <Project> <ScreenName>` now opens the requested screen instead of always falling through to `default_screen`.
- `DetachedWindow` applies a 30 px cascade offset per existing window so a standalone screen opened from a menu doesn't land exactly on top of the first window (which made it look like the screen had opened "as a tab" in the same window).

## Test plan
- [ ] `VIS WOM AssetManager` from CLI launches AssetManager standalone (tabbed=False) instead of Landing.
- [ ] `VIS WOM` (no screen arg) still opens `default_screen` as before.
- [ ] `VIS WOM Landing` opens Landing as a tab (tabbed=True).
- [ ] `VIS WOM BogusName` falls through to `default_screen` (unknown args ignored).
- [ ] From Landing, clicking Tools → Asset Manager opens a new Toplevel offset 30 px from Landing — clearly a separate window, not a tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)