### PR TITLE
Chromeless DetachedWindow mode for standalone screens

### DIFF
--- a/VIStk/Objects/_DetachedWindow.py
+++ b/VIStk/Objects/_DetachedWindow.py
@@ -28,7 +28,8 @@ class DetachedWindow:
 
     def __init__(self, host, module=None, screen_name: str | None = None,
                  x_root: int | None = None, y_root: int | None = None,
-                 btn_offset_x: int = 0, btn_offset_y: int = 0):
+                 btn_offset_x: int = 0, btn_offset_y: int = 0,
+                 chromeless: bool = False):
         """
         Args:
             host:         The owning ``Host`` instance.
@@ -38,6 +39,11 @@ class DetachedWindow:
             y_root:       Screen y coordinate for positioning (or None for default).
             btn_offset_x: Cursor x offset within the original tab button.
             btn_offset_y: Cursor y offset within the original tab button.
+            chromeless:   When True, hide the tab bar and use the screen's
+                          own icon and name for the window — used by
+                          ``Host._open_standalone`` so non-tabbed screens
+                          appear as plain windows rather than single-tab
+                          windows.
         """
         from VIStk.Objects._Host import _HOST_INSTANCE
 
@@ -46,6 +52,9 @@ class DetachedWindow:
 
         self.host = host
         self._closing = False
+        self.chromeless: bool = chromeless
+        """When True the tab bar is hidden and the window adopts the
+        screen's own icon and name (set by ``Host._open_standalone``)."""
 
         # Toplevel on the hidden root
         self.win = Toplevel(host.root)
@@ -97,8 +106,14 @@ class DetachedWindow:
         self.InfoRow.pack(fill="x", side="bottom")
         host._fps_listeners.append(self.InfoRow.set_fps)
 
-        # Set window icon
-        self._load_icon()
+        # Hide the tab bar before laying out the window for chromeless mode
+        # so the geometry math sees the final content area.
+        if self.chromeless:
+            self.tab_manager.hide_tab_bar()
+
+        # Set window icon — chromeless windows use the screen's icon
+        # rather than the project default.
+        self._load_icon(screen_name if self.chromeless else None)
 
         # Bind focus tracking
         self.win.bind("<FocusIn>", self._on_window_focus)
@@ -177,17 +192,33 @@ class DetachedWindow:
         except Exception:
             pass
 
-    def _load_icon(self):
+    def _load_icon(self, screen_name: str | None = None):
+        """Set the window's taskbar icon.
+
+        When ``screen_name`` is provided and the screen has its own icon,
+        use it; otherwise fall back to the project default icon.  Used by
+        chromeless standalone windows to advertise the screen identity in
+        the taskbar instead of the project identity.
+        """
         try:
             import glob as _glob
             import PIL.Image
             import PIL.ImageTk
-            matches = _glob.glob(
-                self.host.Project.p_icons + "/" + self.host.Project.d_icon + ".*"
-            )
+
+            icon_name: str | None = None
+            if screen_name:
+                scr = self.host.Project.getScreen(screen_name)
+                if scr is not None and scr.icon:
+                    icon_name = scr.icon
+            if icon_name is None:
+                icon_name = self.host.Project.d_icon
+
+            matches = _glob.glob(self.host.Project.p_icons + "/" + icon_name + ".*")
             if matches:
                 img = PIL.Image.open(matches[0]).convert("RGBA").resize((32, 32))
-                self.win.iconphoto(True, PIL.ImageTk.PhotoImage(img))
+                # Hold a reference so Tk doesn't garbage-collect the image.
+                self._icon_ref = PIL.ImageTk.PhotoImage(img)
+                self.win.iconphoto(True, self._icon_ref)
         except Exception:
             pass
 
@@ -232,6 +263,12 @@ class DetachedWindow:
             self._set_title(entry.get("display_name", ""), info)
 
     def _set_title(self, screen: str, info: str = ""):
+        if self.chromeless:
+            # Standalone windows advertise the screen identity directly
+            # rather than the project: screen prefix used for the tabbed
+            # Host shell.
+            self.win.title(f"{screen} \u2014 {info}" if info else screen)
+            return
         base = self.host.Project.title
         if info:
             self.win.title(f"{base}: {screen} \u2014 {info}")

--- a/VIStk/Objects/_Host.py
+++ b/VIStk/Objects/_Host.py
@@ -240,12 +240,18 @@ class Host:
                         base_name=scr.name)
 
     def _open_standalone(self, scr):
