### PR TITLE
Lock SplitView in chromeless DetachedWindows

### DIFF
--- a/VIStk/Objects/_DetachedWindow.py
+++ b/VIStk/Objects/_DetachedWindow.py
@@ -107,9 +107,13 @@ class DetachedWindow:
         host._fps_listeners.append(self.InfoRow.set_fps)
 
         # Hide the tab bar before laying out the window for chromeless mode
-        # so the geometry math sees the final content area.
+        # so the geometry math sees the final content area.  Lock the
+        # SplitView so the chromeless window stays single-pane — splits
+        # would re-introduce a tab strip in the new pane and defeat the
+        # standalone presentation.
         if self.chromeless:
             self.tab_manager.hide_tab_bar()
+            self._split_view.lock()
 
         # Set window icon — chromeless windows use the screen's icon
         # rather than the project default.

--- a/VIStk/Widgets/_SplitView.py
+++ b/VIStk/Widgets/_SplitView.py
@@ -46,6 +46,12 @@ class SplitView(Frame):
         self._drop_overlay: Toplevel | None = None
         self._drop_zone_info: tuple | None = None  # (pane, direction)
 
+        # When locked, refuse all splits (right-click and drag-drop) so a
+        # chromeless DetachedWindow can stay single-pane.  Cross-window drag
+        # detection in :meth:`detect_any_drop_zone` skips locked views via
+        # :meth:`detect_drop_zone` returning None.
+        self._locked: bool = False
+
         SplitView._registry.append(self)
 
     def destroy(self):
@@ -240,13 +246,27 @@ class SplitView(Frame):
 
     _DROP_ZONE_RATIO = 0.25  # outer 25 % of the content area triggers a zone
 
+    def lock(self):
+        """Refuse all splits and drag-drop merges into this view.
+
+        Used by chromeless DetachedWindows so a standalone screen stays
+        single-pane.  Idempotent.
+        """
+        self._locked = True
+
+    def unlock(self):
+        """Re-enable splits and drag-drop merges."""
+        self._locked = False
+
     def detect_drop_zone(self, x_root: int, y_root: int):
         """Check if screen coords fall in a split drop zone.
 
         Returns ``(pane, direction)`` where *direction* is one of
         ``"right"``, ``"left"``, ``"down"``, ``"up"``; or ``None`` if the
-        cursor is not in any zone.
+        cursor is not in any zone.  Locked views always return ``None``.
         """
+        if self._locked:
+            return None
         for pane in self.all_tab_managers():
             content = pane._content
             try:
@@ -370,7 +390,14 @@ class SplitView(Frame):
         Returns:
             ``(left_pane, right_pane)`` — the two new ``TabManager`` instances.
             *left_pane* contains all tabs that were in *pane* minus *exclude*.
+
+        Raises:
+            RuntimeError: when the SplitView is locked (chromeless mode).
         """
+        if self._locked:
+            raise RuntimeError(
+                "SplitView is locked (chromeless window) — splits not permitted."
+            )
         from VIStk.Objects._TabManager import TabManager
 
         orient = "horizontal" if direction == "right" else "vertical"


### PR DESCRIPTION
Closes #99. Follow-up to #98.

## Summary
- `SplitView` gains `lock()` / `unlock()` and a `_locked` flag, default False.
- `detect_drop_zone()` returns None when locked, so cross-window drag detection in `detect_any_drop_zone` skips the view naturally — a tab dragged from another window can't be dropped into a locked view.
- `split()` raises `RuntimeError` when locked, defending against programmatic callers.
- `DetachedWindow.__init__` calls `self._split_view.lock()` when `chromeless=True` so a standalone screen stays single-pane.

## Why
`hide_tab_bar()` from #98 hides the *strip* per pane but doesn't say anything about whether the *window* should accept more panes. Without the lock, dragging a tab from another window into a chromeless window would create a second pane (with its own visible tab bar) and break the standalone presentation.

## Test plan
- [ ] Drag a tab from the Landing window onto the chromeless AssetManager window — no blue drop overlay appears, drop is rejected.
- [ ] Tabbed Host windows still accept drops and right-click splits as before.
- [ ] `SplitView.split()` on a locked view raises `RuntimeError("SplitView is locked …")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)