### PR TITLE
Import local changelog hand-edits

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,9 +42,18 @@ New
 Updated
 
 - Menu: buttons highlight on hover
--     : can provide screennames instead of paths
+- 
+
+```
+: can provide screennames instead of paths
+```
+
 - MenuItem(Button): now menuitem is the button and text autosizes
--                 : will use screen.load() if provided with screenname
+- 
+
+```
+            : will use screen.load() if provided with screenname
+```
 
 ---
 
@@ -57,7 +66,7 @@ Updated
 - When `Host.open()` is called for a screen with `single_instance: true` that is already open anywhere (main window or any `DetachedWindow`), the existing tab is focused rather than creating a new instance; the `(2)` / `(3)` suffix logic is skipped entirely
 - Set via `VIS edit <screenname> single_instance true`
 
-**`VIS rename <screenname> <newname>`**
+`VIS rename <screenname> <newname>`
 
 - Validates `newname` against the same rules as `VIS add screen` (no reserved words, valid identifier, no conflicts)
 - Renames the screen's key in `project.json → Screens`
@@ -69,7 +78,7 @@ Updated
 - Runs `stitch` automatically after rename so import blocks are regenerated clean
 - `rename` and `Rename` added to `_RESERVED_VIS_COMMANDS`
 
-**`VIS edit <screenname> <attribute> <value>`**
+`VIS edit <screenname> <attribute> <value>`
 
 - Directly sets any attribute in the screen's `project.json` subdictionary
 - Editable attributes: `script`, `release`, `icon`, `desc`, `tabbed`, `single_instance`, `version`, `current`
@@ -96,7 +105,7 @@ The `HostMenu` menubar is now structured as three permanent layers in order:
 2. **Project layer** — app-wide cascades defined once in `Host.py` at startup; never cleared during normal use
 3. **Screen layer** — cascades contributed by the active tab via `configure_menu(menubar)`; all cleared automatically on tab deactivation
 
-**`HostMenu` changes**
+`HostMenu` **changes**
 
 - `set_project_items(items, label)` — new method; appends one cascade to the project layer; calling it multiple times adds multiple project-layer cascades in order; these persist across all tab changes
 - `clear_project_items()` — removes all project-layer cascades; intended for teardown, not normal use
@@ -108,29 +117,33 @@ The `HostMenu` menubar is now structured as three permanent layers in order:
 
 Project-wide items are set once in `Host.py` after `Host()` is created:
 
-    host = Host()
-    host.HostMenu.set_project_items([
-        {"label": "File", "items": [
-            {"label": "New",  "command": new_fn},
-            {"separator": True},
-            {"label": "Exit", "command": host.quit_host},
-        ]},
-        {"label": "Help", "items": [
-            {"label": "About", "command": about_fn},
-        ]},
-    ], label="File")
+```
+host = Host()
+host.HostMenu.set_project_items([
+    {"label": "File", "items": [
+        {"label": "New",  "command": new_fn},
+        {"separator": True},
+        {"label": "Exit", "command": host.quit_host},
+    ]},
+    {"label": "Help", "items": [
+        {"label": "About", "command": about_fn},
+    ]},
+], label="File")
+```
 
 Screen-specific items are contributed as before via `configure_menu`:
 
-    def configure_menu(menubar):
-        menubar.set_screen_items([
-            {"label": "Export PDF", "command": export_pdf},
-            {"label": "Print",      "command": print_fn},
-        ], label="Work Orders")
+```
+def configure_menu(menubar):
+    menubar.set_screen_items([
+        {"label": "Export PDF", "command": export_pdf},
+        {"label": "Print",      "command": print_fn},
+    ], label="Work Orders")
+```
 
 A screen that needs more than one cascade on the menu bar calls `set_screen_items` multiple times in one `configure_menu` call — all are cleared together on deactivation.
 
-**`VIS add screen <name> menu <menuname>`**
+`VIS add screen <name> menu <menuname>`
 
 - `Screen.addMenu(menu)` implemented (was a stub)
 - Creates `modules/<screen>/m_<menuname>.py` containing a `configure_menu(menubar)` function pre-filled with a commented cascade template
@@ -173,7 +186,7 @@ A screen that needs more than one cascade on the menu bar calls `set_screen_item
 
 **Auto-launch after install**
 
-- Optional "Launch [AppName]" checkbox on the completion page, checked by default
+- Optional "Launch \[AppName\]" checkbox on the completion page, checked by default
 - On Close, launches the default screen binary (which starts the Host if not running); falls back to the first installed screen if the default was not selected
 - Checkbox only appears when at least one screen was installed
 
@@ -186,8 +199,6 @@ A screen that needs more than one cascade on the menu bar calls `set_screen_item
 ---
 
 ### 0.4.0 Host and Tabbed Screens
-
-#### Completed
 
 **Host object**
 
@@ -344,7 +355,7 @@ A screen that needs more than one cascade on the menu bar calls `set_screen_item
 
 **InfoRow app version display**
 
-- The project version (from `project.json` `metadata.version`) is shown on the right of the InfoRow alongside the FPS counter in the form `v1.0.0  |  30.0 fps`
+- The project version (from `project.json` `metadata.version`) is shown on the right of the InfoRow alongside the FPS counter in the form `v1.0.0 | 30.0 fps`
 
 **Bug fix: tab insertion positions**
 
@@ -380,7 +391,7 @@ A screen that needs more than one cascade on the menu bar calls `set_screen_item
 - Per-screen characteristic info string: `"project: screen — info"` format; also shown in the tab button label as `"screen — info"`
 - Same title pattern applied to `DetachedWindow`
 
-**Per-screen characteristic info (`set_tab_info`)**
+**Per-screen characteristic info (**`set_tab_info`**)**
 
 - `TabManager.set_tab_info(name, text_or_var)` — set a characteristic string for a tab; accepts a plain `str` or a `tkinter.StringVar` (traced automatically; tab label and window title update live)
 - Module-level `set_tab_info(frame, text_or_var)` helper exported from `VIStk.Objects` — call from inside `setup(parent)` using the received `parent` frame
@@ -396,7 +407,7 @@ A screen that needs more than one cascade on the menu bar calls `set_screen_item
 
 ### 0.4.3 Split Layouts, Installer Uninstaller & Install Log
 
-Allow the Host window's content area to be divided into multiple panes, each with its own `TabBar` and `TabManager`, with a draggable sash between panes.  Two screens can then run side by side (or stacked) in a single window without spawning a `DetachedWindow`.
+Allow the Host window's content area to be divided into multiple panes, each with its own `TabBar` and `TabManager`, with a draggable sash between panes. Two screens can then run side by side (or stacked) in a single window without spawning a `DetachedWindow`.
 
 **Uninstaller**
 
@@ -411,7 +422,7 @@ Allow the Host window's content area to be divided into multiple panes, each wit
 - The log is used by the uninstaller and by the update-in-place installer (0.4.4) to determine what is currently installed
 - Quiet mode (`--Quiet`) also writes the install log
 
-**`SplitView` widget**
+`SplitView` **widget**
 
 - New widget (`VIStk/Widgets/_SplitView.py`) that replaces the single `TabManager` in `Host`
 - Each instance wraps a `ttk.PanedWindow` (orient = `"horizontal"` or `"vertical"`) and holds two child slots; each slot is either a `TabManager` (leaf) or a nested `SplitView` (branch)
@@ -476,7 +487,7 @@ The existing "Open in new window" entry is unchanged; it still creates a `Detach
 - `HostMenu.clear_screen_items()` restores the original shared cascade menus
 - `HostMenu.reset_overrides()` called on tab deactivate to prevent stale overrides from carrying over
 
-**`Host` changes**
+`Host` **changes**
 
 - `self.TabManager` replaced by `self._split_view: SplitView`; `TabManager` property returns `self._split_view.focused_pane` as a drop-in for the single-pane API
 - `Host.open()` opens new tabs into the globally focused pane (may be Host or DetachedWindow)
@@ -485,14 +496,14 @@ The existing "Open in new window" entry is unchanged; it still creates a `Detach
 - `Host._on_tab_detach` and `Host._on_tab_popout` resolved through the originating pane's `TabManager`
 - `Host._on_tab_split` handles within-pane splits, cross-pane splits, center drops, and cross-window drops
 
-**`DetachedWindow` changes**
+`DetachedWindow` **changes**
 
 - Content area now wrapped in `SplitView` (was bare `TabManager`) — supports splits, drop zones, and focus tracking
 - `tab_manager` property returns `self._split_view.focused_pane`
 - `_on_tab_split` mirrors Host's implementation (within-window, cross-window, and center drops)
 - `_on_close` iterates all panes in the SplitView tree, not just the focused pane
 
-**`TabBar` changes**
+`TabBar` **changes**
 
 - `on_tab_split: callable | None` — new callback `(name: str, direction: str, target_pane=None)`
 - `on_drag_zone: callable | None` — new callback for drag-to-split zone detection during motion events
@@ -543,8 +554,7 @@ The existing "Open in new window" entry is unchanged; it still creates a `Detach
 
 ### 0.4.5 Installer Polish *(absorbed into 0.4.6)*
 
-Implemented in-tree but not released as its own PyPI version. These
-features ship as part of 0.4.6.
+Implemented in-tree but not released as its own PyPI version. These features ship as part of 0.4.6.
 
 **License / EULA page**
 
@@ -571,82 +581,47 @@ features ship as part of 0.4.6.
 
 **Screen groups**
 
