### PR TITLE
Per-screen host_menubar opt-out in chromeless windows

### DIFF
--- a/VIStk/Objects/_DetachedWindow.py
+++ b/VIStk/Objects/_DetachedWindow.py
@@ -110,10 +110,17 @@ class DetachedWindow:
         # so the geometry math sees the final content area.  Lock the
         # SplitView so the chromeless window stays single-pane — splits
         # would re-introduce a tab strip in the new pane and defeat the
-        # standalone presentation.
+        # standalone presentation.  When the active screen opts out of the
+        # host menubar via ``host_menubar=False`` in project.json, detach
+        # the menubar from the window — the HostMenu object stays alive so
+        # screen code that calls ``set_screen_items`` etc. still works.
         if self.chromeless:
             self.tab_manager.hide_tab_bar()
             self._split_view.lock()
+            if screen_name:
+                _scr = host.Project.getScreen(screen_name)
+                if _scr is not None and not _scr.host_menubar:
+                    self.HostMenu.detach()
 
         # Set window icon — chromeless windows use the screen's icon
         # rather than the project default.

--- a/VIStk/Structures/_Project.py
+++ b/VIStk/Structures/_Project.py
@@ -6,10 +6,10 @@ from VIStk.Structures._Screen import *
 
 _EDITABLE_SCREEN_ATTRS = {
     "script", "release", "icon", "desc", "tabbed",
-    "single_instance", "version", "current",
+    "single_instance", "host_menubar", "version", "current",
     "requires", "suggests", "warn_message", "docs",
 }
-_BOOL_ATTRS      = {"release", "tabbed", "single_instance"}
+_BOOL_ATTRS      = {"release", "tabbed", "single_instance", "host_menubar"}
 _NULLABLE_ATTRS  = {"icon", "current", "warn_message", "docs"}
 _VERSION_ATTRS   = {"version"}
 _LIST_ATTRS      = {"requires", "suggests"}
@@ -279,6 +279,7 @@ class Project(VINFO):
                 "desc":            lambda: setattr(scr, "desc", coerced),
                 "tabbed":          lambda: setattr(scr, "tabbed", coerced),
                 "single_instance": lambda: setattr(scr, "single_instance", coerced),
+                "host_menubar":    lambda: setattr(scr, "host_menubar", coerced),
                 "version":         lambda: setattr(scr, "s_version", Version(coerced)),
                 "current":         lambda: setattr(scr, "current", coerced),
                 "requires":        lambda: setattr(scr, "requires", list(coerced)),

--- a/VIStk/Structures/_Screen.py
+++ b/VIStk/Structures/_Screen.py
@@ -83,6 +83,15 @@ class Screen(VINFO):
         """Whether this screen opens as a tab inside the Host window"""
         self.single_instance: bool = info[self.title]["Screens"][self.name].get("single_instance", False)
         """When True only one instance of this screen may be open at a time"""
+        self.host_menubar: bool = info[self.title]["Screens"][self.name].get("host_menubar", True)
+        """Whether the host File/Edit/View/Tools menubar should render when
+        this screen owns a chromeless ``DetachedWindow``.
+
+        Default ``True``.  Set to ``False`` for standalone screens that
+        already draw their own menubar inside their content (e.g.
+        AssetManager).  Ignored for tabbed screens — the host menubar is
+        window-level and shared across all tabs in a tabbed Host window.
+        """
         self.requires: list[str] = list(scr_data.get("requires", []))
         """Names of screens that must be installed alongside this one (hard dependency)."""
         self.suggests: list[str] = list(scr_data.get("suggests", []))

--- a/VIStk/Widgets/_HostMenu.py
+++ b/VIStk/Widgets/_HostMenu.py
@@ -71,6 +71,23 @@ class HostMenu:
         self._parent.config(menu=self.menubar)
         self._build_base()
 
+    def detach(self):
+        """Remove this menu bar from the parent window without destroying it.
+
+        Counterpart to :meth:`attach`.  The underlying ``Menu`` widget and
+        all its cascades / state stay alive, so screen code that calls
+        ``set_screen_items`` / ``restore_defaults`` continues to work — the
+        mutations just aren't visible on the window.
+
+        Used by chromeless ``DetachedWindow`` instances whose active screen
+        opts out of the host menubar via ``host_menubar=False`` in
+        ``project.json``.
+        """
+        try:
+            self._parent.config(menu="")
+        except Exception:
+            pass
+
     def set_project_items(self, items: list[dict], label: str = "Project"):
         """Add one cascade to the project layer.
 


### PR DESCRIPTION
Closes #107.

## Summary
- New `Screen.host_menubar` field (default `true`) read from `project.json`. Setting it to `false` suppresses the host File/Edit/View/Tools menubar when the screen owns a chromeless DetachedWindow.
- `HostMenu` gains `detach()` — counterpart to `attach()` — that calls `self._parent.config(menu="")`. The underlying `Menu` widget stays alive so `set_screen_items` / `restore_defaults` and similar calls continue to work without crashing.
- `DetachedWindow.__init__` calls `HostMenu.detach()` when `chromeless=True` and the active screen has `host_menubar=False`.
- `host_menubar` is editable via `vis edit <screen> host_menubar true|false` (added to `_EDITABLE_SCREEN_ATTRS` and `_BOOL_ATTRS`).

## Why scope to chromeless

The host menubar is window-level, but tabs in a tabbed Host window are per-screen. Honouring `host_menubar=False` on a tabbed screen would mean toggling the strip on every tab change (jarring) or hiding it for the whole window (steals from sibling tabs). Easier to gate on chromeless and revisit if a real per-tab use case appears.

## Migration

No changes required. Existing screens default to `host_menubar: true` and behave exactly as before.

To suppress the menubar for a standalone screen that draws its own (e.g. AssetManager):

```json
"AssetManager": {
    "tabbed": false,
    "host_menubar": false,
    ...
}
```

## Test plan
- [ ] AssetManager with `tabbed: false, host_menubar: false` opens a chromeless window with no host menubar.
- [ ] AssetManager with `tabbed: false` (host_menubar omitted/true) still shows the host menubar.
- [ ] Tabbed screens are unaffected by the value of `host_menubar` (host menubar always renders).
- [ ] `vis edit AssetManager host_menubar false` flips the field in project.json and updates the in-memory Screen.
- [ ] A chromeless screen that calls `Project().menubar.set_screen_items(...)` or similar after detach still mutates without crashing (the calls are silent no-ops visually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)