### PR TITLE
Replace JSON file paths with dict-based j_ data modules

### DIFF
--- a/Form/.VIS/Templates/screen.txt
+++ b/Form/.VIS/Templates/screen.txt
@@ -6,6 +6,8 @@ from Screens.defaults import *
 
 #%Screen Modules
 
+#%Screen Data
+
 #%Screen Elements
 
 #%Define Loop Modules

--- a/VIStk/Structures/_Screen.py
+++ b/VIStk/Structures/_Screen.py
@@ -173,6 +173,17 @@ class Screen(VINFO):
         with open(self.p_project+"/"+self.script,"r") as f: text = f.read()
         stitched = []
 
+        #Data — fully-qualified imports for j_* data modules
+        data_files = glob.glob(self.path+'/j_*')
+        data_import_lines = []
+        for dp in data_files:
+            module_path = dp.replace("\\", "/")
+            module_path = module_path.replace(self.path+"/", "Screens."+self.name+".")[:-3]
+            stitched.append(module_path)
+            data_import_lines.append(f"import {module_path}")
+        data_str = ("\n".join(data_import_lines) + "\n") if data_import_lines else ""
+        text = self._replace_section(text, "Screen Data", data_str)
+
         #Elements — fully-qualified imports at module level, build calls inside setup()
         elements = glob.glob(self.path+'/f_*')
         import_lines = []

--- a/VIStk/Templates/j_menu.txt
+++ b/VIStk/Templates/j_menu.txt
@@ -1,0 +1,7 @@
+menu = {
+    # "<key>": {
+    #     "text": "Menu Item Text",
+    #     "path": "ScreenName",
+    #     "nav": "k",
+    # },
+}

--- a/VIStk/Templates/screen.txt
+++ b/VIStk/Templates/screen.txt
@@ -6,6 +6,8 @@ from Screens.defaults import *
 
 #%Screen Modules
 
+#%Screen Data
+
 #%Screen Elements
 
 #%Define Loop Modules

--- a/VIStk/Widgets/_MenuWindow.py
+++ b/VIStk/Widgets/_MenuWindow.py
@@ -3,7 +3,7 @@ from VIStk.Widgets._VISMenu import VISMenu
 from tkinter import *
 
 class MenuWindow(SubRoot):
-    def __init__(self,parent:Tk|Toplevel,path:str,*args,center_ref=None,**kwargs):
+    def __init__(self,parent:Tk|Toplevel,data:dict,*args,center_ref=None,**kwargs):
         super().__init__(*args,**kwargs)
         self.master=parent
 
@@ -11,7 +11,7 @@ class MenuWindow(SubRoot):
         self.withdraw()
 
         #Load Menu
-        self.menu = VISMenu(self, path)
+        self.menu = VISMenu(self, data)
 
         #SubWindow Geometry
         self.update()

--- a/VIStk/Widgets/_ScrollMenu.py
+++ b/VIStk/Widgets/_ScrollMenu.py
@@ -3,7 +3,7 @@ from VIStk.Widgets._ScrollableFrame import *
 
 class ScrollMenu(ScrollableFrame):
     """A Scrollable Menu"""
-    def __init__(self, root:Widget, path:str, *args, **kwargs):
+    def __init__(self, root:Widget, data:dict, *args, **kwargs):
         super().__init__(root, *args, **kwargs)
-        self.VISMenu = VISMenu(self.scrollable_frame, path)
+        self.VISMenu = VISMenu(self.scrollable_frame, data)
         """The `VISMenu` Object"""

--- a/VIStk/Widgets/_VISMenu.py
+++ b/VIStk/Widgets/_VISMenu.py
@@ -1,37 +1,31 @@
-import json
 from tkinter import *
 from tkinter import ttk
 from VIStk.Widgets import MenuItem
 from VIStk.fUtil import *
 
 class VISMenu():
-    """The menu class drawings a column of buttons with subprocess calls to paths defined in a corresponding .json file.
+    """The menu class draws a column of buttons from a dict (typically a ``j_`` data module).
 
-    Has two roots because can destory both main window and subwindow on redirect.
+    Has two roots because can destroy both main window and subwindow on redirect.
     """
-    def __init__(self, parent:Frame|LabelFrame|Toplevel|Tk, path:str):
+    def __init__(self, parent:Frame|LabelFrame|Toplevel|Tk, data:dict):
         """
         Args:
-            root (Tk): Master root for destruction on redirect
-            _root (Toplevel): Toplevel object to create menu on
-            path (str): Path to .json file describing menu
-            destroyOnRedirect (bool): If True the root window will be destroyed on redicet
+            parent: The parent widget to create menu items in.
+            data (dict): Menu structure dict mapping keys to
+                ``{"text": ..., "path": ..., "nav": ...}`` entries.
         """
 
         self.parent = parent
         """The Parent to Create `MenuItems` in"""
         self.root = self.parent.winfo_toplevel()
         """The Root of the Parent Object"""
-        self.path = path
-        """The Path to the `.json` File to Read"""
         self.ob_dict = []
         """A Dictionary to Store `MenuItems` in"""
         self.n_dict = {}
         """A Dictionary to Store Navigation Controls in"""
 
-        #Open json file for menu structure
-        with open(path) as file:
-            self.dict:dict = json.load(file)
+        self.dict:dict = data
         self.parent.grid_columnconfigure(0,weight=1)
         for i in range(0, len(self.dict.keys()), 1):
             self.parent.grid_rowconfigure(i,weight=1)

--- a/docs/source/widgets.rst
+++ b/docs/source/widgets.rst
@@ -428,7 +428,9 @@ Usage
 
     from VIStk.Widgets import VISMenu
 
-    menu = VISMenu(parent_frame, "path/to/menu.json")
+    from Screens.Landing.j_administrate import menu as admin_data
+
+    menu = VISMenu(parent_frame, admin_data)
 
 ----
 
@@ -436,7 +438,7 @@ MenuItem
 --------
 
 ``MenuItem(Button)`` — A single button used by ``VISMenu``. Can be created directly for
-individual menu-style buttons without a full JSON-driven menu.
+individual menu-style buttons without a ``j_``-driven menu.
 
 .. code-block:: python
 
@@ -460,7 +462,9 @@ centers itself over the parent window.
 
     from VIStk.Widgets import MenuWindow
 
-    menu_win = MenuWindow(root, "path/to/menu.json")
+    from Screens.Landing.j_administrate import menu as admin_data
+
+    menu_win = MenuWindow(root, admin_data)
 
 ----
 
@@ -473,8 +477,9 @@ items than can fit on screen.
 .. code-block:: python
 
     from VIStk.Widgets import ScrollMenu
+    from Screens.Landing.j_administrate import menu as admin_data
 
-    sm = ScrollMenu(parent, "path/to/menu.json")
+    sm = ScrollMenu(parent, admin_data)
     sm.pack(fill=BOTH, expand=True)
 
 The ``VISMenu`` is placed inside the ``scrollable_frame``. Access the underlying menu via

--- a/documentation.md
+++ b/documentation.md
@@ -934,22 +934,22 @@ Label(sf.scrollable_frame, text="Item 2").pack()
 
 ### VISMenu
 
-`VISMenu` builds a column of buttons from a JSON file. Each button can launch a screen by name or a script/executable by path. Keyboard shortcuts are supported via a `nav` character per item.
+`VISMenu` builds a column of buttons from a `j_` data module dict. Each button can launch a screen by name or a script/executable by path. Keyboard shortcuts are supported via a `nav` character per item.
 
-**JSON format:**
+**`j_` data module format** (e.g. `Screens/Landing/j_administrate.py`):
 
-```json
-{
+```python
+menu = {
     "Work Orders": {
         "text": "Work Orders",
         "path": "wo",
-        "nav": "w"
+        "nav": "w",
     },
     "Rolodex": {
         "text": "Rolodex",
         "path": "rolo",
-        "nav": "r"
-    }
+        "nav": "r",
+    },
 }
 ```
 
@@ -963,8 +963,9 @@ Label(sf.scrollable_frame, text="Item 2").pack()
 
 ```python
 from VIStk.Widgets import VISMenu
+from Screens.Landing.j_administrate import menu as admin_data
 
-menu = VISMenu(parent_frame, "path/to/menu.json")
+menu = VISMenu(parent_frame, admin_data)
 ```
 
 `VISMenu` uses `grid` internally and configures the parent frame's rows and columns. Button text autosizes to fit the button. If the `path` matches a registered screen name, `Screen.load()` is called; otherwise the path is executed directly.
@@ -993,7 +994,9 @@ The button highlights blue on hover and returns to default on leave. Clicking ca
 ```python
 from VIStk.Widgets import MenuWindow
 
-menu_win = MenuWindow(root, "path/to/menu.json")
+from Screens.Landing.j_administrate import menu as admin_data
+
+menu_win = MenuWindow(root, admin_data)
 ```
 
 The window sizes itself to fit its menu content and centers on the parent. It does not need explicit geometry — `update()` and `getGeometry` are called internally.
@@ -1006,8 +1009,9 @@ The window sizes itself to fit its menu content and centers on the parent. It do
 
 ```python
 from VIStk.Widgets import ScrollMenu
+from Screens.Landing.j_administrate import menu as admin_data
 
-sm = ScrollMenu(parent, "path/to/menu.json")
+sm = ScrollMenu(parent, admin_data)
 sm.pack(fill=BOTH, expand=True)
 ```
 


### PR DESCRIPTION
## Summary
- VISMenu, MenuWindow, and ScrollMenu now accept a `dict` instead of a file path string, eliminating runtime filesystem dependencies that break compiled executables (fixes PYWOM#61)
- `stitch()` discovers `j_*` data modules alongside `f_*` elements under a new `#%Screen Data` template section
- Added `j_menu.txt` template for scaffolding new menu data modules

## Test plan
- [x] `pip install` and verify imports resolve (`VISMenu`, `MenuWindow` accept `data: dict`)
- [x] Functional test: `VISMenu(frame, {...})` initializes and creates MenuItems from a dict
- [x] PYWOM: convert `Screens/Landing/Menus/*.json` to `j_*.py` data modules and verify popup menus work
- [ ] Run `VIS stitch` on a screen with `j_*` files and verify `#%Screen Data` section populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)