-- `project.json` gains a `release_info.groups` block; each group maps a
-  label to a `{description, screens: {screen_name: {default: bool}}}` entry.
-- A screen belongs to at most one group; ungrouped screens continue to
-  render as individual checkboxes (current behaviour preserved).
-- Group rows in the installer render as a checkbox + label + right-side
-  expand arrow. Expanding a group reveals indented child checkboxes with
-  per-screen version labels.
-- Clicking a group master toggles every child on or every child off
-  (defaults only set the initial state). Tri-state (`alternate`) is shown
-  when a group has a mix of checked/unchecked children; likewise for the
-  top-level "All".
-- Groups with no standalone-screen child actually present in the archive
-  are hidden from the GUI — tabbed screens ship with the Host and cannot
-  be toggled independently at install time.
+- `project.json` gains a `release_info.groups` block; each group maps a label to a `{description, screens: {screen_name: {default: bool}}}` entry.
+- A screen belongs to at most one group; ungrouped screens continue to render as individual checkboxes (current behaviour preserved).
+- Group rows in the installer render as a checkbox + label + right-side expand arrow. Expanding a group reveals indented child checkboxes with per-screen version labels.
+- Clicking a group master toggles every child on or every child off (defaults only set the initial state). Tri-state (`alternate`) is shown when a group has a mix of checked/unchecked children; likewise for the top-level "All".
+- Groups with no standalone-screen child actually present in the archive are hidden from the GUI — tabbed screens ship with the Host and cannot be toggled independently at install time.
 
 **Per-screen dependencies**
 
-- New schema: `Screens.<name>.requires: list[str]`, `suggests: list[str]`,
-  and `warn_message: str|null`.
-- On installer Next click the selected set is cross-checked; unmet
-  `requires` trigger a 3-button dialog (Yes = auto-add + continue,
-  No = continue anyway, Cancel = stay). Unmet `suggests` and required
-  screens that aren't in the archive at all use a simpler OK/Cancel
-  dialog. `warn_message` is folded into the dialog body.
+- New schema: `Screens.<name>.requires: list[str]`, `suggests: list[str]`, and `warn_message: str|null`.
+- On installer Next click the selected set is cross-checked; unmet `requires` trigger a 3-button dialog (Yes = auto-add + continue, No = continue anyway, Cancel = stay). Unmet `suggests` and required screens that aren't in the archive at all use a simpler OK/Cancel dialog. `warn_message` is folded into the dialog body.
 
 **Partial install — developer-side subset release**
 
-- `vis release -Groups <A,B>` builds an installer containing only the
-  union of screens in the listed groups.
-- `vis release -Screens <X,Y>` builds an installer containing only the
-  listed screens. The two flags may be combined.
-- The Host is always included. Excluded screens are never compiled and
-  their entries are pruned from the archived `project.json`. Empty
-  groups are dropped from the pruned schema.
+- `vis release -Groups <A,B>` builds an installer containing only the union of screens in the listed groups.
+- `vis release -Screens <X,Y>` builds an installer containing only the listed screens. The two flags may be combined.
+- The Host is always included. Excluded screens are never compiled and their entries are pruned from the archived `project.json`. Empty groups are dropped from the pruned schema.
 
 **Quiet-mode group expansion**
 
-- `installer.exe --Quiet <group_name>` expands the group into its
-  default-selected members before running the existing archive-matching
-  logic.
-- A group containing at least one tabbed screen implicitly pulls in the
-  Host (tabbed screens ride inside the Host exe).
+- `installer.exe --Quiet <group_name>` expands the group into its default-selected members before running the existing archive-matching logic.
+- A group containing at least one tabbed screen implicitly pulls in the Host (tabbed screens ride inside the Host exe).
 
 **install_log.json**
 
-- Each screen record in the log now carries a `"group"` field (the
-  group name, or `null` for ungrouped / Host). Consumed by the runtime
-  missing-screen detector.
+- Each screen record in the log now carries a `"group"` field (the group name, or `null` for ungrouped / Host). Consumed by the runtime missing-screen detector.
 
 **Runtime missing-screen handling**
 
-- `Host.open()` now calls `VIStk.Structures.is_screen_installed(name)`
-  before routing. When the binary is not present in the current
-  installation, it shows an inline warning banner in the active
-  `InfoRow` (via the new `InfoRow.show_banner(text, duration_ms, level)`)
-  instead of silently failing.
-- `is_screen_installed()` reads `.VIS/install_log.json` first and falls
-  back to a filesystem probe for `.Runtime/<name>.exe` or
-  `Screens/<name>.pyd`. Always returns `True` in dev mode (non-frozen).
-- The banner uses the screen's `warn_message` when available; otherwise
-  a generic "X is not installed. Reinstall and select it to enable this
-  feature." string.
+- `Host.open()` now calls `VIStk.Structures.is_screen_installed(name)`before routing. When the binary is not present in the current installation, it shows an inline warning banner in the active `InfoRow` (via the new `InfoRow.show_banner(text, duration_ms, level)`) instead of silently failing.
+- `is_screen_installed()` reads `.VIS/install_log.json` first and falls back to a filesystem probe for `.Runtime/<name>.exe` or `Screens/<name>.pyd`. Always returns `True` in dev mode (non-frozen).
+- The banner uses the screen's `warn_message` when available; otherwise a generic "X is not installed. Reinstall and select it to enable this feature." string.
 
 **CLI additions**
 
-- `vis group add/remove/assign/unassign/default/list` — manage groups in
-  `project.json`.
+- `vis group add/remove/assign/unassign/default/list` — manage groups in `project.json`.
 - `vis release -Groups A,B -Screens X,Y` — subset release.
-- `vis edit <screen> requires "A,B"` / `suggests "C"` / `warn_message "…"`
-  — list-typed attrs accept a comma-separated value; `warn_message`
-  accepts a plain string or `none`/`null`.
+- `vis edit <screen> requires "A,B"` / `suggests "C"` / `warn_message "…"`— list-typed attrs accept a comma-separated value; `warn_message`accepts a plain string or `none`/`null`.
 
 **Absorbed from 0.4.5**
 
-The License/EULA page, `\r` quiet-mode progress bar, and
-`metadata.installer_icon` land as part of this release.
+The License/EULA page, `\r` quiet-mode progress bar, and `metadata.installer_icon` land as part of this release.
 
 ---
 
@@ -656,88 +631,726 @@ The License/EULA page, `\r` quiet-mode progress bar, and
 
 **Identity module**
 
-- New `VIStk/Objects/_Identity.py` provides `new_id()`, a monotonic
-  integer allocator used for every tab, pane, and window.
-- IDs are process-unique but **not** persisted across runs; persistence
-  (for features like "remember open tabs on restart") is out of scope.
+- New `VIStk/Objects/_Identity.py` provides `new_id()`, a monotonic integer allocator used for every tab, pane, and window.
+- IDs are process-unique but **not** persisted across runs; persistence (for features like "remember open tabs on restart") is out of scope.
 
 **Tab IDs**
 
-- `TabManager.open_tab(name, ...)` now returns the new `tab_id: int`
-  (was `bool`) — hold this to address a specific instance.
-- `TabManager._tabs` is keyed by `tab_id` (was the display label); each
-  entry carries its own `display_name`, `base_name`, and `tab_id`.
-- `TabManager` public methods (`close_tab`, `focus_tab`, `has_tab`,
-  `force_refresh_tab`, `set_tab_info`) accept **either** a `tab_id`
-  (`int`) or a display label (`str`). Label lookups are
-  non-deterministic when duplicates exist.
-- `TabManager.active` is now `int | None` (was `str | None`); use the
-  new `TabManager.display_name(tab_id)` helper to resolve back to a
-  label.
-- `TabManager` ⇄ Host callbacks now pass `tab_id` instead of the
-  display name: `on_tab_activate(tab_id, module)`,
-  `on_tab_deactivate(tab_id | None)`, `on_tab_popout(tab_id)`,
-  `on_tab_detach(tab_id)`, `on_tab_refresh(tab_id)`,
-  `on_tab_info_change(tab_id, info)`,
-  `on_tab_split(tab_id, direction, target_pane)`.
-- `TabBar._tabs` is keyed by `tab_id` with the label stored in
-  `entry["label"]`; `update_tab_label(tab_id, new_label)` replaces it.
+- `TabManager.open_tab(name, ...)` now returns the new `tab_id: int`(was `bool`) — hold this to address a specific instance.
+- `TabManager._tabs` is keyed by `tab_id` (was the display label); each entry carries its own `display_name`, `base_name`, and `tab_id`.
+- `TabManager` public methods (`close_tab`, `focus_tab`, `has_tab`, `force_refresh_tab`, `set_tab_info`) accept **either** a `tab_id`(`int`) or a display label (`str`). Label lookups are non-deterministic when duplicates exist.
+- `TabManager.active` is now `int | None` (was `str | None`); use the new `TabManager.display_name(tab_id)` helper to resolve back to a label.
+- `TabManager` ⇄ Host callbacks now pass `tab_id` instead of the display name: `on_tab_activate(tab_id, module)`, `on_tab_deactivate(tab_id | None)`, `on_tab_popout(tab_id)`, `on_tab_detach(tab_id)`, `on_tab_refresh(tab_id)`, `on_tab_info_change(tab_id, info)`, `on_tab_split(tab_id, direction, target_pane)`.
+- `TabBar._tabs` is keyed by `tab_id` with the label stored in `entry["label"]`; `update_tab_label(tab_id, new_label)` replaces it.
 
 **Pane and window IDs**
 
 - `TabManager` gains `self.id: int` at construction.
-- `_SplitNode` gains `self.id: int` so `SplitView._pane_parents` is now
-  keyed by `.id` instead of Python's `id(...)` — stable across the
-  object's lifetime, no risk of address reuse collisions.
-- `DetachedWindow` gains `self.id: int` (currently used only for
-  debug/logging; no lookups yet).
+- `_SplitNode` gains `self.id: int` so `SplitView._pane_parents` is now keyed by `.id` instead of Python's `id(...)` — stable across the object's lifetime, no risk of address reuse collisions.
+- `DetachedWindow` gains `self.id: int` (currently used only for debug/logging; no lookups yet).
 
