### PR TITLE
Uninstaller: recursive cleanup via deferred batch

### DIFF
--- a/VIStk/Structures/Uninstaller.py
+++ b/VIStk/Structures/Uninstaller.py
@@ -254,15 +254,58 @@ def _kill_app_processes(location):
 
 
 def schedule_self_delete():
-    """Schedule deletion of this executable after exit (Windows only)."""
+    """Schedule recursive cleanup of the install directory after exit.
+
+    PyInstaller --onefile holds an exclusive lock on the user-facing
+    Uninstaller.exe while it is running, so the exe (and any DLLs that
+    happen to be locked at the moment of the call) cannot be removed
+    by the in-process Python cleanup.  We hand the recursive removal
+    off to a detached cmd batch that waits for this process to fully
+    exit, then sweeps the install root.
+
+    ``Settings/`` is intentionally preserved (see #34 — users always
+    expect their per-machine config to survive an uninstall).  If the
+    install directory becomes empty after Settings/ also goes (e.g.
+    Settings/ doesn't exist), the parent dir is removed too.
+    """
     if sys.platform != "win32" or not getattr(sys, "frozen", False):
         return
-    exe = sys.executable
-    # Use cmd to wait briefly then delete
+
+    install_dir = os.path.dirname(sys.executable)
+
+    # Build a self-deleting .bat in %TEMP% that does the recursive
+    # cleanup.  Quoting through subprocess.Popen with chained '&'
+    # commands gets hairy fast — a real .bat file is easier to read.
+    import tempfile
+    fd, bat_path = tempfile.mkstemp(suffix="_uninstall.bat")
+    bat_lines = [
+        "@echo off",
+        # Wait for the uninstaller process to fully exit.  ping is
+        # the standard "wait N seconds" idiom that ships on every
+        # Windows since XP without needing PowerShell.
+        "ping 127.0.0.1 -n 3 >NUL",
+        f'cd /d "{install_dir}" 2>NUL',
+        "if errorlevel 1 exit /b 1",
+        # Recursively remove every directory at the install root
+        # except Settings/.
+        'for /D %%i in (*) do if /I not "%%i"=="Settings" rmdir /s /q "%%i" 2>NUL',
+        # Remove every loose file at the install root.  At this point
+        # the uninstaller exe is no longer running and so unlocked.
+        'for %%i in (*) do del /f /q "%%i" 2>NUL',
+        # Step out before trying to remove the install dir itself.
+        'cd /d "%TEMP%"',
+        # rmdir without /s only succeeds when the dir is empty, so
+        # this is a no-op if Settings/ survived.  That's intentional.
+        f'rmdir /q "{install_dir}" 2>NUL',
+        # Self-delete this .bat.  The (goto) 2>NUL trick is the
+        # standard idiom for a Windows batch file that removes itself.
+        '(goto) 2>NUL & del "%~f0"',
+    ]
+    with os.fdopen(fd, "w", newline="\r\n") as f:
+        f.write("\r\n".join(bat_lines) + "\r\n")
+
     subprocess.Popen(
-        f'cmd /c ping 127.0.0.1 -n 3 > NUL & del /f /q "{exe}" & '
-        f'rmdir /q "{os.path.dirname(exe)}" 2>NUL',
-        shell=True,
+        ["cmd", "/c", bat_path],
         creationflags=subprocess.CREATE_NO_WINDOW
             if hasattr(subprocess, "CREATE_NO_WINDOW") else 0,
     )
@@ -533,11 +576,19 @@ def _do_uninstall():
 
     remove_installed_files(filtered_log, location, progress_fn=_gui_progress)
 
+    # Schedule deferred recursive cleanup as soon as the in-process
+    # work is done (#34).  Firing here -- not on Close click -- means
+    # cleanup runs even if the user dismisses the window with the X
+    # button or kills the process.  The deferred .bat waits 3s before
+    # sweeping, which is plenty of time for the GUI to close after
+    # whatever button the user chose.
+    if all_selected:
+        schedule_self_delete()
+
     progress_label.config(text="Uninstallation complete.")
     progress_bar.config(value=100)
     close_btn.state(["!disabled"])
-    close_btn.config(command=lambda: (schedule_self_delete() if all_selected else None, root.destroy())
-                     if all_selected else root.destroy())
+    close_btn.config(command=root.destroy)
     root.update()
 
 


### PR DESCRIPTION
## Summary

Fixes #34. The uninstaller used to exit cleanly but leave the install directory nearly intact — only the user-facing `Uninstaller.exe` itself was actually removed, and the framework folders / Nuitka exes / Python runtime DLLs all stayed on disk.

## Root cause

Two compounding bugs in `VIStk/Structures/Uninstaller.py`:

1. **`schedule_self_delete()` only swept the uninstaller exe.** The deferred cmd was:
   ```cmd
   ping 127.0.0.1 -n 3 > /dev/null & del /f /q "<uninstaller>" & rmdir /q "<install_dir>" 2>/dev/null
   ```
   `rmdir` without `/s` succeeds only on empty directories. So whenever the in-process Python cleanup missed anything (locked files, missing entries in `install_log.json.directories`, swallowed exceptions), the install dir survived.

2. **The deferred cleanup was wired to the Close button's callback.** Dismissing the GUI with the X button — or anything other than clicking Close — bypassed `schedule_self_delete()` entirely.

## Fix

- **`schedule_self_delete()`** now writes a self-deleting `.bat` to `%TEMP%` that:
  1. Waits 3 s for the uninstaller process to fully exit (`ping 127.0.0.1 -n 3`).
  2. `cd`s into the install dir.
  3. `rmdir /s /q` every subdirectory except `Settings/`.
  4. `del /f /q` every loose file (the user-facing exe is now unlocked).
  5. `rmdir` (non-recursive) the install dir itself — succeeds when `Settings/` is absent, harmless no-op when present.
  6. Self-deletes the `.bat` (standard `(goto) 2>/dev/null & del "%~f0"` idiom).

- **GUI fires `schedule_self_delete()` immediately after `remove_installed_files()` returns**, regardless of how the user dismisses the window. The 3 s `.bat` delay is plenty for the window to close before the sweep starts.

- **Close button** reverts to a plain `root.destroy`.

QUIET-mode flow is unchanged — it already called `schedule_self_delete()` directly before `sys.exit(0)`.

## Why `Settings/` is preserved

Per discussion in #34 — users expect per-machine config (window geometry, recently-opened items, app preferences) to survive an uninstall + reinstall cycle. The exclusion is hard-coded; if a project ever needs a "wipe everything" mode, that's a follow-up flag.

## Closes

Closes #34.

## Test plan

- [x] Syntax-check the patched file (`python -c "import ast; ast.parse(...)"`) — clean.
- [ ] Build a fresh `VIS release`, install, then run the uninstaller from the Start menu / Add-Remove Programs / `Uninstaller.exe` directly. Verify the install directory is fully gone (or contains only `Settings/`).
- [ ] Repeat with the GUI dismissed via the X button (not Close) — should still clean up.
- [ ] QUIET mode: `Uninstaller.exe --Quiet` — should print progress and clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)