-        """Open a standalone (tabbed=False) screen as a new DetachedWindow."""
+        """Open a standalone (tabbed=False) screen as a new DetachedWindow.
+
+        Standalone windows are chromeless: the tab bar is hidden and the
+        window adopts the screen's own icon and name, so a screen with
+        ``tabbed=False`` looks like a plain application window rather than
+        a single-tab Host shell.
+        """
         module = self._import_screen(scr)
         if module is None:
             return
         from VIStk.Objects._DetachedWindow import DetachedWindow
-        dw = DetachedWindow(self, module, scr.name)
+        dw = DetachedWindow(self, module, scr.name, chromeless=True)
 
     def _load_tab_icon(self, scr) -> "PIL.ImageTk.PhotoImage | None":
         if not scr.icon:

--- a/VIStk/Objects/_TabManager.py
+++ b/VIStk/Objects/_TabManager.py
@@ -101,6 +101,7 @@ class TabManager(Frame):
         self.tab_bar.owner = self
 
         self._content = Frame(self)
+        self._tab_bar_hidden: bool = False
         self._repack_layout()
 
         self.tab_bar.on_focus_change = self._on_focus_change
@@ -149,14 +150,22 @@ class TabManager(Frame):
     # ── Layout ─────────────────────────────────────────────────────────────────
 
     def _repack_layout(self):
-        """Pack tab_bar and _content based on the current position setting."""
+        """Pack tab_bar and _content based on the current position setting.
+
+        When ``_tab_bar_hidden`` is set the tab bar is omitted entirely and
+        the content frame fills the pane — used by chromeless standalone
+        DetachedWindows that host a single non-tabbed screen.
+        """
         self.tab_bar.pack_forget()
         self._content.pack_forget()
+        if not self._tab_bar_hidden:
+            if self._position in ("top", "bottom"):
+                self.tab_bar.pack(side=self._position, fill="x")
+            else:  # left or right
+                self.tab_bar.pack(side=self._position, fill="y")
         if self._position in ("top", "bottom"):
-            self.tab_bar.pack(side=self._position, fill="x")
             self._content.pack(side="top", fill="both", expand=True)
-        else:  # left or right
-            self.tab_bar.pack(side=self._position, fill="y")
+        else:
             self._content.pack(side="left", fill="both", expand=True)
 
     def set_position(self, position: str):
@@ -164,6 +173,18 @@ class TabManager(Frame):
         self._position = position
         self.tab_bar.set_position(position)
         self._repack_layout()
+
+    def hide_tab_bar(self):
+        """Hide the tab bar — used for chromeless standalone windows."""
+        if not self._tab_bar_hidden:
+            self._tab_bar_hidden = True
+            self._repack_layout()
+
+    def show_tab_bar(self):
+        """Restore the tab bar after :meth:`hide_tab_bar`."""
+        if self._tab_bar_hidden:
+            self._tab_bar_hidden = False
+            self._repack_layout()
 
     # ── Identity helpers ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #96, #97, and #99.

## Summary
- `TabManager` gains `hide_tab_bar()` / `show_tab_bar()` and a `_tab_bar_hidden` flag honored by `_repack_layout()`. When hidden, the content frame fills the pane; public tab APIs are unchanged.
- `SplitView` gains `lock()` / `unlock()` and a `_locked` flag. `detect_drop_zone()` returns None when locked (cross-window drag detection skips it naturally) and `split()` raises `RuntimeError` to defend programmatic callers.
- `DetachedWindow` accepts `chromeless: bool`. When True it hides the primary TabManager's tab bar, locks its SplitView, loads the active screen's own icon for the taskbar (falling back to the project default when the screen has none), and titles the window after the screen instead of `<Project>: <Screen>`.
- `Host._open_standalone` passes `chromeless=True`. Tabbed-screen routing is untouched.

## Why
Before this change, `tabbed: false` screens (e.g. AssetManager) opened in a `DetachedWindow` that still had the WOM icon, a one-tab strip, and the title `WOM: AssetManager`. Visually indistinguishable from a tab in the existing Host shell. Without the SplitView lock, dragging a tab from another window into the chromeless window would also re-introduce a tab strip.

## Test plan
- [ ] `VIS WOM AssetManager` opens a window with the AssetManager icon, no tab bar, title `AssetManager`.
- [ ] Tools → Asset Manager from the Landing window opens the same chromeless window (offset from Landing).
- [ ] Dragging a tab from the Landing window into the chromeless AssetManager window finds no drop zone (no blue overlay appears).
- [ ] Closing the chromeless window destroys the AssetManager tab and removes the window from the Host as before.
- [ ] `VIS WOM` still opens Landing as a tabbed Host shell with the project icon and title.
- [ ] Tabbed screens (Landing, WorderEditor, etc.) still show the tab bar, accept splits, and use `WOM: <Screen>` title.

## Out of scope (follow-up)
- Hiding the menu bar in chromeless mode so the screen owns its full menu surface.