### PR TITLE
Read-only handling on RecordBinding (#73)

### DIFF
--- a/VIStk/Bindings/_RecordBinding.py
+++ b/VIStk/Bindings/_RecordBinding.py
@@ -18,10 +18,22 @@ from tkinter import ttk
 _DEFAULT_GETTERS: dict = {}
 _DEFAULT_SETTERS: dict = {}
 
+# Read-only state setters. Maps widget class -> ``fn(widget, locked: bool)``.
+# Resolution mirrors value setters but with one important difference: the
+# fallback for unknown widgets is a silent no-op, not an error. Read-only
+# is advisory UI — the binding still enforces "can't enter modified" for
+# any field whose policy says it's locked, regardless of whether the
+# widget visually grays out.
+_DEFAULT_READONLY_SETTERS: dict = {}
+
 
 def _set_entry(widget, value):
-    """Setter for Entry-shaped widgets, robust to readonly/disabled state."""
-    state = widget.cget("state")
+    """Setter for Entry-shaped widgets, robust to readonly/disabled state.
+
+    Note: ``widget.cget("state")`` returns a Tcl_Obj for ttk widgets and a
+    plain string for tk widgets — coerce via ``str()`` before comparing.
+    """
+    state = str(widget.cget("state"))
     restore = state in ("readonly", "disabled")
     if restore:
         widget.config(state="normal")
@@ -67,6 +79,29 @@ if hasattr(ttk, "Spinbox"):
     _DEFAULT_SETTERS[ttk.Spinbox] = _set_entry
 
 
+def _readonly_via_state(widget, locked):
+    """Toggle widgets that support state="readonly" / "normal"."""
+    widget.config(state="readonly" if locked else "normal")
+
+
+def _readonly_text(widget, locked):
+    """tk.Text has no "readonly" state — use disabled / normal."""
+    widget.config(state="disabled" if locked else "normal")
+
+
+# Read-only handlers for the same widget classes that have value setters.
+# Label is intentionally a no-op: it's already non-editable.
+_DEFAULT_READONLY_SETTERS[tk.Entry]      = _readonly_via_state
+_DEFAULT_READONLY_SETTERS[ttk.Entry]     = _readonly_via_state
+_DEFAULT_READONLY_SETTERS[ttk.Combobox]  = _readonly_via_state
+_DEFAULT_READONLY_SETTERS[tk.Spinbox]    = _readonly_via_state
+if hasattr(ttk, "Spinbox"):
+    _DEFAULT_READONLY_SETTERS[ttk.Spinbox] = _readonly_via_state
+_DEFAULT_READONLY_SETTERS[tk.Text]       = _readonly_text
+_DEFAULT_READONLY_SETTERS[tk.Label]      = lambda w, locked: None
+_DEFAULT_READONLY_SETTERS[ttk.Label]     = lambda w, locked: None
+
+
 def _resolve_getter(widget, override=None):
     if override is not None:
         return override
@@ -97,6 +132,24 @@ def _resolve_setter(widget, override=None):
         f"setter= to bind() or register one via "
         f"RecordBinding.register_widget()"
     )
+
+
+def _resolve_readonly_setter(widget):
+    """Resolve the read-only setter for *widget*.
+
+    Walks ``type(widget).__mro__``; falls back to ``widget.set_readonly``
+    if defined; otherwise returns a silent no-op. Unlike the value
+    setter, missing read-only support is **not** an error — the binding
+    still honors the policy in evaluate/refresh, the widget just doesn't
+    visually gray out.
+    """
+    for cls in type(widget).__mro__:
+        if cls in _DEFAULT_READONLY_SETTERS:
+            return _DEFAULT_READONLY_SETTERS[cls]
+    fn = getattr(widget, "set_readonly", None)
+    if callable(fn):
+        return lambda w, locked, _f=fn: _f(locked)
+    return lambda w, locked: None
 
 
 class RecordBinding:
