### PR TITLE
Record tabbed screens in install_log + surface setup() exceptions

### DIFF
--- a/VIStk/Objects/_TabManager.py
+++ b/VIStk/Objects/_TabManager.py
@@ -365,7 +365,37 @@ class TabManager(Frame):
             try:
                 module.setup(frame)
             except Exception:
-                pass
+                # Surface the failure: print a traceback to stderr (visible
+                # in dev runs and console-attached frozen builds) and
+                # render an inline error panel inside the otherwise-blank
+                # tab so windowed Windows installs (where stderr goes
+                # nowhere) still tell the user what failed (#131).
+                import traceback as _tb
+                import sys as _sys
+                err_text = _tb.format_exc()
+                try:
+                    _sys.stderr.write(
+                        f"\n[VIStk] setup() failed for tab "
+                        f"{name!r}:\n{err_text}\n"
+                    )
+                    _sys.stderr.flush()
+                except Exception:
+                    pass
+                try:
+                    from tkinter import Label
+                    Label(
+                        frame,
+                        text=(
+                            f"setup() raised an exception for "
+                            f"{name}:\n\n{err_text}"
+                        ),
+                        bg="#ffe5e5", fg="#600",
+                        justify="left", anchor="nw",
+                        wraplength=1100,
+                        font=("Consolas", 9),
+                    ).pack(fill="both", expand=True, padx=12, pady=12)
+                except Exception:
+                    pass
 
         self.tab_bar.open_tab(tab_id, name, icon=icon, insert_idx=insert_idx)
         return tab_id

--- a/VIStk/Structures/Installer.py
+++ b/VIStk/Structures/Installer.py
@@ -308,17 +308,38 @@ def write_install_log(location, selected_screens, desktop_shortcuts):
     """Write install_log.json recording what was installed."""
     directories = [".VIS", "Icons", "Images", ".Runtime"]
 
-    # Build screen list with versions
+    # Build screen list with versions.
+    #
+    # The GUI only exposes the host group + standalone screens as
+    # selectable, but the host bundle physically installs every tabbed
+    # screen's compiled .pyd alongside it.  Record those too — otherwise
+    # is_screen_installed("<tabbed name>") returns False against this log
+    # and Host.update silently refuses to open the default screen on
+    # startup (#130).
+    ext = ".exe" if sys.platform == "win32" else ""
+    mod_ext = ".pyd" if sys.platform == "win32" else ".so"
     screens = []
+    seen: set[str] = set()
     for name in selected_screens:
         scr_info = info[title]["Screens"].get(name, {})
-        ext = ".exe" if sys.platform == "win32" else ""
         screens.append({
             "name": name,
             "version": scr_info.get("version", ""),
             "executable": name + ext,
             "group": _group_of(name),
         })
+        seen.add(name)
+    if title in selected_screens:
+        for sname, scfg in info[title]["Screens"].items():
+            if sname in seen or not scfg.get("tabbed", False):
+                continue
+            screens.append({
+                "name": sname,
+                "version": scfg.get("version", ""),
+                "executable": "",  # tabbed screens have no exe; loaded by Host as .pyd
+                "group": _group_of(sname),
+            })
+            seen.add(sname)
 
     registry_key = ""
     if sys.platform == "win32":

--- a/VIStk/Structures/_Install.py
+++ b/VIStk/Structures/_Install.py
@@ -24,37 +24,70 @@ def _install_dir() -> Path | None:
     return None
 
 
