### PR TITLE
Implement bind/unbind/bound_keys on RecordBinding (#71)

### DIFF
--- a/VIStk/Bindings/_RecordBinding.py
+++ b/VIStk/Bindings/_RecordBinding.py
@@ -49,3 +49,70 @@ class RecordBinding:
     def __init__(self, record):
         self._record = record
         self._state = {}
+
+    # ------------------------------------------------------------------ #
+    # Registration                                                        #
+    # ------------------------------------------------------------------ #
+
+    def bind(self, key, widget, readonly=False, getter=None, setter=None,
+             replace=False):
+        """Register *widget* against record *key*.
+
+        Parameters
+        ----------
+        key : hashable
+            Field name in the bound record.
+        widget : Tk widget
+            Stored by reference; the caller must ``unbind()`` before
+            destroying the widget.
+        readonly : bool or callable, optional
+            ``True`` locks the field; a callable ``(record) -> bool`` is
+            re-evaluated on every refresh. Falsy values are not stored.
+            (Behavioural application of read-only state lands in #73.)
+        getter, setter : callable, optional
+            Override the default widget value access. Defaults are
+            registered per widget class in #72; until that lands the
+            initial widget population (#71 acceptance item 2) is
+            deferred — callers that need it immediately should pass an
+            explicit ``setter`` and call it themselves.
+        replace : bool, optional
+            If a widget is already bound to *key*, ``replace=True`` swaps
+            it in; otherwise ``ValueError`` is raised.
+
+        Raises
+        ------
+        KeyError
+            If *key* is not present in the bound record.
+        ValueError
+            If *key* is already bound and *replace* is False.
+        """
+        if key not in self._record:
+            raise KeyError(
+                f"cannot bind {key!r}: key not in record "
+                f"(call bind() only for fields the record actually carries)"
+            )
+        if key in self._state and not replace:
+            raise ValueError(
+                f"key {key!r} is already bound; pass replace=True to override"
+            )
+
+        entry = {"widget": widget}
+        if readonly:
+            entry["readonly"] = readonly
+        if getter is not None:
+            entry["getter"] = getter
+        if setter is not None:
+            entry["setter"] = setter
+        self._state[key] = entry
+
+    def unbind(self, key):
+        """Remove the registration for *key*.
+
+        Idempotent — silent if *key* was not bound. The widget itself is
+        left untouched (not destroyed, not cleared).
+        """
+        self._state.pop(key, None)
+
+    def bound_keys(self):
+        """Return the set of currently bound field keys."""
+        return set(self._state)


### PR DESCRIPTION
## Summary
Implements 5 of 6 acceptance bullets on #71 — the primary user-facing registration API for `RecordBinding`:

- `bind(key, widget, readonly=False, getter=None, setter=None, replace=False)` builds a sparse-flag entry per the #70 storage shape.
- Missing record key → `KeyError` with a clear message.
- Re-binding an already-bound key → `ValueError` unless `replace=True`. Chose the explicit flag over a warning so accidental re-binds fail loudly.
- `unbind(key)` is idempotent — silent if absent; widget is left untouched (not destroyed, not cleared).
- `bound_keys()` returns `set(self._state)`.

**Deferred to #72:** acceptance item 2 ("on bind, the widget is populated with the current record value via the resolved setter"). It depends on the default getter/setter dispatch table that lands with #72; once that's in, the line `self._set(key, self._record[key])` slots into `bind()` and item 2 closes.

Refs #71. Part of #40.

## Test plan
- [x] Smoke-tested all paths against real `tk.Entry`/`tk.Label` widgets:
  - happy-path bind for plain, readonly bool, readonly callable, getter override
  - missing record key raises `KeyError`
  - already-bound key raises `ValueError`; `replace=True` swaps the widget in
  - `unbind` is idempotent on bound and unbound keys
  - sparse-flag entries omit absent keys (`'edited' not in state['name']`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)