-**`SplitView.remove_pane` focus restore — the bug fix**
+`SplitView.remove_pane` **focus restore — the bug fix**
 
-- Before removing a pane, the SplitView records which `tab_id` was
-  focused in the surviving pane subtree.
-- `_snapshot_subtree` / `_rebuild_from_snapshot` preserve each tab's
-  `tab_id` across destroy-and-rebuild by passing the original ID
-  through the new `TabManager.open_tab(..., tab_id=...)` kwarg.
-- After the rebuild the SplitView finds the new pane that now owns the
-  recorded `tab_id` and restores focus there. Previously focus fell
-  back to the first pane in left-to-right order, which failed when
-  multiple panes held tabs with the same base name.
-- `SplitView.find_pane_for_tab(tab_id)` replaces the former
-  name-based helper.
+- Before removing a pane, the SplitView records which `tab_id` was focused in the surviving pane subtree.
+- `_snapshot_subtree` / `_rebuild_from_snapshot` preserve each tab's `tab_id` across destroy-and-rebuild by passing the original ID through the new `TabManager.open_tab(..., tab_id=...)` kwarg.
+- After the rebuild the SplitView finds the new pane that now owns the recorded `tab_id` and restores focus there. Previously focus fell back to the first pane in left-to-right order, which failed when multiple panes held tabs with the same base name.
+- `SplitView.find_pane_for_tab(tab_id)` replaces the former name-based helper.
 
-**`Host`**
+`Host`
 
-- `_find_tab_by_base(base_name)` now returns `(tm, tab_id)` instead of
-  `(tm, display_name)`.
-- `_get_all_tab_names` → `_get_all_tab_labels` (collects labels for
-  `_unique_display_name` only; internal tracking uses IDs).
-- `_open_counts` retired — tab IDs make multi-instance tracking
-  trivial; label collisions stay a UX concern only.
-- `Screen.close()` routes through the new ID-based
-  `close_tab(tab_id)`.
+- `_find_tab_by_base(base_name)` now returns `(tm, tab_id)` instead of `(tm, display_name)`.
+- `_get_all_tab_names` → `_get_all_tab_labels` (collects labels for `_unique_display_name` only; internal tracking uses IDs).
+- `_open_counts` retired — tab IDs make multi-instance tracking trivial; label collisions stay a UX concern only.
+- `Screen.close()` routes through the new ID-based `close_tab(tab_id)`.
 
 **IPC**
 
-- The original 0.4.7 scope mentioned `__VIS_CLOSE__` IPC. IPC is not
-  being reintroduced — in-process `_HOST_INSTANCE` singleton stays the
-  only navigation path. If IPC ever comes back it will use IDs
-  natively.
+- The original 0.4.7 scope mentioned `__VIS_CLOSE__` IPC. IPC is not being reintroduced — in-process `_HOST_INSTANCE` singleton stays the only navigation path. If IPC ever comes back it will use IDs natively.
 
 **Out of scope**
 