+def _screen_script_stem(root: Path, name: str) -> str:
+    """Resolve a screen's script stem from the installed ``project.json``.
+
+    Falls back to ``name`` when the project.json is unreadable or doesn't
+    list the screen — which preserves the old "name-equals-stem" assumption
+    for screens whose script happens to match their registry name.
+    """
+    try:
+        with open(root / ".VIS" / "project.json") as f:
+            info = json.load(f)
+        title = next(iter(info.keys()))
+        scr = info[title].get("Screens", {}).get(name, {})
+        script = scr.get("script", "")
+        if script:
+            stem = script.rsplit("/", 1)[-1]
+            stem = stem.rsplit(".", 1)[0]
+            return stem or name
+    except Exception:
+        pass
+    return name
+
+
 def is_screen_installed(name: str, install_dir: Path | None = None) -> bool:
     """Return True if screen ``name`` is present on disk in the installation.
 
     Dev mode always returns True. For frozen builds the check prefers
-    ``.VIS/install_log.json``; when the log is missing or stale the helper
-    falls back to a direct filesystem check for the tabbed
-    ``Screens/<name>.pyd`` (``.so`` on Linux/macOS) or standalone
-    ``<name>.exe`` artifact at the install root (#105).
-    The legacy ``.Runtime/<name>.exe`` location is also checked for
-    back-compat with installations made before #105.
+    ``.VIS/install_log.json``; when the log doesn't list the screen the
+    helper falls through to a direct filesystem probe for the tabbed
+    ``Screens/<script_stem>.pyd`` (``.so`` on Linux/macOS) or the
+    standalone ``<name>.exe`` artifact at the install root (#105).  The
+    legacy ``.Runtime/<name>.exe`` location is also checked for back-
+    compat with installations made before #105.
+
+    The fall-through-on-missing behaviour exists because old installers
+    only listed user-selectable screens in the log, omitting tabbed ones
+    that physically ship with the host bundle (#130).  The filesystem
+    probe catches that case.
     """
     root = install_dir or _install_dir()
     if root is None:
         return True  # dev mode — assume every screen is importable from source
 
+    # Step 1: trust the install log when it claims to know the screen.
     log_path = root / ".VIS" / "install_log.json"
     if log_path.exists():
         try:
             with open(log_path) as f:
                 log = json.load(f)
             names = {s.get("name") for s in log.get("screens", [])}
-            if names:
-                return name in names
+            if name in names:
+                return True
         except Exception:
-            pass  # fall through to filesystem check
+            pass  # fall through to filesystem probe
 
+    # Step 2: filesystem probe — covers tabbed screens that older logs
+    # silently omitted, plus a sanity check on standalone exes.
     ext = ".exe" if sys.platform == "win32" else ""
     mod_ext = ".pyd" if sys.platform == "win32" else ".so"
     if (root / (name + ext)).exists():
         return True
-    if (root / "Screens" / f"{name}{mod_ext}").exists():
+    stem = _screen_script_stem(root, name)
+    if (root / "Screens" / f"{stem}{mod_ext}").exists():
+        return True
+    if stem != name and (root / "Screens" / f"{name}{mod_ext}").exists():
         return True
     # Legacy layout (pre-#105): standalone exe in .Runtime/
     if (root / ".Runtime" / (name + ext)).exists():


### PR DESCRIPTION
Closes #130, closes #131.

## Summary
- `Installer.write_install_log` now records every tabbed screen that ships with the host bundle, not just the user-selectable subset.
- `_Install.is_screen_installed` falls through to its filesystem probe even when the log lists some screens, and resolves the screen's script stem from `project.json` so `Landing → Screens/StartUp.pyd` reconciles correctly.
- `TabManager.open_tab` stops silently swallowing exceptions from `module.setup(frame)`. It now prints a traceback to stderr and renders an inline error panel inside the otherwise-blank tab so windowed Windows installs still tell the user what failed.

## Why
After install, `is_screen_installed("Landing")` returned False against a log that listed only `WOM`, `AssetManager`, `FloorView` (no tabbed screens), so `Host.update` silently refused to open the default tab on startup. When the user manually navigated via `View → Home`, the tab opened but the body was blank — a runtime error inside `setup()` was being eaten by `try: ... except Exception: pass`, leaving zero diagnostics.

## Test plan
- [ ] Fresh install with host + standalone screens selected → `install_log.json` lists every tabbed screen alongside the host and standalones.
- [ ] Host launches and auto-opens the default screen tab.
- [ ] If `setup()` raises, the tab body shows the traceback in red text instead of silently rendering empty.
- [ ] `is_screen_installed("WorderEditor")` returns True against the new log AND against an old-style log (FS probe fall-through).
- [ ] Existing behaviour preserved: standalone-screen lookups still resolve via the log's executable list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)