### PR TITLE
Widget value access protocol on RecordBinding (#72)

### DIFF
--- a/VIStk/Bindings/_RecordBinding.py
+++ b/VIStk/Bindings/_RecordBinding.py
@@ -1,5 +1,103 @@
 """RecordBinding — links a dict record to a set of Tk widgets."""
 
+import tkinter as tk
+from tkinter import ttk
+
+
+# --------------------------------------------------------------------- #
+# Module-level widget value access registry                              #
+# --------------------------------------------------------------------- #
+# Maps widget class -> callable. Getters take ``(widget)`` and return
+# the displayed value; setters take ``(widget, value)`` and write it.
+# Resolution at bind/get/set time:
+#   explicit override on bind()  ->  registered default for the widget's
+#   class (MRO walk, so subclasses like AutocompleteEntry inherit the
+#   Entry handler)  ->  ``getattr(widget, "get"/"set")`` if callable
+#   ->  TypeError pointing at register_widget().
+
+_DEFAULT_GETTERS: dict = {}
+_DEFAULT_SETTERS: dict = {}
+
+
+def _set_entry(widget, value):
+    """Setter for Entry-shaped widgets, robust to readonly/disabled state."""
+    state = widget.cget("state")
+    restore = state in ("readonly", "disabled")
+    if restore:
+        widget.config(state="normal")
+    try:
+        widget.delete(0, "end")
+        widget.insert(0, "" if value is None else str(value))
+    finally:
+        if restore:
+            widget.config(state=state)
+
+
+def _set_text(widget, value):
+    """Setter for tk.Text — full content replacement."""
+    widget.delete("1.0", "end")
+    widget.insert("1.0", "" if value is None else str(value))
+
+
+# Stock tkinter widgets — register at import time. Most field-shaped
+# widgets work out of the box; users only need register_widget() for
+# custom widgets that don't expose .get()/.set().
+_DEFAULT_GETTERS[tk.Entry] = lambda w: w.get()
+_DEFAULT_SETTERS[tk.Entry] = _set_entry
+_DEFAULT_GETTERS[ttk.Entry] = lambda w: w.get()
+_DEFAULT_SETTERS[ttk.Entry] = _set_entry
+
+_DEFAULT_GETTERS[tk.Label] = lambda w: w.cget("text")
+_DEFAULT_SETTERS[tk.Label] = lambda w, v: w.config(text="" if v is None else v)
+_DEFAULT_GETTERS[ttk.Label] = lambda w: w.cget("text")
+_DEFAULT_SETTERS[ttk.Label] = lambda w, v: w.config(text="" if v is None else v)
+
+_DEFAULT_GETTERS[tk.Text] = lambda w: w.get("1.0", "end-1c")
+_DEFAULT_SETTERS[tk.Text] = _set_text
+
+_DEFAULT_GETTERS[ttk.Combobox] = lambda w: w.get()
+_DEFAULT_SETTERS[ttk.Combobox] = lambda w, v: w.set("" if v is None else v)
+
+# tk.Spinbox is Entry-shaped (no native .set()); ttk.Spinbox does
+# expose .set() but delete/insert works on both, so reuse _set_entry.
+_DEFAULT_GETTERS[tk.Spinbox] = lambda w: w.get()
+_DEFAULT_SETTERS[tk.Spinbox] = _set_entry
+if hasattr(ttk, "Spinbox"):
+    _DEFAULT_GETTERS[ttk.Spinbox] = lambda w: w.get()
+    _DEFAULT_SETTERS[ttk.Spinbox] = _set_entry
+
+
+def _resolve_getter(widget, override=None):
+    if override is not None:
+        return override
+    for cls in type(widget).__mro__:
+        if cls in _DEFAULT_GETTERS:
+            return _DEFAULT_GETTERS[cls]
+    fn = getattr(widget, "get", None)
+    if callable(fn):
+        return lambda w, _f=fn: _f()
+    raise TypeError(
+        f"no getter for widget of type {type(widget).__name__!r}: pass "
+        f"getter= to bind() or register one via "
+        f"RecordBinding.register_widget()"
+    )
+
+
+def _resolve_setter(widget, override=None):
+    if override is not None:
+        return override
+    for cls in type(widget).__mro__:
+        if cls in _DEFAULT_SETTERS:
+            return _DEFAULT_SETTERS[cls]
+    fn = getattr(widget, "set", None)
+    if callable(fn):
+        return lambda w, v, _f=fn: _f(v)
+    raise TypeError(
+        f"no setter for widget of type {type(widget).__name__!r}: pass "
+        f"setter= to bind() or register one via "
+        f"RecordBinding.register_widget()"
+    )
+
 
 class RecordBinding:
     """Links a dict-shaped record to a set of bound widgets.
@@ -71,10 +169,12 @@ class RecordBinding:
             (Behavioural application of read-only state lands in #73.)
         getter, setter : callable, optional
             Override the default widget value access. Defaults are
-            registered per widget class in #72; until that lands the
-            initial widget population (#71 acceptance item 2) is
-            deferred — callers that need it immediately should pass an
-            explicit ``setter`` and call it themselves.
+            registered per widget class at module load (Entry, Label,
+            Text, Combobox, Spinbox, ttk equivalents) and discovered via
+            an MRO walk so subclasses inherit the parent class handler.
+            For widgets without a registered handler, the binding falls
+            back to ``widget.get`` / ``widget.set`` and finally raises a
+            ``TypeError`` pointing at ``register_widget()``.
         replace : bool, optional
             If a widget is already bound to *key*, ``replace=True`` swaps
             it in; otherwise ``ValueError`` is raised.
@@ -105,6 +205,12 @@ class RecordBinding:
             entry["setter"] = setter
         self._state[key] = entry
 
+        # Populate the widget with the current record value (closes #71
+        # acceptance item 2). Resolution failure surfaces here, on bind,
+        # rather than later from evaluate() — which is when the caller
+        # can still pass setter= or call register_widget().
+        self._set(key, self._record[key])
+
     def unbind(self, key):
         """Remove the registration for *key*.
 
@@ -116,3 +222,44 @@ class RecordBinding:
     def bound_keys(self):
         """Return the set of currently bound field keys."""
         return set(self._state)
+
+    # ------------------------------------------------------------------ #
+    # Widget value access (private)                                       #
+    # ------------------------------------------------------------------ #
+
+    def _get(self, key):
+        """Read the current displayed value from the bound widget."""
+        s = self._state[key]
+        return _resolve_getter(s["widget"], s.get("getter"))(s["widget"])
+
+    def _set(self, key, value):
+        """Write *value* into the bound widget."""
+        s = self._state[key]
+        _resolve_setter(s["widget"], s.get("setter"))(s["widget"], value)
+
+    # ------------------------------------------------------------------ #
+    # Default registry (module-level, extensible)                         #
+    # ------------------------------------------------------------------ #
+
+    @classmethod
+    def register_widget(cls, widget_class, getter=None, setter=None):
+        """Register default getter/setter for *widget_class*.
+
+        Pass either or both. The registry is module-level — registering
+        once affects every ``RecordBinding`` instance, current and
+        future. Resolution walks ``type(widget).__mro__``, so registering
+        a base class is enough to cover its subclasses.
+
+        Parameters
+        ----------
+        widget_class : type
+            The widget class to register handlers for.
+        getter : callable, optional
+            Signature ``(widget) -> value``.
+        setter : callable, optional
+            Signature ``(widget, value) -> None``.
+        """
+        if getter is not None:
+            _DEFAULT_GETTERS[widget_class] = getter
+        if setter is not None:
+            _DEFAULT_SETTERS[widget_class] = setter


### PR DESCRIPTION
## Summary
Adds the getter/setter dispatch the binding uses to read and write widget values, and uses it to close the last open acceptance bullet on #71 (populate-on-bind).

- Module-level `_DEFAULT_GETTERS` / `_DEFAULT_SETTERS` seeded at import with handlers for `tk`/`ttk` `Entry`, `Label`, `Text`, `Combobox`, and `Spinbox`. `tk.Spinbox` is Entry-shaped (no native `.set`), so it shares `_set_entry` — which temporarily un-readonlies the widget for the write and restores state afterwards.
- `_resolve_getter` / `_resolve_setter` walk `type(widget).__mro__` so subclasses inherit their parent class handler — `AutocompleteEntry` (subclass of `ttk.Entry`) gets the Entry handler for free. Final fallback wraps `getattr(widget, "get"/"set")` (which is how `DateEntry` works), then raises `TypeError` pointing at `register_widget()`.
- `RecordBinding._get` / `._set` are the private methods the rest of the binding will use (evaluate/refresh/commit in #74-#77).
- `RecordBinding.register_widget(WidgetClass, getter=..., setter=...)` is the public extension hook for custom widgets.
- `bind()` now calls `self._set(key, self._record[key])` after registering — populates the widget with the current record value. Closes the deferred acceptance item from #71.

Closes #71. Closes #72. Part of #40.

## Test plan
Smoke-tested every path against real Tk widgets:
- [x] tk/ttk `Entry`, `Label`, `Combobox`, `Spinbox`, `Text` populate correctly on bind and round-trip via `_get`
- [x] explicit `getter=`/`setter=` overrides take priority over registry
- [x] `AutocompleteEntry` (ttk.Entry subclass) hits the Entry handler via MRO
- [x] `DateEntry` (Frame with own `.get`/`.set`) hits the `getattr` fallback
- [x] Unsupported widget raises `TypeError` mentioning the class name and `register_widget`
- [x] `RecordBinding.register_widget(...)` extension hook works
- [x] Setter on a readonly Entry temporarily un-readonlies for the write and restores state

🤖 Generated with [Claude Code](https://claude.com/claude-code)