### PR TITLE
Fail loudly when release build produces no output

### DIFF
--- a/VIStk/Structures/_Release.py
+++ b/VIStk/Structures/_Release.py
@@ -443,6 +443,14 @@ class Release(Project):
                 # Move .pyd to Screens/ with clean name (strip cpython tag)
                 import glob as _glob
                 built_pyds = _glob.glob(f"{self.build_dir}{stem}*.pyd")
+                if not built_pyds:
+                    self._status(
+                        f"  [{self._step}/{self._total_steps}] {self._category} "
+                        f"{self._cat_index}/{self._cat_count} - {scr.name} FAILED — "
+                        f"no .pyd produced at {self.build_dir}{stem}*.pyd",
+                        newline=True,
+                    )
+                    return False
                 for bp in built_pyds:
                     shutil.move(bp, f"{final}/Screens/{stem}.pyd")
 
@@ -484,18 +492,44 @@ class Release(Project):
                 # Merge standalone build into the shared dist folder
                 scr_stem = os.path.splitext(scr.script)[0]
                 scr_dist = f"{self.build_dir}{scr_stem}.dist"
-                if exists(scr_dist):
-                    _skip = {'.build', '_internal', '__pycache__'}
-                    for dirpath, dirs, files in os.walk(scr_dist):
-                        dirs[:] = [d for d in dirs if d not in _skip and not d.endswith('.build')]
-                        rel = os.path.relpath(dirpath, scr_dist)
-                        dest = os.path.join(final, rel)
-                        os.makedirs(dest, exist_ok=True)
-                        for f in files:
-                            dest_file = os.path.join(dest, f)
-                            if not exists(dest_file):
-                                shutil.copy2(os.path.join(dirpath, f), dest_file)
-                    shutil.rmtree(scr_dist)
+                if not exists(scr_dist):
+                    # Nuitka exited 0 but produced no .dist — fail loudly
+                    # rather than silently shipping an installer without
+                    # this screen's exe (issue #115).
+                    try:
+                        siblings = sorted(os.listdir(self.build_dir))
+                    except OSError:
+                        siblings = []
+                    self._status(
+                        f"  [{self._step}/{self._total_steps}] {self._category} "
+                        f"{self._cat_index}/{self._cat_count} - {scr.name} FAILED — "
+                        f"expected {scr_dist} not produced (build_dir contains: "
+                        f"{', '.join(siblings) or 'nothing'})",
+                        newline=True,
+                    )
+                    return False
+                _skip = {'.build', '_internal', '__pycache__'}
+                for dirpath, dirs, files in os.walk(scr_dist):
+                    dirs[:] = [d for d in dirs if d not in _skip and not d.endswith('.build')]
+                    rel = os.path.relpath(dirpath, scr_dist)
+                    dest = os.path.join(final, rel)
+                    os.makedirs(dest, exist_ok=True)
+                    for f in files:
+                        dest_file = os.path.join(dest, f)
+                        if not exists(dest_file):
+                            shutil.copy2(os.path.join(dirpath, f), dest_file)
+                shutil.rmtree(scr_dist)
+                # Post-condition: the screen's exe must be at final root
+                exe_ext = ".exe" if sys.platform == "win32" else ""
+                expected_exe = os.path.join(final, f"{scr.name}{exe_ext}")
+                if not exists(expected_exe):
+                    self._status(
+                        f"  [{self._step}/{self._total_steps}] {self._category} "
+                        f"{self._cat_index}/{self._cat_count} - {scr.name} FAILED — "
+                        f"expected {expected_exe} after merge but it is missing",
+                        newline=True,
+                    )
+                    return False
 
         return True
 
@@ -547,6 +581,14 @@ class Release(Project):
             # Move .pyd to Shared/ directory — strip cpython tag
             import glob as _glob
             built_pyds = _glob.glob(f"{self.build_dir}{pkg}*.pyd")
+            if not built_pyds:
+                self._status(
+                    f"  [{self._step}/{self._total_steps}] {self._category} "
+                    f"{self._cat_index}/{self._cat_count} - {pkg} FAILED — "
+                    f"no .pyd produced at {self.build_dir}{pkg}*.pyd",
+                    newline=True,
+                )
+                return False
             for bp in built_pyds:
                 shutil.move(bp, f"{shared_dir}/{pkg}.pyd")
 
@@ -762,6 +804,29 @@ class Release(Project):
         # No PyInstaller launcher shim, no .Runtime/ indirection — see #105.
         pendix = self.title if self.flag == "" else f"{self.title}-{self.flag}"
         final = f"{self.location}{pendix}"
+
+        # Post-condition: every standalone screen we said we'd build must
+        # have its exe present at the install root.  Catches silent
+        # failures further upstream (issue #115) so we don't ship a
+        # binaries.zip that's missing the screens the user paid to compile.
+        exe_ext = ".exe" if sys.platform == "win32" else ""
+        missing_exes = []
+        for scr in self.screenlist:
+            if not self._screen_in_subset(scr):
+                continue
+            if scr.tabbed or not scr.release:
+                continue
+            expected = os.path.join(final, f"{scr.name}{exe_ext}")
+            if not exists(expected):
+                missing_exes.append(scr.name)
+        if missing_exes:
+            print(
+                f"\nRelease FAILED: standalone exe(s) missing from {final}: "
+                f"{', '.join(missing_exes)}.  Inspect the build output above "
+                f"for the underlying failure.",
+                flush=True,
+            )
+            return
 
         #%Installer & Uninstaller Generation
         binaries_zip = f"{self.location}binaries.zip"


### PR DESCRIPTION
Closes #115.

## Summary
- `compile_screens(mode="exe")`: when `_run_nuitka` returns True but the expected `<scr>.dist` is not produced, fail loudly with the expected path and the contents of `build_dir`. After a successful merge, also assert the screen's `.exe` landed at the install root.
- `compile_screens(mode="pyd")`: same loud-failure for the `<stem>*.pyd` glob.
- `compile_shared`: same loud-failure for the shared-package `.pyd` glob.
- `release()`: post-`clean()` audit that every `tabbed: false, release: true` screen has its `.exe` at the install root before `binaries.zip` is created.

## Why
Running `VIS release -f Windows` on PYWOM produced an installer that only installed `WOM.exe`. The standalone screen exes (AssetManager, FloorView) were silently dropped because Nuitka exited 0 but didn't leave a `.dist` folder at the path the merge expected. The silent `if exists(scr_dist)` guard skipped the copy, the loop continued, and the user got a broken installer with no warning.

This PR doesn't fix the underlying Nuitka-output-missing problem — it converts the silent skip into a loud failure that prints the missing path and surrounding `build_dir` contents, plus an audit that catches any later step that removes the exe from the install root. The next release attempt will surface concrete diagnostics so we can actually fix the root cause.

## Test plan
- [ ] `VIS release -f Windows` on PYWOM either produces an installer with AssetManager.exe + FloorView.exe + WOM.exe, or aborts with a message naming the missing path. No more silent successes.
- [ ] On a successful release, the printed audit message confirms each standalone screen's exe was located at the install root.
- [ ] Tabbed-only releases (no `release: true` standalone screens) still complete normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)