@@ -138,6 +191,25 @@ class RecordBinding:
       - Binding a key that is not present in the record raises ``KeyError``
         (decided in #70 to keep `bind()` strict; see #71 acceptance).
 
+    Read-only semantics (#73):
+      - The ``readonly`` argument to ``bind()`` is the *policy*, stored
+        sparsely on the entry (``True`` or a callable; absent for False).
+        Callables have signature ``(record_dict) -> bool`` and are
+        re-evaluated against the current record on every ``refresh()``.
+      - The widget's visual state is applied separately via the readonly
+        setter registry (Entry/Combobox/Spinbox use ``state="readonly"``,
+        Text uses ``state="disabled"``, Label is a no-op). Custom widgets
+        with no registered handler silently no-op — read-only is advisory
+        UI, not load-bearing; the binding still honors the policy below
+        regardless of whether the widget grays out.
+      - A field whose policy flips True->False between refreshes unlocks
+        for editing on the next ``refresh()``; flipping False->True locks
+        on the same boundary.
+      - A read-only field cannot enter the modified state. ``evaluate()``
+        skips read-only keys for edit detection (cheap per-frame); but
+        ``refresh()`` still compares widget vs. record value for them, so
+        external mutations to read-only fields are detected as divergence.
+
     This class is being built incrementally — storage shape lands in #70;
     bind/unbind/bound_keys in #71; getter/setter dispatch in #72;
     read-only handling in #73; evaluate/refresh in #74/#75; callbacks
@@ -164,9 +236,12 @@ class RecordBinding:
             Stored by reference; the caller must ``unbind()`` before
             destroying the widget.
         readonly : bool or callable, optional
-            ``True`` locks the field; a callable ``(record) -> bool`` is
-            re-evaluated on every refresh. Falsy values are not stored.
-            (Behavioural application of read-only state lands in #73.)
+            ``True`` locks the field; a callable ``(record_dict) -> bool``
+            is re-evaluated on every refresh. Falsy values are not
+            stored. The widget's visual state is applied immediately via
+            the readonly setter registry; the policy is also honored by
+            ``evaluate()`` (skipped for edit detection) and ``refresh()``
+            (still checked for divergence).
         getter, setter : callable, optional
             Override the default widget value access. Defaults are
             registered per widget class at module load (Entry, Label,
@@ -211,6 +286,11 @@ class RecordBinding:
         # can still pass setter= or call register_widget().
         self._set(key, self._record[key])
 
+        # Apply read-only state (#73). Done after the value write so the
+        # final widget state matches the policy, regardless of whether
+        # the widget started in normal/readonly/disabled.
+        self._apply_readonly(key)
+
     def unbind(self, key):
         """Remove the registration for *key*.
 
@@ -238,14 +318,42 @@ class RecordBinding:
         _resolve_setter(s["widget"], s.get("setter"))(s["widget"], value)
 
     # ------------------------------------------------------------------ #
+    # Read-only handling (#73)                                            #
+    # ------------------------------------------------------------------ #
+
+    def _is_readonly(self, key):
+        """Resolve the read-only policy for *key* against the current record.
+
+        Returns ``True`` if the field is currently locked. Callable
+        policies are invoked with the current ``self._record``.
+        """
+        policy = self._state[key].get("readonly")
+        if policy is None:
+            return False
+        if callable(policy):
+            return bool(policy(self._record))
+        return bool(policy)
+
+    def _apply_readonly(self, key):
+        """Apply the resolved read-only state to the bound widget.
+
+        Called from ``bind()`` and (per #75) from ``refresh()`` so a
+        callable policy whose verdict has changed takes effect on the
+        next refresh.
+        """
+        widget = self._state[key]["widget"]
+        _resolve_readonly_setter(widget)(widget, self._is_readonly(key))
+
+    # ------------------------------------------------------------------ #
     # Default registry (module-level, extensible)                         #
     # ------------------------------------------------------------------ #
 
     @classmethod
-    def register_widget(cls, widget_class, getter=None, setter=None):
-        """Register default getter/setter for *widget_class*.
+    def register_widget(cls, widget_class, getter=None, setter=None,
+                        readonly_setter=None):
+        """Register default handlers for *widget_class*.
 
-        Pass either or both. The registry is module-level — registering
+        Pass any combination. The registry is module-level — registering
         once affects every ``RecordBinding`` instance, current and
         future. Resolution walks ``type(widget).__mro__``, so registering
         a base class is enough to cover its subclasses.
@@ -258,8 +366,15 @@ class RecordBinding:
             Signature ``(widget) -> value``.
         setter : callable, optional
             Signature ``(widget, value) -> None``.
+        readonly_setter : callable, optional
+            Signature ``(widget, locked: bool) -> None``. Applies visual
+            read-only state. If omitted for a widget class with no
+            registered handler, read-only is silently a visual no-op
+            (the binding still honors the policy in evaluate/refresh).
         """
         if getter is not None:
             _DEFAULT_GETTERS[widget_class] = getter
         if setter is not None:
             _DEFAULT_SETTERS[widget_class] = setter
+        if readonly_setter is not None:
+            _DEFAULT_READONLY_SETTERS[widget_class] = readonly_setter


### PR DESCRIPTION
## Summary
Adds the read-only policy storage and visual-state application that #74 (`evaluate`) and #75 (`refresh`) will lean on.

- **Sparse policy storage.** `state["readonly"]` is absent for `False`, `True` for boolean, or the callable as-is for `(record) -> bool` predicates. `_is_readonly(key)` resolves the policy against the current record on demand — no state duplication.
- **Module-level readonly setter registry** parallel to the value setter registry. Stock handlers cover Entry/Combobox/Spinbox via `state="readonly"`, Text via `state="disabled"` (no readonly state on Text), and Label as an explicit no-op (already non-editable). Resolution walks the MRO; missing handlers fall back to `getattr(widget, "set_readonly")` and finally to a silent no-op — read-only is advisory UI, not load-bearing.
- **`bind()` calls `_apply_readonly(key)`** after value population so the widget ends in the correct state regardless of starting state.
- **`register_widget()` extended** with a `readonly_setter=` kwarg.
- **Documented constraints for #74/#75:** True->False flip unlocks at the next `refresh()`; `evaluate()` skips read-only keys for edit detection but `refresh()` still detects divergence on them.

**Drive-by fix:** `_set_entry` was comparing `cget("state")` directly to strings, which silently failed for ttk widgets (returns `Tcl_Obj`). Coerce via `str()` before comparing.

Closes #73. Part of #40.

## Test plan
Smoke-tested every path against real Tk widgets:
- [x] `readonly=True` on tk/ttk Entry, Combobox, Spinbox locks via `state="readonly"`
- [x] `readonly=True` on tk.Text locks via `state="disabled"`
- [x] `readonly=True` on tk.Label is a no-op (text still populated)
- [x] `readonly=False` doesn't store anything (sparse) and leaves widget normal
- [x] Callable `(record) -> bool` policy stored as-is and re-evaluated as record changes
- [x] Frame with no readonly handler silently no-ops; policy still honored
- [x] Custom widget with `set_readonly()` method picked up via getattr fallback
- [x] `register_widget(readonly_setter=...)` extension hook
- [x] `bind()` applies correct state regardless of widget's prior state
- [x] ttk Entry already in readonly state: `_set_entry`'s `Tcl_Obj` fix lets the value populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)