-- UUIDs for cross-process persistence — deferred to 0.6.X application
-  settings when "remember open tabs" lands.
-- Deregistering stale TabManager references from
-  `Host.registered_tab_managers` / `DetachedWindow.tab_managers` after
-  `remove_pane` — pre-existing bookkeeping leak, not part of this
-  refactor.
+- UUIDs for cross-process persistence — deferred to 0.6.X application settings when "remember open tabs" lands.
+- Deregistering stale TabManager references from `Host.registered_tab_managers` / `DetachedWindow.tab_managers` after `remove_pane` — pre-existing bookkeeping leak, not part of this refactor.
+
+# Changelog and Roadmap
+
+## Released
+
+### 0.3 Release
+
+#### Changes
+
+Releasing
+
+- Added release command to release version of project
+- Using internal project.json to build spec file to create release
+- Can switch from Screen to Screen using internal methods (os)
+- Can release single Screen
+- Releasing creates Installers for the project
+
+Screen Functionality
+
+- Default Form Changed
+- Currently active Screen is tracked
+- Can load with args
+
+#### Objects
+
+New
+
+- VIMG can bind image path resizing to widget
+
+#### Widgets
+
+New
+
+- Window
+- Root Widget (Tk, Window)
+- SubRoot Widget (TopLevel, Window)
+- WindowGeometry
+- LayoutFrame (ttk.Frame)
+- QuestionWindow (SubRoot)
+- ScrollableFrame (ttk.Frame)
+- ScrollMenu (ScrollableFrame)
+
+Updated
+
+- Menu: buttons highlight on hover
+- 
+
+```
+: can provide screennames instead of paths
+```
+
+- MenuItem(Button): now menuitem is the button and text autosizes
+- 
+
+```
+            : will use screen.load() if provided with screenname
+```
+
+---
+
+### 0.4.1 Screen Management
+
+**Single-instance screens**
+
+- New `single_instance` boolean field in each screen's `project.json` entry (default `false`)
+- `Screen.__init__` reads and exposes `screen.single_instance`
+- When `Host.open()` is called for a screen with `single_instance: true` that is already open anywhere (main window or any `DetachedWindow`), the existing tab is focused rather than creating a new instance; the `(2)` / `(3)` suffix logic is skipped entirely
+- Set via `VIS edit <screenname> single_instance true`
+
+`VIS rename <screenname> <newname>`
+
+- Validates `newname` against the same rules as `VIS add screen` (no reserved words, valid identifier, no conflicts)
+- Renames the screen's key in `project.json → Screens`
+- Renames the script file on disk if the filename matches the old screen name pattern (`oldname.py` → `newname.py`); updates the `script` field accordingly
+- Renames `Screens/<oldname>/` → `Screens/<newname>/`
+- Renames `modules/<oldname>/` → `modules/<newname>/` and renames `m_<oldname>.py` → `m_<newname>.py` inside it
+- Rewrites all `Screens.<oldname>.` and `modules.<oldname>.` import references inside the screen script
+- Updates `default_screen` in `project.json` if it matches the old name
+- Runs `stitch` automatically after rename so import blocks are regenerated clean
+- `rename` and `Rename` added to `_RESERVED_VIS_COMMANDS`
+
+`VIS edit <screenname> <attribute> <value>`
+
+- Directly sets any attribute in the screen's `project.json` subdictionary
+- Editable attributes: `script`, `release`, `icon`, `desc`, `tabbed`, `single_instance`, `version`, `current`
+- Type coercion applied automatically by attribute:
+  - `release`, `tabbed`, `single_instance` — `true`/`yes`/`1` → `True`; `false`/`no`/`0` → `False`
+  - `icon`, `current` — `none`/`null` → `None`; any other string stored as-is
+  - `version` — stored as string; must be valid `major.minor.patch` format
+  - `script` — stored as plain string; rejects the value if the file does not exist in the project root
+  - `desc` — stored as plain string
+- Prints confirmation of old and new value
+- Rejects unknown attribute names with a clear error rather than silently writing garbage keys
+- Keeps the in-memory `Screen` object in sync immediately after writing
+- `edit` and `Edit` added to `_RESERVED_VIS_COMMANDS`
+
+---
+
+### 0.4.2 Menus
+
+**Three-layer menubar model**
+
+The `HostMenu` menubar is now structured as three permanent layers in order:
+
+1. **Built-in layer** — the "App" cascade (Close Window / Quit), always first, built automatically by `attach()`
+2. **Project layer** — app-wide cascades defined once in `Host.py` at startup; never cleared during normal use
+3. **Screen layer** — cascades contributed by the active tab via `configure_menu(menubar)`; all cleared automatically on tab deactivation
+
+`HostMenu` **changes**
+
+- `set_project_items(items, label)` — new method; appends one cascade to the project layer; calling it multiple times adds multiple project-layer cascades in order; these persist across all tab changes
+- `clear_project_items()` — removes all project-layer cascades; intended for teardown, not normal use
+- `set_screen_items(items, label)` — behaviour change: **accumulates** rather than replaces; calling it multiple times within a single `configure_menu` hook adds multiple screen-layer cascades side by side; still the right method for screen contributions
+- `clear_screen_items()` — unchanged signature; now removes **all** accumulated screen cascades (tracked internally as a list of labels rather than a single slot)
+- `_project_labels: list[str]` replaces nothing (new); `_screen_labels: list[str]` replaces the single `_screen_cascade` / `_screen_label` pair
+
+**Usage pattern**
+
+Project-wide items are set once in `Host.py` after `Host()` is created:
+
+```
+host = Host()
+host.HostMenu.set_project_items([
+    {"label": "File", "items": [
+        {"label": "New",  "command": new_fn},
+        {"separator": True},
+        {"label": "Exit", "command": host.quit_host},
+    ]},
+    {"label": "Help", "items": [
+        {"label": "About", "command": about_fn},
+    ]},
+], label="File")
+```
+
+Screen-specific items are contributed as before via `configure_menu`:
+
+```
+def configure_menu(menubar):
+    menubar.set_screen_items([
+        {"label": "Export PDF", "command": export_pdf},
+        {"label": "Print",      "command": print_fn},
+    ], label="Work Orders")
+```
+
+A screen that needs more than one cascade on the menu bar calls `set_screen_items` multiple times in one `configure_menu` call — all are cleared together on deactivation.
+
+`VIS add screen <name> menu <menuname>`
+
+- `Screen.addMenu(menu)` implemented (was a stub)
+- Creates `modules/<screen>/m_<menuname>.py` containing a `configure_menu(menubar)` function pre-filled with a commented cascade template
+- If `modules/<screen>/m_<screenname>.py` (the hooks module) already exists and does not define `configure_menu`, a delegation function is appended so the new menu module is wired in automatically
+- If `configure_menu` already exists in the hooks module, import instructions are added as comments for manual wiring
+- The generated file is a standard module file — developer fills in the item specs and it is picked up on next Host launch
+
+**Installer & Release fixes**
+
+- Replaced `from tkinter import *` with `import tkinter as tk` in `Installer.py` — the wildcard import shadowed the builtin `all()`, breaking the "Select All" checkbox logic
+- Fixed `shortcut()`: used stale loop variable `i` instead of `name`, and called nonexistent `user_desktop_dir()` instead of `platformdirs.user_desktop_path()`
+- Removed stale `i_file.close()` in `makechecks` that closed the root icon handle instead of per-screen handles
+- Fixed `extal()`: only `chmod +x` actual binaries on Linux (no extension or `.sh`), not every extracted file
+- Replaced `os.mkdir` with `os.makedirs(exist_ok=True)` in `adjacents()` so nested directories don't fail
+- Deduplicated `installables` list to prevent duplicate checkboxes
+- Replaced `source.index(i)` with `enumerate` in `makechecks` to avoid wrong indices with duplicate names
+- Added `archive.close()` calls in quiet mode exit and GUI close button to release the zip handle
+- Fixed prefix matching in extraction: `file.startswith(i)` → `file == i or file.startswith(i + ".") or file.startswith(i + "/")` to prevent false matches
+- Fixed `_internal` filter: added trailing slash (`_internal/`) so files with `_internal` in their name are not incorrectly excluded from installables
+- Fixed `previous()`: module-level `next_btn` reference is now updated via `global next_btn` so Back→Next round-trips don't crash
+- Replaced four redundant extraction loops with a single-pass install + progress bar UI (filename above bar, installed/total size below-left, percentage below-right)
+- Added version display: app version in installer header, per-screen versions next to checkboxes
+- Fixed `binstall()`: takes a separate `selected_screens` parameter so installation proceeds regardless of shortcut checkbox state
+- Replaced manual argument parsing with `ArgHandler`; added `--Help`, `--Path`, and `--Desktop` flags with enforcement that `--Desktop` and `--Path` require `--Quiet`
+- `--Quiet` with no screen names now defaults to installing all screens
+- Added `binaries.zip` existence check with user-friendly error message on missing archive
+- Removed unused `shutil` import
+- Fixed `newVersion()` in `_Release.py`: compared `self.Version == "Major"` (Version object vs string) → `self.type == "Major"`
+- Added user confirmation prompt in `newVersion()` before applying a version change, with revert on cancel
+- Re-enabled `newVersion()` call in `release()` (was commented out)
+- Collapsed duplicated path logic in `clean()` into a single `pendix`/`out_dir` variable + loop
+- Removed `os.chdir()` from `release()`; all paths are now explicit with `cwd=` parameter for subprocess calls
+
+**Cached installer builds**
+
+- `_Release.py` no longer runs PyInstaller for the installer on every release; the base installer exe is compiled once and cached in `.VIS/cache/`
+- On subsequent releases, `binaries.zip` is appended directly to the cached base exe — `ZipFile(sys.executable)` reads the appended zip from the end of the file
+- A SHA-256 hash of `Installer.py` + the icon file is stored alongside the cache; the base is only recompiled when the installer source or icon changes
+- `Installer.py` tries self-contained mode first (`sys.frozen` + `ZipFile(sys.executable)`), falls back to external `binaries.zip` for development/testing
+
+**Auto-launch after install**
+
+- Optional "Launch \[AppName\]" checkbox on the completion page, checked by default
+- On Close, launches the default screen binary (which starts the Host if not running); falls back to the first installed screen if the default was not selected
+- Checkbox only appears when at least one screen was installed
+
+**Documentation updates**
+
+- `HostMenu` section updated to describe all three layers and the accumulate behaviour of `set_screen_items`
+- `configure_menu` hook documentation updated with a multi-cascade example
+- `VIS add screen <name> menu <menuname>` added to the CLI reference
+
+---
+
+### 0.4.0 Host and Tabbed Screens
+
+**Host object**
+
+- `Host` — persistent `Root` subclass; hides to system tray on window close; never destroys
+- Host registers itself in the Windows startup registry on first run (`_register_startup`)
+- Host is always the parent process and sole owner of the Tk root window
+- Closing the Host window hides it to tray; `VIS stop` or tray Quit fully shuts it down
+- Thread-safe cross-thread call queue (`queue.SimpleQueue`) polled by `_poll_main_queue`; pystray and IPC threads never call Tkinter directly
+- `_HOST_INSTANCE` module-level singleton; `Project.open()` checks it to route navigation
+
+**TabManager and TabBar**
+
+- `TabManager` object — `Frame` subclass that owns the tab strip and content area; sits at the top level of the Host window
+- `TabBar` widget — row of clickable tabs; flat buttons with configurable background colours; active/inactive/hover states; close button per tab; vertical separator between tabs
+- Tab buttons show the screen icon (16×16 PIL image) to the left of the screen name when an icon is configured
+- Full hover behaviour: hovering the tab name button changes both the name and close button together; hovering the close button alone changes only the close button to IndianRed
+
+**Screen navigation**
+
+- `host.open(screen)` — unified navigation; tabbed screens open as Frame tabs inside Host window; standalone screens open as `Toplevel` windows within the Host process
+- `TabManager.open_tab` / `TabManager.close_tab` — full tab lifecycle including `setup()`, `on_activate()`, `on_deactivate()` hooks
+- `__VIS_CLOSE__:<name>` IPC message — a screen can ask the Host to close itself
+
+**IPC**
+
+- `send_to_host(project_title, message)` — sends any message to a running Host via localhost TCP
+- Host writes its port to `%TEMP%/<ProjectTitle>_vis_host.port` on startup; removed on quit
+- IPC messages: screen name (open), `__VIS_QUIT__` (shut down), `__VIS_CLOSE__:<name>` (close one screen)
+
+**Screen hooks**
+
+- `setup(parent)` — called with the tab Frame when the Host opens a screen as a tab; all widget creation must be inside this function so the module can be imported without side-effects
+- `configure_menu(menubar)` — called when a tab activates; screen contributes items to `HostMenu`; items cleared on deactivation
+- `on_activate()` / `on_deactivate()` — lifecycle hooks called on tab focus change
+
+**Screen template**
+
+- Hook stubs (`configure_menu`, `on_activate`, `on_deactivate`) placed before `setup()` so `stitch()` cannot overwrite them
+- All widget creation sections (`#%Screen Grid`, `#%Screen Elements`) placed inside `setup(parent)` to avoid import side-effects
+- Standalone entry point uses `if __name__ == "__main__":` guard; imports `root, frame` from `Screens/root.py` only in that block
+- `_replace_section` regex fixed: `(?=\n?[ \t]*#%)` — the `\n` is now optional so adjacent `#%` markers (no blank line between) are handled correctly
+
+**VIS commands**
+
+- `VIS stop` — sends `__VIS_QUIT__` to a running Host via IPC
+- `VIS <ProjectName>` — starts the Host if not running (via `subprocess.Popen`), then sends the default screen name via IPC so the window surfaces automatically
+- `VIS <ProjectName> <ScreenName>` — starts the Host if not running, then sends the screen name via IPC; no longer falls back to `os.execl`
+- `VIS new` — prompts for default screen name after project creation
+
+**Project creation**
+
+- Project name defaults to the current folder name (press Enter to accept)
+- Project name is validated against reserved VIS commands (`new`, `add`, `stop`, `stitch`, `release`, `-v`, etc.)
+- `VIS new` prompts for a default screen immediately after project creation
+- `Host.py` generated into `.VIS/Host.py` instead of the project root (not intended for user editing)
+- `default_screen` stored under `defaults.default_screen` in `project.json` (previously top-level); backwards-compatible read path retained
+
+**Dependencies added**
+
+- `pystray` — cross-platform system tray support
+
+**Tab drag-to-reorder**
+
+- Tabs in the TabBar can be dragged left or right to change their display order
+- An 8-pixel motion threshold distinguishes a drag from a click
+- The tab click action is suppressed when a drag occurred in the same press
+
+**InfoRow widget**
+
+- `InfoRow` widget — `Frame` packed at the bottom of the Host window
+- Left: active screen name and version (updated on tab focus change)
+- Centre: project copyright string (static, set at Host startup)
+- Right: live frames-per-second counter (updated once per second by `tick_fps`)
+
+**Host quit closes managed screens**
+
+- `_do_quit()` now calls `on_deactivate` hooks and destroys all managed Toplevels and tabs before tearing down the Tk root
+
+**Layout constraint enforcement**
+
+- `Layout` now stores its parent frame reference in `__init__`
+- New `Layout.apply(widget, row, col, ...)` method places a widget with absolute pixel coordinates and re-places it automatically on every parent `<Configure>` event, enforcing the `minsize` and `maxsize` constraints set via `rowSize()` / `colSize()`
+- Existing `cell()` method is unchanged — relative-placement workflows are unaffected
+
+**Screen lifecycle additions**
+
+- `Screen.close()` — sends `__VIS_CLOSE__:<name>` to the Host via IPC; asks the Host to close a specific tab or Toplevel from within the screen itself
+- `Project.set_default_screen(name)` — persists the default screen name to `project.json`; called automatically when the first screen is created via `newScreen`
+- `newScreen` now prompts whether the new screen should open as a tab inside the Host (`tabbed` field stored in `project.json`)
+
+**VINFO / project metadata**
+
+- `VINFO.copyright` field — separate copyright string stored under `metadata.copyright` in `project.json`; falls back to the company name if not set; used by `InfoRow`
+
+**Bug fixes**
+
+- `TabBar._btn_click` drag suppression: `_drag_active` is now cleared inside `_btn_click` rather than `_on_drag_release`; previously the flag was always `False` by the time `_btn_click` ran (Tk fires `command=` after `<ButtonRelease-1>` bindings), so clicking after a drag would incorrectly focus the tab
+- `Layout.rowSize` / `colSize` list mutation: both methods now copy the caller's list before inserting the leading `0` sentinel; previously they mutated the original list in place, which could corrupt reused list variables
+
+**Hook rename**
+
+- `on_activate()` / `on_deactivate()` renamed to `on_focused()` / `on_unfocused()` across all framework code and the screen template
+- `Host` and `TabManager` look for the new names; the screen template stubs are updated accordingly
+
+**Lifecycle hooks in module file**
+
+- `on_focused`, `on_unfocused`, and `configure_menu` are now looked up in `modules/<screen>/m_<screen>.py` first; the screen script is used as a fallback so that existing screens without a separate hooks file continue to work
+- `Host._import_hooks(scr)` — imports the hooks module for a screen; returns `None` if the file does not exist
+- `TabManager._get_hook(name, hook_name)` — priority lookup across hooks module and screen module
+- `TabManager.open_tab` now accepts a `hooks` keyword argument; the hooks module is stored in the tab dict and passed through all lifecycle calls
+
+**Tab right-click context menu**
+
+- Right-clicking any tab button shows a context menu with three options: **Open in new window**, **Force refresh**, and **Close**
+- **Open in new window** closes the tab in the current `TabManager` and opens it in a new `DetachedWindow`; `TabBar.on_tab_popout` → `TabManager._on_popout_request` → `TabManager.on_tab_popout` → `Host._on_tab_popout`
+- **Force refresh** re-imports and re-runs `setup(parent)` for the tab; hooks module is also re-imported; tab is reopened at its original position
+- **Close** closes the tab as if its close button were clicked
+
+**Tab drag-to-detach**
+
+- Releasing a dragged tab outside all registered `TabBar` instances fires `TabBar.on_drag_detach`
+- `Host._on_tab_detach` closes the tab from the main `TabManager` and opens it in a new `DetachedWindow`
+
+**Tab drag-to-merge**
+
+- All live `TabBar` instances register in the module-level `_TABBAR_REGISTRY` list; they deregister in `TabBar.destroy()`
+- `TabBar.owner` attribute (set by `TabManager.__init__`) links each bar to its owning manager
+- During drag motion the cursor is checked against all registered bars; the hovered bar shows its insertion indicator at the would-be drop position
+- On release over a different `TabBar`, that bar's `on_drag_merge(name, source_bar, insert_idx)` is fired once
+- `TabManager._on_merge_request` closes the tab in the source manager and re-opens it in the receiving manager via `open_tab` (which re-calls `setup(parent)`)
+
+**DetachedWindow**
+
+- New `VIStk.Objects._DetachedWindow.DetachedWindow` class — wraps a `Toplevel` + `TabManager` for popped-out or drag-detached tabs
+- Pop out from a `DetachedWindow` (right-click or drag-out) sends the tab back to the main Host `TabManager`
+- Closing a `DetachedWindow` runs `on_unfocused` on all its tabs before destroying them
+- `Host._do_quit()` closes all `DetachedWindow` instances before tearing down the main window
+
+**Drag ghost window and insertion indicator**
+
+- Dragging a tab shows a semi-transparent `overrideredirect(True)` ghost `Toplevel` that follows the cursor; the ghost replicates the tab label (and icon if present) at 75 % opacity
+- Tabs do not slide during a drag; position is committed only on release
+- A thin coloured vertical bar (insertion indicator) appears inside whichever `TabBar` the cursor is over, showing exactly where the tab will land
+- On release: reorder in the same bar at the indicated position / merge into another bar at the indicated position / detach into a new `DetachedWindow` if the cursor is not over any bar
+- Dragged tab is dimmed while the ghost is live; normal colour is restored on release
+- `TabBar.get_tab_idx(name)` — returns the 0-based position of a tab
+- `TabBar.set_insert_indicator(idx)` / `TabBar.clear_insert_indicator()` — placed via `place()` over the packed tab strip using `_INDICATOR_COLOR` (dodger blue)
+- `TabBar.open_tab` and `TabManager.open_tab` now accept `insert_idx` to insert at a specific position
+- `TabManager.force_refresh_tab(name)` — close and reopen at same position
+
+**InfoRow copyright formatting**
+
+- `©` and the current year are automatically prepended to the copyright string if they are not already present
+
+**InfoRow app version display**
+
+- The project version (from `project.json` `metadata.version`) is shown on the right of the InfoRow alongside the FPS counter in the form `v1.0.0 | 30.0 fps`
+
+**Bug fix: tab insertion positions**
+
+- `TabBar._reorder_to_idx` no longer applies the erroneous `old_idx < idx` index compensation; the index from `_get_insert_idx_at` is already in "without-dragged-tab" space so no adjustment is needed — with two tabs open all three positions (before first, between, after last) now work correctly
+
+**Drag ghost cursor alignment**
+
+- Ghost window positions with the cursor at the exact pixel offset it had within the original tab button (`_drag_btn_offset_x/y` stored on drag start); same alignment is used to position the new `DetachedWindow` when a tab is released outside all bars
+- `TabBar._last_drag_btn_offset_x/y` persists the offset after the drag ends so Host can read it in `_on_tab_detach`
+
+**Empty TabBar drop zone**
+
+- When a `TabBar` has no open tabs it shrinks to a 28 px visible drop-zone strip styled with `_BG_EMPTY`
+- During a drag hover the strip highlights (`_BG_HOVER_EMPTY`) and shows a full-width horizontal insertion indicator at the bottom edge
+- `_update_empty_state()` is called after every `open_tab` / `close_tab`
+
+**DetachedWindow gets menu, info bar, icon, and geometry**
+
+- `DetachedWindow` now contains a `HostMenu` (App → "Close Window"), a `TabManager`, and an `InfoRow` matching the main Host layout
+- `InfoRow` FPS is broadcast from `Host.tick_fps()` via `_fps_listeners`; `DetachedWindow` registers and deregisters automatically
+- Window icon is loaded from the project's default icon
+- Window is sized to match the Host window and positioned so the cursor lands on the tab button at the same offset as during the drag; the window is withdrawn before placement and shown only after the exact position is calculated from measured widget layout offsets
+- `DetachedWindow` is created as a peer `Toplevel()` (no explicit parent) so all application windows are at the same level
+
+**Empty DetachedWindow does not close**
+
+- When all tabs are removed from a `DetachedWindow` (e.g. dragged elsewhere), the window remains open showing the empty drop-zone strip; only the user's X button or `quit_host()` closes it
+
+**Window title management**
+
+- Host window title defaults to `project.title`
+- Title updates to `"project: screen"` when a tab activates and resets to `project.title` when all tabs close
+- Per-screen characteristic info string: `"project: screen — info"` format; also shown in the tab button label as `"screen — info"`
+- Same title pattern applied to `DetachedWindow`
+
+**Per-screen characteristic info (**`set_tab_info`**)**
+
+- `TabManager.set_tab_info(name, text_or_var)` — set a characteristic string for a tab; accepts a plain `str` or a `tkinter.StringVar` (traced automatically; tab label and window title update live)
+- Module-level `set_tab_info(frame, text_or_var)` helper exported from `VIStk.Objects` — call from inside `setup(parent)` using the received `parent` frame
+- StringVar traces are removed automatically when the tab closes (no leaked callbacks)
+- `TabManager.on_tab_info_change` callback: `(name, info)` — wired to Host and DetachedWindow
+
+**Multiple instances of the same screen**
+
+- Opening a screen that is already open anywhere creates a new tab with a `(2)`, `(3)` suffix on the display name
+- `base_name` stored in each tab entry maps the display name back to the screen registry entry for re-import, refresh, and popout operations
+
+---
+
+### 0.4.3 Split Layouts, Installer Uninstaller & Install Log
+
+Allow the Host window's content area to be divided into multiple panes, each with its own `TabBar` and `TabManager`, with a draggable sash between panes. Two screens can then run side by side (or stacked) in a single window without spawning a `DetachedWindow`.
+
+**Uninstaller**
+
+- `Release.release()` generates an uninstaller executable alongside the installer
+- Uninstaller reads `.VIS/install_log.json` to know exactly which files and shortcuts were created
+- Removes all installed binaries, adjacent files, and desktop shortcuts
+- Optionally deregisters from Windows Add/Remove Programs if the installer registered there
+
+**Install log**
+
+- Installer writes `.VIS/install_log.json` after a successful install — records every extracted file path, every shortcut created, the install location, and a timestamp
+- The log is used by the uninstaller and by the update-in-place installer (0.4.4) to determine what is currently installed
+- Quiet mode (`--Quiet`) also writes the install log
+
+`SplitView` **widget**
+
+- New widget (`VIStk/Widgets/_SplitView.py`) that replaces the single `TabManager` in `Host`
+- Each instance wraps a `ttk.PanedWindow` (orient = `"horizontal"` or `"vertical"`) and holds two child slots; each slot is either a `TabManager` (leaf) or a nested `SplitView` (branch)
+- This tree-of-panes model supports arbitrary split arrangements — splitting right and then down produces a `horizontal SplitView → [TabManager, vertical SplitView → [TabManager, TabManager]]`
+- `SplitView.split(pane, direction)` — replaces the `TabManager` leaf at *pane* with a new `SplitView` containing the original pane and a fresh empty `TabManager`; `direction` is `"right"` or `"down"`
+- `SplitView.remove_pane(pane)` — collapses the parent `SplitView` that contains *pane*, promoting the surviving sibling back to the parent's slot; if the root becomes a single `TabManager`, the `SplitView` wrapper is dissolved
+- Sash positions are set to 50/50 by default; the user can drag them freely
+
+**Focused pane**
+
+- `SplitView.focused_pane: TabManager | None` tracks which pane the user last interacted with
+- Clicking a tab in any pane sets that pane as focused; clicking anywhere in a pane's content frame also sets it focused
+- The `HostMenu` and window title always reflect the focused pane's active tab — only one tab drives these at a time
+- When the focused pane is removed (its last tab closed), focus transfers to the nearest remaining pane
+
+**Right-click split actions**
+
+Two new entries added to the `TabBar` right-click context menu:
+
+- **Split right** — calls `on_tab_split(name, "right")` on the owning `TabManager`; `SplitView` handles this by splitting the pane horizontally and moving the tab into the new right pane
+- **Split down** — same, with `"down"` and a vertical split
+
+The existing "Open in new window" entry is unchanged; it still creates a `DetachedWindow`.
+
+**Pane auto-removal**
+
+- When a pane's tab count reaches zero (last tab closed or dragged elsewhere), the pane calls `on_pane_empty` on its owning `SplitView`
+- The `SplitView` removes the empty pane and promotes the surviving sibling; if the root pane becomes empty there is nothing to promote — Host falls back to showing a single empty `TabManager`
+
+**Drag-to-split**
+
+- Dragging a tab into the outer 25% of any pane's content area shows a translucent blue overlay indicating a split zone (right, left, down, up)
+- Releasing in a split zone creates the split and places the tab in the new pane
+- Dragging to the center of a pane shows a full-pane overlay; dropping there adds the tab to that pane without splitting
+- If a pane has only one tab, dragging it over its own pane shows the center overlay (no split possible)
+- Tab bar insertion indicator shown alongside the center overlay to preview where the tab will appear
+- Parent sash positions are preserved when performing nested splits (e.g. splitting the right pane vertically no longer shifts the left pane's width)
+
+**Cross-window drag-to-split**
+
+- Drag-to-split works across Host and DetachedWindows in both directions
+- `DetachedWindow` is now wrapped in `SplitView` — same split, drop zone, and focus behaviour as the Host
+- `SplitView._registry` (class-level list) enables cross-window zone detection; all registered SplitViews are checked during a drag
+- Z-order aware: when windows overlap, only the frontmost window at the cursor position shows drop zones (uses Tk `wm stackorder`)
+- Target window is lifted to the front as soon as the cursor enters its non-overlapping area during a drag; overlapping areas respect stacking order
+
+**Focus-aware tab styling**
+
+- Active tab in the focused pane is shown in a brighter grey; active tabs in unfocused panes are dimmer
+- When a window loses OS focus (`<FocusOut>`), all pane focus indicators dim; they restore on `<FocusIn>`
+- `SplitView._global_focused_pane` tracks the last-focused pane across all windows (Host and DetachedWindows)
+
+**Global focus tracking**
+
+- Clicking any widget inside a pane (buttons, entries, etc.) sets focus to that pane via a toplevel-level `<Button-1>` binding that walks the widget tree
+- `Host._open_tab()` uses `SplitView._global_focused_pane` to open new tabs in the correct pane, even when the call originates from a DetachedWindow
+- `Host.open()` only raises the Host window if the tab was opened there; if the tab was opened in a DetachedWindow, that window is raised instead
+
+**Menu bar fixes**
+
+- `HostMenu.set_screen_items()` now replaces shared cascades in-place (via `entryconfigure`) when the label matches an existing shared cascade, preventing duplicate File/Edit/View/Tools menus
+- `HostMenu.clear_screen_items()` restores the original shared cascade menus
+- `HostMenu.reset_overrides()` called on tab deactivate to prevent stale overrides from carrying over
+
+`Host` **changes**
+
+- `self.TabManager` replaced by `self._split_view: SplitView`; `TabManager` property returns `self._split_view.focused_pane` as a drop-in for the single-pane API
+- `Host.open()` opens new tabs into the globally focused pane (may be Host or DetachedWindow)
+- `Host._get_all_tab_names()` walks the full `SplitView` tree rather than a single `TabManager`
+- Activate/deactivate/menu/title callbacks wired to all panes; focused pane arbitrates which tab drives `HostMenu` and the title bar
+- `Host._on_tab_detach` and `Host._on_tab_popout` resolved through the originating pane's `TabManager`
+- `Host._on_tab_split` handles within-pane splits, cross-pane splits, center drops, and cross-window drops
+
+`DetachedWindow` **changes**
+
+- Content area now wrapped in `SplitView` (was bare `TabManager`) — supports splits, drop zones, and focus tracking
+- `tab_manager` property returns `self._split_view.focused_pane`
+- `_on_tab_split` mirrors Host's implementation (within-window, cross-window, and center drops)
+- `_on_close` iterates all panes in the SplitView tree, not just the focused pane
+
+`TabBar` **changes**
+
+- `on_tab_split: callable | None` — new callback `(name: str, direction: str, target_pane=None)`
+- `on_drag_zone: callable | None` — new callback for drag-to-split zone detection during motion events
+- Right-click menu gains "Split right" and "Split down" entries that fire `on_tab_split`
+- Drag motion checks all registered SplitViews for drop zones when cursor is not over any TabBar
+- Focus-aware `_tab_bg()` returns different colours based on pane focus state
+
+---
+
+### 0.4.3.1 Patch — Screen Splitting Fixes
+
+- Fixed broken aspects of screen splitting introduced in 0.4.3
+
+---
+
+### 0.4.4 Tab Bar Enhancements, Installer Update & Integrity
+
+**Tab bar enhancements**
+
+- Tab bar position — top, left, bottom, or right
+- Maximum simultaneous open tabs — enforced when opening new tabs
+- Close confirmation — warn when closing a tab with unsaved state (requires `has_unsaved()` hook)
+- Multiple tabs of the same screen — already implemented via `_unique_display_name()` (`Name (2)`, `Name (3)` suffixes); verify behaviour holds correctly with split layouts introduced in 0.4.3
+
+**Update-in-place / patch installer**
+
+- Installer detects an existing installation at the target path by reading `.VIS/install_log.json`
+- Compares archive checksums against installed files and only extracts changed or new files
+- Preserves user-modified files (e.g. settings) unless explicitly overwritten
+- Significantly reduces install time for updates compared to a full reinstall
+
+**Rollback on failure**
+
+- If extraction fails mid-install, the installer cleans up all partially extracted files from the current run
+- If updating an existing installation, the previous state is restored from a temporary backup created before extraction began
+
+**Verify installation**
+
+- Post-install integrity check confirms all expected files are present and match expected sizes from the archive
+- Can be triggered manually from the installer menubar or via `--Verify` in quiet mode
+
+**Installer menubar**
+
+- Installer GUI gains a menubar with an "Options" dropdown
+- Options menu entries: "Run Uninstaller" (launches the uninstaller if installed), "Verify File Integrity" (runs the verification check against `install_log.json`)
+
+---
+
+### 0.4.5 Installer Polish *(absorbed into 0.4.6)*
+
+Implemented in-tree but not released as its own PyPI version. These features ship as part of 0.4.6.
+
+**License / EULA page**
+
+- Optional installer page that displays a license agreement loaded from a `LICENSE` or `EULA.txt` file in the archive
+- "I agree" checkbox gates the Next button; installation cannot proceed without acceptance
+- Skipped automatically if no license file is present in the archive
+
+**Silent progress output**
+
+- In `--Quiet` mode, print a progress bar to stdout using `\r` carriage returns instead of one line per extracted file
+- Shows current file, percentage, and installed/total size inline
+
+**Custom installer icon**
+
+- `project.json` gains an optional `metadata.installer_icon` field
+- If set, `Release.release()` uses it for the installer executable instead of the default app icon
+- Falls back to the app icon if not specified
+
+---
+
+### 0.4.6 Screen Groups, Partial Installs & Missing-Screen Banner
+
+*Released — absorbs every feature from 0.4.5.*
+
+**Screen groups**
+
+- `project.json` gains a `release_info.groups` block; each group maps a label to a `{description, screens: {screen_name: {default: bool}}}` entry.
+- A screen belongs to at most one group; ungrouped screens continue to render as individual checkboxes (current behaviour preserved).
+- Group rows in the installer render as a checkbox + label + right-side expand arrow. Expanding a group reveals indented child checkboxes with per-screen version labels.
+- Clicking a group master toggles every child on or every child off (defaults only set the initial state). Tri-state (`alternate`) is shown when a group has a mix of checked/unchecked children; likewise for the top-level "All".
+- Groups with no standalone-screen child actually present in the archive are hidden from the GUI — tabbed screens ship with the Host and cannot be toggled independently at install time.
+
+**Per-screen dependencies**
+
+- New schema: `Screens.<name>.requires: list[str]`, `suggests: list[str]`, and `warn_message: str|null`.
+- On installer Next click the selected set is cross-checked; unmet `requires` trigger a 3-button dialog (Yes = auto-add + continue, No = continue anyway, Cancel = stay). Unmet `suggests` and required screens that aren't in the archive at all use a simpler OK/Cancel dialog. `warn_message` is folded into the dialog body.
+
+**Partial install — developer-side subset release**
+
+- `vis release -Groups <A,B>` builds an installer containing only the union of screens in the listed groups.
+- `vis release -Screens <X,Y>` builds an installer containing only the listed screens. The two flags may be combined.
+- The Host is always included. Excluded screens are never compiled and their entries are pruned from the archived `project.json`. Empty groups are dropped from the pruned schema.
+
+**Quiet-mode group expansion**
+
+- `installer.exe --Quiet <group_name>` expands the group into its default-selected members before running the existing archive-matching logic.
+- A group containing at least one tabbed screen implicitly pulls in the Host (tabbed screens ride inside the Host exe).
+
+**install_log.json**
+
+- Each screen record in the log now carries a `"group"` field (the group name, or `null` for ungrouped / Host). Consumed by the runtime missing-screen detector.
+
+**Runtime missing-screen handling**
+
+- `Host.open()` now calls `VIStk.Structures.is_screen_installed(name)`before routing. When the binary is not present in the current installation, it shows an inline warning banner in the active `InfoRow` (via the new `InfoRow.show_banner(text, duration_ms, level)`) instead of silently failing.
+- `is_screen_installed()` reads `.VIS/install_log.json` first and falls back to a filesystem probe for `.Runtime/<name>.exe` or `Screens/<name>.pyd`. Always returns `True` in dev mode (non-frozen).
+- The banner uses the screen's `warn_message` when available; otherwise a generic "X is not installed. Reinstall and select it to enable this feature." string.
+
+**CLI additions**
+
+- `vis group add/remove/assign/unassign/default/list` — manage groups in `project.json`.
+- `vis release -Groups A,B -Screens X,Y` — subset release.
+- `vis edit <screen> requires "A,B"` / `suggests "C"` / `warn_message "…"`— list-typed attrs accept a comma-separated value; `warn_message`accepts a plain string or `none`/`null`.
+
+**Absorbed from 0.4.5**
+
+The License/EULA page, `\r` quiet-mode progress bar, and `metadata.installer_icon` land as part of this release.
+
+---
+
+### 0.4.7 Tab Identity Refactor
+
+*Released.*
+
+**Identity module**
+
+- New `VIStk/Objects/_Identity.py` provides `new_id()`, a monotonic integer allocator used for every tab, pane, and window.
+- IDs are process-unique but **not** persisted across runs; persistence (for features like "remember open tabs on restart") is out of scope.
+
+**Tab IDs**
+
+- `TabManager.open_tab(name, ...)` now returns the new `tab_id: int`(was `bool`) — hold this to address a specific instance.
+- `TabManager._tabs` is keyed by `tab_id` (was the display label); each entry carries its own `display_name`, `base_name`, and `tab_id`.
+- `TabManager` public methods (`close_tab`, `focus_tab`, `has_tab`, `force_refresh_tab`, `set_tab_info`) accept **either** a `tab_id`(`int`) or a display label (`str`). Label lookups are non-deterministic when duplicates exist.
+- `TabManager.active` is now `int | None` (was `str | None`); use the new `TabManager.display_name(tab_id)` helper to resolve back to a label.
+- `TabManager` ⇄ Host callbacks now pass `tab_id` instead of the display name: `on_tab_activate(tab_id, module)`, `on_tab_deactivate(tab_id | None)`, `on_tab_popout(tab_id)`, `on_tab_detach(tab_id)`, `on_tab_refresh(tab_id)`, `on_tab_info_change(tab_id, info)`, `on_tab_split(tab_id, direction, target_pane)`.
+- `TabBar._tabs` is keyed by `tab_id` with the label stored in `entry["label"]`; `update_tab_label(tab_id, new_label)` replaces it.
+
+**Pane and window IDs**
+
+- `TabManager` gains `self.id: int` at construction.
+- `_SplitNode` gains `self.id: int` so `SplitView._pane_parents` is now keyed by `.id` instead of Python's `id(...)` — stable across the object's lifetime, no risk of address reuse collisions.
+- `DetachedWindow` gains `self.id: int` (currently used only for debug/logging; no lookups yet).
+
+`SplitView.remove_pane` **focus restore — the bug fix**
+
+- Before removing a pane, the SplitView records which `tab_id` was focused in the surviving pane subtree.
+- `_snapshot_subtree` / `_rebuild_from_snapshot` preserve each tab's `tab_id` across destroy-and-rebuild by passing the original ID through the new `TabManager.open_tab(..., tab_id=...)` kwarg.
+- After the rebuild the SplitView finds the new pane that now owns the recorded `tab_id` and restores focus there. Previously focus fell back to the first pane in left-to-right order, which failed when multiple panes held tabs with the same base name.
+- `SplitView.find_pane_for_tab(tab_id)` replaces the former name-based helper.
+
+`Host`
+
+- `_find_tab_by_base(base_name)` now returns `(tm, tab_id)` instead of `(tm, display_name)`.
+- `_get_all_tab_names` → `_get_all_tab_labels` (collects labels for `_unique_display_name` only; internal tracking uses IDs).
+- `_open_counts` retired — tab IDs make multi-instance tracking trivial; label collisions stay a UX concern only.
+- `Screen.close()` routes through the new ID-based `close_tab(tab_id)`.
+
+**IPC**
+
+- The original 0.4.7 scope mentioned `__VIS_CLOSE__` IPC. IPC is not being reintroduced — in-process `_HOST_INSTANCE` singleton stays the only navigation path. If IPC ever comes back it will use IDs natively.
+
+**Out of scope**
+
+- UUIDs for cross-process persistence — deferred to 0.6.X application settings when "remember open tabs" lands.
+- Deregistering stale TabManager references from `Host.registered_tab_managers` / `DetachedWindow.tab_managers` after `remove_pane` — pre-existing bookkeeping leak, not part of this refactor.
 
 ---
 
 ### 0.5.0 VIS Widgets, Help Button & Popup Polish
 
-**Released.**  Adds general-purpose widgets, a one-line Help-button hookup, standard confirmation dialogs, and a flicker-free popup centring helper.
+**Released.** Adds general-purpose widgets, a one-line Help-button hookup, standard confirmation dialogs, and a flicker-free popup centring helper.
 
 **VIS Widgets** — all exported from `VIStk.Widgets`:
 
@@ -752,15 +1365,22 @@ The License/EULA page, `\r` quiet-mode progress bar, and
 - `confirm_discard(parent, *, title=None, message=None, name=None) -> "save" | "discard" | "cancel"` — three-button Save / Discard / Cancel; closing the window or pressing Escape returns `"cancel"`
 - Both are modal, transient, and centred via `WindowGeometry.center_on` (no flicker)
 
-**Help button & per-screen `docs` URL:**
+**Help button & per-screen** `docs` **URL:**
 
 - `HostMenu.add_project_command(label, command)` — adds a clickable leaf entry directly on the menubar (not a cascade); persists across all tab changes
+
 - `Screen.docs: str | None` — per-screen URL field on `project.json` `Screens.<name>.docs`
+
 - `Project.default_docs: str | None` — project-wide fallback (`defaults.docs`)
+
 - `Project.resolve_docs_url(screen_name=None)` — runs the resolution chain (per-screen → project default → `None`)
+
 - `Project.active_screen_name` property — returns the active tab's `base_name` (resolved via the 0.4.7 tab IDs)
+
 - `VIStk.Objects.open_active_screen_docs()` — looks up the active screen's URL and hands it to `webbrowser.open`; returns `True` on dispatch
+
 - `VIS docs` CLI:
+
   ```
   VIS docs set <screen_name> <url>
   VIS docs set --default <url>
@@ -768,7 +1388,9 @@ The License/EULA page, `\r` quiet-mode progress bar, and
   VIS docs clear --default
   VIS docs list
   ```
+
 - `VIS add screen` scaffolder writes `"docs": null` so the field is discoverable
+
 - URLs are passed verbatim to `webbrowser.open` — no path normalisation; authors write fully-qualified URLs
 
 **Popup flicker fix:**
@@ -781,76 +1403,11 @@ The License/EULA page, `\r` quiet-mode progress bar, and
 
 - **Project Upgrade Tool** (`VIS upgrade`) — moved to 0.7 (already titled "Defaults & Navigation, update tools")
 - **Color palette feature** — tracked separately for a later 0.5.x or 0.6.x
-- **`is_dirty` auto-generated `on_quit`** — `confirm_discard` covers the manual case; the auto-wrapper can land later without an API break
+- `is_dirty` **auto-generated** `on_quit` — `confirm_discard` covers the manual case; the auto-wrapper can land later without an API break
 
----
+## Planned
 
-### 0.5.1 Release Pipeline & Host Runtime
-
-**Released.**  Hardens the cross-platform release toolchain, flattens the install layout, and wires `loop()` straight into the Host's update path.
-
-**Per-platform C compiler selection** (#83):
-
-- New `Release._compiler_args()` returns `["--msvc=latest"]` on Windows and `[]` elsewhere; passed to every `compile_host` / `compile_screens` / `compile_shared` Nuitka invocation.
-- Sidesteps zig 0.15.2 + Nuitka 4.0.8 + Python 3.13 producing corrupt frozen bytecode (`Fatal Python error: init_fs_encoding` / `EOFError: marshal data too short`) — see #35.
-- On Linux and macOS, Nuitka's auto-detection picks gcc / clang as before — no flag needed.
-
-**Pre-flight checks** (#84, #88):
-
-- `Release._check_compiler()` runs at the top of `release()` and aborts before any compilation if the platform's required C compiler is missing.  Windows uses `vswhere.exe` directly (matches Nuitka's MSVC discovery; doesn't rely on `cl.exe` being on PATH inside a Developer Command Prompt).  Linux and macOS check `gcc` / `clang` via `shutil.which`.
-- `Release._check_tools()` verifies pip / nuitka / pyinstaller are importable.  Replaces the old auto-upgrade pass that ran `pip install --upgrade` on every release — that auto-upgrade was the trigger for the zig regression in #35 and added 30–60 s to every build.
-- Both helpers print the exact install command (`pip install ...`, `vs_BuildTools.exe`, `apt install build-essential`, `xcode-select --install`) when something is missing, so first-time users get an actionable error.
-
-**Per-flag Nuitka build cache** (#91):
-
-- New `Release.build_dir = f"{p_project}/build/{pendix}/"`.  Nuitka's working directory (`.build/`, transient `.dist/`) now lives under `<project>/build/<pendix>/` instead of `<project>/dist/`.
-- `<project>/dist/` becomes deliverables-only — final folders + installers + `binaries.zip`.
-- `VIS release -f Windows` and `VIS release -f Linux` get isolated caches (`build/WOM-Windows/`, `build/WOM-Linux/`) and stop stomping each other's per-module `.build/` hashes.
-- Eight Nuitka I/O sites in `_Release.py` swapped from `self.location` to `self.build_dir`.  The PyInstaller paths for the installer / uninstaller build are unchanged.
-
-**Drop the PyInstaller launcher shim layer** (#105, also closes #36, #37):
-
-- `compile_screens(mode="exe")` and `compile_host()` outputs now stay at the install root.  The `clean()` move-to-`.Runtime/` block and the entire `release()` launcher generation block are gone.
-- `VIStk/Structures/Launcher.py` (the source PyInstaller wrapped) is deleted as dead code.
-- Each project install loses ~30 MB (3 × ~10 MB PyInstaller `--onefile` shims on PYWOM) without changing the user-facing entry points — the Nuitka standalone exe already had the correct icon baked in; the shim was only doing cosmetic hiding of the runtime DLLs.
-- `_Install.py.is_screen_installed` checks `<root>/<name>.exe` first and falls back to the legacy `.Runtime/<name>.exe` path so installations made before this version still resolve.
-
-**Uninstaller: deferred recursive cleanup** (#34):
-
-- `Uninstaller.schedule_self_delete()` writes a self-deleting `.bat` to `%TEMP%` that waits 3 s for the uninstaller process to exit, then `rmdir /s /q`s every directory at the install root except `Settings/` and `del /f /q`s every loose file.  The uninstaller exe itself is unlocked and removed in the same sweep.
-- `Settings/` is preserved by design — per-machine config survives uninstall + reinstall.
-- The deferred cleanup now fires immediately after the in-process `remove_installed_files()` returns rather than waiting on a Close-button click.  Window-X dismissals trigger the sweep too.
-
-**Host drives `loop()` directly** (#117):
-
-- New `Host._tick_screens()` iterates every registered TabManager (main window + DetachedWindows) and calls `loop()` on each open tab's module.  Exceptions inside any one `loop()` are logged with a traceback but do not break the chain.
-- Called once per `Host.update()` invocation — same cadence as the standalone driver.  No `tk.after` throttle, no framework-imposed frame-rate cap.  If a screen wants to rate-limit its own `loop()`, it does so in its body via timestamp gating.
-- Replaces the `_schedule_loop` workaround that screens previously hand-rolled (PYWOM dropped its three copies in PYWOM #58).
-- Screen template's `loop()` docstring updated to spell out the new contract.
-
-**Closes**
-
-- #34 — Uninstaller leaves install directory intact
-- #35 — Nuitka silent crash (`init_fs_encoding`); verified end-to-end on Windows + Linux
-- #36 — Screen `.exe` files leak into `.Runtime/`
-- #37 — Rename `.Runtime\<exe>` to `VIStkHost.exe` (moot after the launcher-shim drop)
-- #83 — Per-platform C compiler selection
-- #84 — Pre-flight compiler check
-- #88 — Stop auto-upgrading pip / nuitka / pyinstaller
-- #91 — Per-flag Nuitka build cache
-- #105 — Drop PyInstaller launcher shims
-- #117 — Host drives `loop()` directly
-
-**Still deferred (carried forward from 0.5.0):**
-
-- **Color palette feature** — tracked for a later 0.5.x or 0.6.x.
-- **`is_dirty` auto-generated `on_quit`** — `confirm_discard` (0.5.0) covers the manual case; auto-wrapper can land later without an API break.
-
----
-
-### 0.5.2 Screen Isolation
-
-*Upcoming.*
+### 0.5.1 Screen Isolation
 
 Tabbed screens now own their `Screens/<screen>/` and `modules/<screen>/` trees in the compiled `.pyd`. The Host stops being a code-bundle for every screen in the project. Cross-screen imports between siblings become visible (linter warning) instead of silently working.
 
@@ -882,9 +1439,10 @@ Tabbed screens now own their `Screens/<screen>/` and `modules/<screen>/` trees i
 - A tabbed screen's code now enters memory only when the user opens the tab for the first time. Cold-start time and resident memory both drop in proportion to the number of unopened screens.
 - `modules.<screen>.m_<screen>` hook lookup ordering is unchanged — the Host still consults the screen's hooks module first and falls back to the screen script. The lookup just happens after the `.pyd` is loaded.
 
-**Compilation-order documentation update**
+`clean()` **documentation update**
 
 - `docs/source/structures.rst` "Compilation order" section updated to reflect that `--include-package=modules` / `--include-package=Screens` are now per-screen, not Host-level.
+- `clean()` description gains the line about moving the runtime into `.Runtime/` (long-standing behavior, was missing from the doc).
 
 **Migration notes for existing projects**
 
@@ -895,62 +1453,6 @@ Tabbed screens now own their `Screens/<screen>/` and `modules/<screen>/` trees i
 
 - Auto-rewrite of cross-screen imports — linter flags only.
 - Per-screen access control on `shared/` — possible future addition.
-
----
-
-### 0.7.X Project Upgrade Tool *(moved from 0.5)*
-
-# this kinda seems like a bad idea looking at it now
-
-`VIS upgrade` — bring an existing VIS project forward to the installed version of VIStk without touching user-written code.
-
-**What gets updated**
-
-Three things are replaced or patched on every upgrade; user screen scripts, `Screens/`, and `modules/` are never touched:
-
-- **`.VIS/Host.py`** — regenerated from the current `host.txt` template; the icon name is read from `project.json` before overwriting so the setting is preserved
-- **`.VIS/Templates/`** — overwritten from the VIStk install directory using `shutil.copytree`; ensures `screen.txt`, `f_element.txt`, and all widget templates match the installed version
-- **`project.json` schema migration** — new keys required by newer VIStk versions are added with their default values; existing keys and user-set values are never changed or removed
-
-**`project.json` compatibility tracking**
-
-- A `vis_version` field is added to the `metadata` block at first upgrade (and at project creation going forward)
-- The upgrade tool reads this to determine which migrations have already been applied and skips them
-- On success the field is updated to the current VIStk version
-
-**Migration registry**
-
-Migrations live in `VIStk/Structures/_Upgrade.py` as an ordered list of `(version_string, step_fn)` pairs.  Each `step_fn(info: dict)` receives the raw `project.json` dict and adds or coerces a single field.  The runner applies all steps whose version is newer than the recorded `vis_version`.
-
-This means upgrading across multiple releases in one step works correctly — every migration between the recorded version and the current version fires in order.
-
-**`VIS upgrade` command**
-
-Added to `VIS.py` as a new top-level case:
-
-    vis upgrade
-
-Steps in order:
-
-1. Load `project.json` and read `metadata.vis_version` (treat missing as `"0.0.0"`)
-2. Run all pending schema migrations in version order, patching `info` in memory
-3. Regenerate `.VIS/Host.py` from the current template
-4. Overwrite `.VIS/Templates/` from the VIStk install
-5. Create any missing top-level project directories (`Screens/`, `modules/`, `Icons/`, `Images/`)
-6. Write the updated `project.json` with `vis_version` set to the current VIStk version
-7. Print a per-step summary — "already up to date" if nothing changed
-
-**Dry-run flag**
-
-    vis upgrade --dry-run
-
-Prints what would change without writing any files.  Useful before upgrading a project that has uncommitted changes.
-
-**Documentation updates**
-
-- `VIS upgrade` added to the CLI reference
-- `project.json` schema reference updated with `metadata.vis_version`
-- Migration registry documented for contributors adding new VIStk versions
 
 ---
 
@@ -1002,6 +1504,7 @@ Settings stored per-project in `.VIS/settings.json`, accessed via `Project.setti
 - Enable/Disable Keyboard Navigation
 - More Navigation tools
 - Update tools to ensure that updating VIS will not break code
+- - Should include warning if a VIS commands run but there are out of date VIS features (Host.py)
 - Tools to update created binaries
 
 ---
@@ -1038,18 +1541,3 @@ Settings stored per-project in `.VIS/settings.json`, accessed via `Project.setti
   - GUI for VIS default settings
   - GUI for VIS project settings (defaults, screens, icons)
 - Auto updating of things like icon and script when changes are made
-
----
-
-### Working with VIScode Extension
-
-- Configure auto object creation
-
-#### Upcoming in VSCode extension
-
-- Add screen menu
-- Add element menu
-- Edit screen settings menu
-- Global object format setting
-- Global object format defaults
-- Use local format for object creation if present


### PR DESCRIPTION
## Summary

Brings the hand-edits in the local master copy of `changelog.md` (`C:/Users/elija/Documents/VIStk/changelog.md`) into the repo. Net diff: **+781 / -293** across the file.

## Why this is a separate PR

Earlier today's PR #122 (which cut 0.5.1) only added the new `0.5.1 Release Pipeline & Host Runtime` and renamed-`0.5.2 Screen Isolation` sections on top of `origin/master`. It did **not** import the additional ~488 lines of hand-edits the user had been accumulating in the local copy. Per the user's call-out, some of those edits touched the `0.4.2` section (already-released material) and they wanted a chance to eyeball the diff before it lands.

This PR lets you do that — review the full diff in GitHub's UI (which renders sectioned markdown changes much better than `diff -u` on the terminal), then either merge as-is or pull this branch locally and clean it up before merging.

## Recommended review workflow

1. Open the **Files changed** tab on this PR.
2. Scan each `### x.y.z` heading's diff. Flag anything in `0.3` / `0.4.x` / `0.5.0` (already-released sections) that you didn't intend to change.
3. If anything's wrong, comment on the line, then either:
   - Pull this branch (`gh pr checkout 123`), edit, push, and merge.
   - Or close this PR without merging and re-do the import yourself.
4. If everything looks intentional, squash-merge.

## What this does *not* do

- Doesn't change `pyproject.toml` (still `0.5.1` from PR #122).
- Doesn't touch any code — changelog only.
- Doesn't reset the local master copy after merge — that's still on you (or the CLAUDE.md sync command).

## Note

After this merges, `origin/master`'s `changelog.md` will match what you currently have locally minus any further edits you make between now and then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)