### PR TITLE
Installer: include the full Python runtime, not just prefix-listed dirs

### DIFF
--- a/VIStk/Structures/Installer.py
+++ b/VIStk/Structures/Installer.py
@@ -1267,17 +1267,33 @@ def binstall(desktop:list[str], selected_screens:list[str]):
                 root.update()
                 return
 
-    # Build the full list of files to install and compute total size
-    _base_prefixes = (".VIS/", "Images/", "Icons/", ".Runtime/")
-    _host_prefixes = ("Screens/", "modules/", "Shared/")
+    # Build the full list of files to install and compute total size.
+    #
+    # The host group owns the entire shared Nuitka runtime — every top-
+    # level Python DLL, stdlib .pyd, third-party package directory, and
+    # Tcl/Tk asset that lives next to WOM.exe.  When the host is selected
+    # we install everything in the archive *except* files exclusively
+    # owned by other standalone screens that weren't selected.  This
+    # replaces the old prefix-list approach (#128) which was written for
+    # the pre-#106 layout where the runtime was hidden under .Runtime/
+    # and only Screens/ modules/ Shared/ at root needed explicit listing.
+    _base_prefixes = (".VIS/", "Images/", "Icons/")
+    _unselected_screens = _standalone_screens - set(selected_screens)
+    _excluded_files = set()
+    for sname in _unselected_screens:
+        for file in archive.namelist():
+            if (file == sname or file.startswith(sname + ".")
+                    or file.startswith(sname + "/")):
+                _excluded_files.add(file)
+
     install_files = []
     host_selected = title in selected_screens
     for file in archive.namelist():
+        if file in _excluded_files:
+            continue
         if file.startswith(_base_prefixes):
             install_files.append(file)
-        elif host_selected and file.startswith(_host_prefixes):
-            install_files.append(file)
-        elif host_selected and file.endswith(".py"):
+        elif host_selected:
             install_files.append(file)
         else:
             base = ".".join(file.split(".")[:-1]) if "." in file else file


### PR DESCRIPTION
Closes #128.

## Summary
- `Installer.binstall` now installs everything in the archive except files exclusively owned by an unselected standalone screen, when the host is selected. Replaces the prefix-list approach that only matched `.VIS/ Images/ Icons/ .Runtime/ Screens/ modules/ Shared/` and `.py` files.
- Drops `.Runtime/` from `_base_prefixes` — dead carry-over from the pre-#106 layout.
- Removes the dead `_host_prefixes` constant and the dead `.py` host-only branch (the new "everything except excluded screens" rule covers them).

## Why
After a clean Windows install, `WOM.exe` / `AssetManager.exe` / `FloorView.exe` did nothing when launched — no window, no Event Viewer entry, no Defender quarantine. The release pipeline correctly produces a full Nuitka standalone bundle in `dist/WOM-Windows/` (python313.dll, stdlib .pyds, tcl/, tk/, vcruntime, PIL/, psutil/, etc.) and zips it into `binaries.zip`, but the installer's prefix filter stripped out every one of those root-level files and directories. The exes couldn't load `python313.dll` and exited silently before any GUI code ran.

This was the dead-code follow-up #106's PR body called out: *"Installer.py still has dead .Runtime/ references in its path filters … Cleanup pass tracked separately if desired."*  Turns out it wasn't harmless — the old layout hid the runtime under `.Runtime/` so the prefix filter happened to cover it; the new layout puts everything at root so the filter dropped it on the floor.

## Test plan
- [ ] Install with host selected → install dir contains `python313.dll`, `_tkinter.pyd`, `tcl/`, `PIL/`, `vcruntime140.dll`. Double-clicking `WOM.exe` opens the Landing tab.
- [ ] Install with host + AssetManager selected → `AssetManager.exe` runs and shows the chromeless window.
- [ ] Install with host + AssetManager selected, FloorView NOT selected → install dir contains `AssetManager.exe` but NOT `FloorView.exe`.
- [ ] Existing `.VIS/ Icons/ Images/ Screens/ Shared/` install correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)