### PR TITLE
Pre-flight check for patchelf on Linux before VIS release

### DIFF
--- a/VIStk/Structures/_Release.py
+++ b/VIStk/Structures/_Release.py
@@ -222,6 +222,34 @@ class Release(Project):
             flush=True,
         )
 
+    def _check_patchelf(self) -> bool:
+        """Verify ``patchelf`` is installed when releasing on Linux.
+
+        Nuitka's standalone mode on Linux requires ``patchelf`` to rewrite
+        ``RPATH`` / ``RUNPATH`` on every bundled ``.so``.  Without it Nuitka
+        aborts mid-build (often after many compilations have already
+        finished), so fail fast here with an actionable hint — same
+        treatment as the compiler check (#86).
+
+        macOS uses ``install_name_tool`` from the Xcode CLI tools; Windows
+        PE binaries import by base name and need nothing analogous.
+
+        Returns ``True`` when the prerequisite is satisfied (or when the
+        platform doesn't need it), ``False`` (with a printed message)
+        otherwise.
+        """
+        if sys.platform != "linux":
+            return True
+        if shutil.which("patchelf") is None:
+            print(
+                "\nVIS release requires patchelf on Linux.\n"
+                "Install via your package manager, e.g.:\n"
+                "    sudo apt install patchelf\n",
+                flush=True,
+            )
+            return False
+        return True
+
     def _status(self, text: str, newline: bool = False):
         """Overwrite the single progress line. Pads to _LINE_WIDTH."""
         end = "\n" if newline else ""
@@ -630,10 +658,12 @@ class Release(Project):
 
     def release(self):
         """Releases a version of your project"""
-        #Pre-flight: compiler + required Python tools.
+        #Pre-flight: compiler + patchelf (Linux) + required Python tools.
         #Fail fast with actionable messages before any version bumps,
         #user prompts, or compilation work.
         if not self._check_compiler():
+            return
+        if not self._check_patchelf():
             return
         if not self._check_tools():
             return


### PR DESCRIPTION
Closes #110.

## Summary
- New `_check_patchelf()` parallel to `_check_compiler()`. Linux-only: aborts `VIS release` with an actionable apt-install hint when `patchelf` is missing. No-op on Windows / macOS.
- `release()` runs the check immediately after the compiler check, before any pip / version-bump / compilation work.

## Why
Nuitka's standalone mode on Linux requires `patchelf` to rewrite `RPATH` / `RUNPATH` on every bundled `.so`. Without it Nuitka aborts mid-build (often after 16+ compilations have already finished). Same pattern as #86 for the compiler.

## Hint output
```
VIS release requires patchelf on Linux.
Install via your package manager, e.g.:
    sudo apt install patchelf
```

## Test plan
- [ ] `VIS release` on a Linux box without patchelf installed prints the hint and exits 0 before any compilation.
- [ ] `VIS release` after `sudo apt install patchelf` proceeds normally.
- [ ] Windows / macOS releases unaffected (check returns True without running `which`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)