### PR TITLE
Per-tab namespaces, wrapper .pyds, always-Host model

### DIFF
--- a/VIStk/Objects/_DetachedWindow.py
+++ b/VIStk/Objects/_DetachedWindow.py
@@ -26,15 +26,17 @@ class DetachedWindow:
     tabs allow closing, the window is destroyed.
     """
 
-    def __init__(self, host, module=None, screen_name: str | None = None,
+    def __init__(self, host, scr=None,
                  x_root: int | None = None, y_root: int | None = None,
                  btn_offset_x: int = 0, btn_offset_y: int = 0,
                  chromeless: bool = False):
         """
         Args:
             host:         The owning ``Host`` instance.
-            module:       Imported screen module for the first tab (or None).
-            screen_name:  Screen registry name for the first tab.
+            scr:          ``Screen`` to open as the first tab, or ``None``
+                          to create an empty window (used by drag-detach and
+                          pop-out, which then call ``move_tab`` to bring an
+                          existing tab in with its per-tab namespace intact).
             x_root:       Screen x coordinate for positioning (or None for default).
             y_root:       Screen y coordinate for positioning (or None for default).
             btn_offset_x: Cursor x offset within the original tab button.
@@ -117,25 +119,22 @@ class DetachedWindow:
         if self.chromeless:
             self.tab_manager.hide_tab_bar()
             self._split_view.lock()
-            if screen_name:
-                _scr = host.Project.getScreen(screen_name)
-                if _scr is not None and not _scr.host_menubar:
-                    self.HostMenu.detach()
+            if scr is not None and not scr.host_menubar:
+                self.HostMenu.detach()
 
         # Set window icon — chromeless windows use the screen's icon
         # rather than the project default.
-        self._load_icon(screen_name if self.chromeless else None)
+        self._load_icon(scr.name if (self.chromeless and scr is not None) else None)
 
         # Bind focus tracking
         self.win.bind("<FocusIn>", self._on_window_focus)
 
-        # Open the first tab if a module was provided
-        if module is not None and screen_name is not None:
-            hooks = host._import_hooks(host.Project.getScreen(screen_name))
-            icon = host._load_tab_icon(host.Project.getScreen(screen_name))
-            display = host._unique_display_name(screen_name)
-            self.tab_manager.open_tab(display, module, hooks=hooks, icon=icon,
-                                      base_name=screen_name)
+        # Open the first tab if a screen was provided.  TabManager.open_screen
+        # builds the per-tab namespace and exec's the entry script into it.
+        if scr is not None:
+            icon = host._load_tab_icon(scr)
+            display = host._unique_display_name(scr.name)
+            self.tab_manager.open_screen(scr, display, icon=icon)
 
         # Position window
         if x_root is not None and y_root is not None:
@@ -179,7 +178,6 @@ class DetachedWindow:
     def _position_window(self, x_root: int, y_root: int,
                          btn_offset_x: int, btn_offset_y: int):
         """Position the window so the cursor sits over the new tab at the same offset."""
-        import re
         try:
             self.win.geometry("1200x800+0+0")
             self.win.update_idletasks()
@@ -251,10 +249,8 @@ class DetachedWindow:
         # Route configure_menu through TabManager
         self.tab_manager._call_configure_menu(tab_id)
 
-        # Apply MENU_OVERRIDES if present
-        hooks = entry.get("hooks")
-        overrides = (getattr(hooks, "MENU_OVERRIDES", None)
-                     or getattr(module, "MENU_OVERRIDES", None))
+        # Apply MENU_OVERRIDES if present on the per-tab namespace
+        overrides = getattr(module, "MENU_OVERRIDES", None)
         if overrides:
             try:
                 self.HostMenu.apply_overrides(overrides)
@@ -278,81 +274,65 @@ class DetachedWindow:
             # Standalone windows advertise the screen identity directly
             # rather than the project: screen prefix used for the tabbed
             # Host shell.
-            self.win.title(f"{screen} \u2014 {info}" if info else screen)
+            self.win.title(f"{screen} — {info}" if info else screen)
             return
         base = self.host.Project.title
         if info:
-            self.win.title(f"{base}: {screen} \u2014 {info}")
+            self.win.title(f"{base}: {screen} — {info}")
         else:
             self.win.title(f"{base}: {screen}")
 
     # ── Pop-out, detach, refresh, split ───────────────────────────────────────
 
     def _on_tab_popout(self, tab_id: int):
-        """Pop out a tab into a new DetachedWindow at cursor position."""
+        """Pop out a tab into a new DetachedWindow at cursor position.
+
+        Uses ``move_tab`` so the per-tab namespace and in-tab state
+        survive the pop-out — the user expects to find their work in
+        the new window, not a fresh-loaded screen.
+        """
         pane = self._split_view.find_pane_for_tab(tab_id)
         if pane is None:
             return
-        entry = pane._tabs[tab_id]
-        display = entry["display_name"]
-        module = entry.get("module")
-        hooks = entry.get("hooks")
-        icon = entry.get("icon")
-        base_name = entry.get("base_name", display)
-        pane.close_tab(tab_id, skip_on_quit=True)
         x = self.win.winfo_pointerx()
         y = self.win.winfo_pointery()
-        self._create_detached(display, module, hooks, icon, base_name, x, y, 0, 0)
+        self._create_detached(pane, tab_id, x, y, 0, 0)
 
     def _on_tab_detach(self, tab_id: int):
         """Handle drag-to-detach — use pointer position and stored offsets."""
         pane = self._split_view.find_pane_for_tab(tab_id)
         if pane is None:
             return
-        entry = pane._tabs[tab_id]
-        display = entry["display_name"]
-        module = entry.get("module")
-        hooks = entry.get("hooks")
-        icon = entry.get("icon")
-        base_name = entry.get("base_name", display)
         bx = pane.tab_bar._last_drag_btn_offset_x
         by = pane.tab_bar._last_drag_btn_offset_y
-        pane.close_tab(tab_id, skip_on_quit=True)
         x = self.win.winfo_pointerx()
         y = self.win.winfo_pointery()
-        self._create_detached(display, module, hooks, icon, base_name, x, y, bx, by)
+        self._create_detached(pane, tab_id, x, y, bx, by)
 
-    def _create_detached(self, display, module, hooks, icon, base_name,
+    def _create_detached(self, source_pane, tab_id: int,
                          x_root, y_root, btn_offset_x, btn_offset_y):
-        """Create a new DetachedWindow and open a tab in it."""
-        dw = DetachedWindow(self.host, module=None, screen_name=None,
+        """Create an empty new DetachedWindow and move *tab_id* into it.
+
+        The empty window is positioned so the cursor lands over the
+        moved tab's button at the same offset the drag started with.
+        """
+        dw = DetachedWindow(self.host, scr=None,
                             x_root=x_root, y_root=y_root,
                             btn_offset_x=btn_offset_x,
                             btn_offset_y=btn_offset_y)
-        dw.tab_manager.open_tab(display, module, hooks=hooks, icon=icon,
-                                base_name=base_name)
+        dw.tab_manager.move_tab(source_pane, tab_id)
 
     def _on_tab_refresh(self, tab_id: int):
+        """Refresh delegates to TabManager.force_refresh_tab.
+
+        The previous override exists only because force_refresh_tab
+        couldn't resolve the Screen object itself; it now does, so the
+        override is a one-line delegation.
+        """
         pane = self._split_view.find_pane_for_tab(tab_id)
         if pane is None:
             return
-        entry = pane._tabs[tab_id]
-        display = entry["display_name"]
-        base_name = entry.get("base_name", display)
-        icon = entry.get("icon")
-        idx = pane.tab_bar.get_tab_idx(tab_id)
-        scr = self.host.Project.getScreen(base_name)
-        if scr is None:
-            pane.force_refresh_tab(tab_id)
-            return
-        pane.close_tab(tab_id, skip_on_quit=True)
-        module = self.host._import_screen(scr)
-        hooks = self.host._import_hooks(scr)
-        # Reuse the original tab_id so external references (recorded focus
-        # IDs, _pane_parents look-ups) survive the refresh — mirrors the
-        # identity-preserving behaviour of TabManager.force_refresh_tab.
-        pane.open_tab(display, module, hooks=hooks, icon=icon,
-                      insert_idx=idx, base_name=base_name, tab_id=tab_id)
+        pane.force_refresh_tab(tab_id)
 
     def _on_tab_split(self, tab_id: int, direction: str, target_pane=None):
         """Handle right-click 'Split right' / 'Split down' or drag-to-split."""
@@ -362,35 +342,40 @@ class DetachedWindow:
         if source_pane is None:
             return
         split_pane = target_pane if target_pane is not None else source_pane
-        entry = source_pane._tabs[tab_id]
-        display = entry["display_name"]
-        module = entry.get("module")
-        hooks = entry.get("hooks")
-        icon = entry.get("icon")
-        base_name = entry.get("base_name", display)
 
         target_sv = SplitView.find_owner(split_pane)
         if target_sv is None:
             target_sv = self._split_view
 
         if direction == "center":
+            # Merge into an existing pane — namespace must survive.
             if split_pane is source_pane:
                 return
-            source_pane.close_tab(tab_id, skip_on_quit=True)
-            split_pane.open_tab(display, module, hooks=hooks, icon=icon,
-                                base_name=base_name)
+            split_pane.move_tab(source_pane, tab_id)
         elif split_pane is source_pane:
+            # Same-pane split: the source pane splits into left/right;
+            # everything except this tab transfers to left_pane, then we
+            # place this tab in right_pane.  SplitView.split() preserves
+            # module references for non-excluded tabs; the excluded tab's
+            # per-tab namespace stays alive in sys.modules through the
+            # destroy-and-reopen because we never call close_tab.
             if len(source_pane._tabs) <= 1:
                 return
-            left_pane, right_pane = target_sv.split(
+            entry = source_pane._tabs[tab_id]
+            display   = entry["display_name"]
+            module    = entry.get("module")
+            icon      = entry.get("icon")
+            base_name = entry.get("base_name", display)
+            _, right_pane = target_sv.split(
                 split_pane, direction, exclude={tab_id})
-            right_pane.open_tab(display, module, hooks=hooks, icon=icon,
-                                base_name=base_name)
+            right_pane.open_tab(display, module, icon=icon,
+                                base_name=base_name, tab_id=tab_id)
         else:
-            source_pane.close_tab(tab_id, skip_on_quit=True)
-            left_pane, right_pane = target_sv.split(split_pane, direction)
-            right_pane.open_tab(display, module, hooks=hooks, icon=icon,
-                                base_name=base_name)
+            # Cross-pane split: split the destination first, then move the
+            # tab from source_pane into the new right_pane (namespace
+            # preserved via move_tab).
+            _, right_pane = target_sv.split(split_pane, direction)
+            right_pane.move_tab(source_pane, tab_id)
 
     # ── SplitView pane callbacks ──────────────────────────────────────────────
 
@@ -440,14 +425,14 @@ class DetachedWindow:
         # silently skipped in those panes.
         live_panes = list(self._split_view.all_tab_managers())
 
-        # Pass 1: collect vetoes (by tab_id)
+        # Pass 1: collect vetoes (by tab_id).  Under the per-tab namespace
+        # design hooks live inside ``module`` (the per-tab namespace) —
+        # no separate hooks key to consult.
         vetoed: set[int] = set()
         for tm in live_panes:
             for tab_id, tab in list(tm._tabs.items()):
                 module = tab.get("module")
-                hooks = tab.get("hooks")
-                quit_fn = (getattr(hooks, "on_quit", None)
-                           or getattr(module, "on_quit", None))
+                quit_fn = getattr(module, "on_quit", None)
                 if quit_fn:
                     try:
                         if quit_fn() is False:

--- a/VIStk/Objects/_Host.py
+++ b/VIStk/Objects/_Host.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import importlib
-import importlib.util
-import os
-import queue
 import sys
 import time
 from pathlib import Path
@@ -222,8 +218,6 @@ class Host:
                 return
 
         display = self._unique_display_name(scr.name)
-        module = self._import_screen(scr)
-        hooks = self._import_hooks(scr)
         icon = self._load_tab_icon(scr)
 
         # Open in the active TabManager, or the first window's primary pane
@@ -231,13 +225,12 @@ class Host:
         if target is None and self.detached_windows:
             target = self.detached_windows[0].tab_manager
         if target is None:
-            # No window exists yet — create one
+            # No window exists yet — create one; it opens the tab itself.
             from VIStk.Objects._DetachedWindow import DetachedWindow
-            dw = DetachedWindow(self, module, scr.name)
+            dw = DetachedWindow(self, scr)
             return
 
-        target.open_tab(display, module, hooks=hooks, icon=icon,
-                        base_name=scr.name)
+        target.open_screen(scr, display, icon=icon)
 
     def _open_standalone(self, scr):
         """Open a standalone (tabbed=False) screen as a new DetachedWindow.
@@ -247,11 +240,8 @@ class Host:
         ``tabbed=False`` looks like a plain application window rather than
         a single-tab Host shell.
         """
-        module = self._import_screen(scr)
-        if module is None:
-            return
         from VIStk.Objects._DetachedWindow import DetachedWindow
-        dw = DetachedWindow(self, module, scr.name, chromeless=True)
+        dw = DetachedWindow(self, scr, chromeless=True)
 
     def _load_tab_icon(self, scr) -> "PIL.ImageTk.PhotoImage | None":
         if not scr.icon:
@@ -269,53 +259,6 @@ class Host:
                    .resize((16, 16), Resampling.LANCZOS))
             return PIL.ImageTk.PhotoImage(img)
         except Exception:
-            return None
-
-    # ── Screen import ──────────────────────────────────────────────────────────
-
-    def _import_screen(self, scr):
-        script_path = self.Project.p_project + "/" + scr.script
-        project_dir = self.Project.p_project
-        try:
-            if project_dir not in sys.path:
-                sys.path.insert(0, project_dir)
-            # Module name must match the file's PyInit_<stem> export when
-            # loading a compiled .pyd, so use the script stem rather than
-            # scr.name (which is the logical screen label and may differ —
-            # e.g. screen "Landing" whose entry is "StartUp.pyd" exports
-            # PyInit_StartUp, not PyInit_Landing).
-            stem = os.path.splitext(os.path.basename(scr.script))[0]
-            spec = importlib.util.spec_from_file_location(stem, script_path)
-            if spec is None:
-                return None
-            mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(mod)
-            return mod
-        except Exception:
-            import traceback
-            sys.stderr.write(f"\n[VIStk] _import_screen failed for {scr.name!r}:\n{traceback.format_exc()}\n")
-            return None
-
-    def _import_hooks(self, scr):
-        name = scr.name
-        hooks_path = self.Project.p_project + f"/modules/{name}/m_{name}.py"
-        try:
-            if not os.path.exists(hooks_path):
-                return None
-            project_dir = self.Project.p_project
-            if project_dir not in sys.path:
-                sys.path.insert(0, project_dir)
-            spec = importlib.util.spec_from_file_location(
-                f"modules.{name}.m_{name}", hooks_path
-            )
-            if spec is None:
-                return None
-            mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(mod)
-            return mod
-        except Exception:
-            import traceback
-            sys.stderr.write(f"\n[VIStk] _import_hooks failed for {scr.name!r}:\n{traceback.format_exc()}\n")
             return None
 
     # ── FPS ────────────────────────────────────────────────────────────────────

--- a/VIStk/Objects/_TabManager.py
+++ b/VIStk/Objects/_TabManager.py
@@ -583,15 +583,104 @@ class TabManager(Frame):
 
         where each ``<bytes>`` value is the output of ``marshal.dumps``
         on the original source's compiled code object.
+
+        Patches: the wrapper .pyd may carry a VISKPATCH trailer
+        appended by ``Release.patch_screens``.  When present, the
+        trailer's override dict (same shape as ``_EMBEDDED``) is merged
+        over the baked-in dict — overridden entries win.  See
+        :meth:`_read_viskpatch` for the trailer format.
         """
         stem = os.path.splitext(scr.script)[0]
         mod = importlib.import_module(stem)
-        e = mod._EMBEDDED
+        embedded = mod._EMBEDDED
+
+        overrides = self._read_viskpatch(mod.__file__) if mod.__file__ else None
+        if overrides:
+            # Shallow merge — "entry" replaces wholesale, sub-dicts
+            # ("screens" / "modules") merge per-stem.  Avoid mutating
+            # the cached _EMBEDDED in place; build a fresh dict.
+            merged = {
+                "entry":   overrides.get("entry", embedded.get("entry")),
+                "screens": {**embedded.get("screens", {}),
+                            **overrides.get("screens", {})},
+                "modules": {**embedded.get("modules", {}),
+                            **overrides.get("modules", {})},
+            }
+            embedded = merged
+
         return (
-            marshal.loads(e["entry"]),
-            {k: marshal.loads(v) for k, v in e.get("screens", {}).items()},
-            {k: marshal.loads(v) for k, v in e.get("modules", {}).items()},
+            marshal.loads(embedded["entry"]),
+            {k: marshal.loads(v) for k, v in embedded.get("screens", {}).items()},
+            {k: marshal.loads(v) for k, v in embedded.get("modules", {}).items()},
         )
+
+    # VISKPATCH trailer format (v1):
+    #
+    #   [ ...wrapper .pyd bytes (unchanged)... ]
+    #   [ payload:  <length> bytes — marshal.dumps(override_dict) ]
+    #   [ checksum: 4 bytes BE uint32 — zlib.crc32(payload) ]
+    #   [ pyver:    4 bytes BE uint32 — (major<<8)|minor ]
+    #   [ length:   4 bytes BE uint32 — len(payload) ]
+    #   [ version:  1 byte  — 0x01 (format version) ]
+    #   [ magic:    9 bytes — b"VISKPATCH" ]
+    #
+    # Header is the last 22 bytes of the file.  Read backward from EOF:
+    # check magic first, then unpack the rest, then read the payload
+    # that sits immediately before the header.
+    _VISKPATCH_MAGIC = b"VISKPATCH"
+    _VISKPATCH_HEADER_LEN = 22   # 4+4+4+1+9
+    _VISKPATCH_FORMAT_VERSION = 1
+
+    @classmethod
+    def _read_viskpatch(cls, pyd_path: str):
+        """Return the marshalled override dict from a .pyd's VISKPATCH
+        trailer, or ``None`` if no trailer is present / invalid.
+
+        Returning ``None`` means "use the wrapper's ``_EMBEDDED`` as-is" —
+        callers should treat absence and corruption identically.
+
+        Rejection reasons (all silent, returning None):
+          * File smaller than the header.
+          * Magic mismatch — no trailer was appended.
+          * Format version mismatch — patch was built for a newer
+            VISKPATCH revision that this runtime doesn't understand.
+          * Python major.minor mismatch — marshal format is
+            interpreter-version-specific; refusing to unmarshal
+            avoids crashes on subtly-wrong code objects.
+          * CRC32 mismatch — payload corruption.
+        """
+        try:
+            with open(pyd_path, "rb") as f:
+                f.seek(0, 2)
+                size = f.tell()
+                if size < cls._VISKPATCH_HEADER_LEN:
+                    return None
+                f.seek(-cls._VISKPATCH_HEADER_LEN, 2)
+                header = f.read(cls._VISKPATCH_HEADER_LEN)
+                if header[-9:] != cls._VISKPATCH_MAGIC:
+                    return None
+                version  = header[-10]
+                length   = int.from_bytes(header[-14:-10], "big")
+                pyver    = int.from_bytes(header[-18:-14], "big")
+                checksum = int.from_bytes(header[-22:-18], "big")
+                if version != cls._VISKPATCH_FORMAT_VERSION:
+                    return None
+                expected_pyver = (sys.version_info.major << 8) | sys.version_info.minor
+                if pyver != expected_pyver:
+                    return None
+                if size < cls._VISKPATCH_HEADER_LEN + length:
+                    return None
+                f.seek(-(cls._VISKPATCH_HEADER_LEN + length), 2)
+                payload = f.read(length)
+        except OSError:
+            return None
+        import zlib
+        if zlib.crc32(payload) != checksum:
+            return None
+        try:
+            return marshal.loads(payload)
+        except Exception:
+            return None
 
     @staticmethod
     def _compile_file(path: str):

--- a/VIStk/Objects/_TabManager.py
+++ b/VIStk/Objects/_TabManager.py
@@ -385,10 +385,12 @@ class TabManager(Frame):
 
         pkg = ModuleType(pkg_name)
         pkg.__path__ = [scr.path]
+        pkg.__getattr__ = self._make_lazy_resolver(pkg_name)
         sys.modules[pkg_name] = pkg
 
         mod_pkg = ModuleType(mod_pkg_name)
         mod_pkg.__path__ = [scr.m_path]
+        mod_pkg.__getattr__ = self._make_lazy_resolver(mod_pkg_name)
         sys.modules[mod_pkg_name] = mod_pkg
 
         # Routing builtins reference the per-tab packages, so they must
@@ -404,16 +406,23 @@ class TabManager(Frame):
         entry_code, screens_codes, modules_codes = self._load_screen_codes(scr)
 
         # Pre-register every submodule under both per-tab packages with
-        # its pending code object attached.  Exec is deferred: the
-        # routing __import__ calls ``_ensure_executed`` to run any
-        # pending code at first reference.  This handles import-order
-        # surprises where module A (alphabetically earlier) does
-        # ``from B import name`` before B has been exec'd — eager
-        # exec in sorted order would return B's empty shell and
-        # raise ImportError on the name lookup.
-        for codes, parent_pkg, parent_name in (
-            (screens_codes, pkg,     pkg_name),
-            (modules_codes, mod_pkg, mod_pkg_name),
+        # its pending code object attached.  Exec is deferred to first
+        # access; the per-tab package's ``__getattr__`` (set above)
+        # runs the pending code when the submodule is first looked up,
+        # whether via routing-rewritten ``import`` or direct attribute
+        # access through the screen / module proxy.
+        #
+        # We intentionally do NOT ``setattr(parent_pkg, stem, sub)``.
+        # Pre-setting would make ``__getattr__`` skip — Python only
+        # invokes module ``__getattr__`` on missed attribute lookup.
+        # Leaving the submodules out of the parent's ``__dict__`` lets
+        # every access funnel through the lazy resolver, which is what
+        # gives us correct exec ordering even for late accesses from
+        # ``setup()`` (e.g. ``AM.m_parts._m_parts`` where ``AM`` is the
+        # per-tab modules package).
+        for codes, parent_name in (
+            (screens_codes, pkg_name),
+            (modules_codes, mod_pkg_name),
         ):
             for stem, code in codes.items():
                 full_name = f"{parent_name}.{stem}"
@@ -421,15 +430,63 @@ class TabManager(Frame):
                 sub.__builtins__ = routing_builtins
                 sub.__vistk_pending_code__ = code   # exec-on-demand marker
                 sys.modules[full_name] = sub
-                setattr(parent_pkg, stem, sub)
 
         # Exec the entry script into the per-tab package itself.  Its
         # top-level imports cascade through the routing __import__,
         # which exec's each submodule on demand in the correct order.
         # After this returns, ``pkg.setup``, ``pkg.loop``, etc. are
-        # populated in ``pkg.__dict__``.
+        # populated in ``pkg.__dict__``.  Submodules with pending code
+        # that weren't referenced by the entry script stay pending —
+        # the per-tab packages' ``__getattr__`` exec's them the moment
+        # someone (e.g. ``setup()``) reaches for them.
         exec(entry_code, pkg.__dict__)
         return pkg
+
+    @staticmethod
+    def _make_lazy_resolver(parent_name: str):
+        """Build the module-level ``__getattr__`` for a per-tab package.
+
+        Python 3.7+ invokes a module's ``__getattr__`` function when a
+        normal attribute lookup misses.  We hook that to find a
+        pre-registered submodule in ``sys.modules`` and exec its
+        pending code on first access.  After exec, we cache the
+        resolved submodule on the parent module's ``__dict__`` so
+        subsequent accesses go through the fast normal-attribute path
+        without re-invoking the resolver.
+
+        Crucial for two access patterns:
+
+        1. Routing-rewritten imports — ``import Screens.X.f_wonum``
+           rewrites to the per-tab name, real ``__import__`` finds the
+           pre-registered shell in ``sys.modules``, and the import
+           machinery's parent-attribute walk lands here.
+        2. Direct attribute chains — ``AM.m_parts._m_parts`` where
+           ``AM`` is the per-tab modules package.  No routing, just
+           plain attribute access; the resolver still fires because
+           we deliberately didn't ``setattr`` submodules at build time.
+        """
+        def __getattr__(name):
+            full_name = f"{parent_name}.{name}"
+            sub = sys.modules.get(full_name)
+            if sub is None:
+                raise AttributeError(
+                    f"module {parent_name!r} has no attribute {name!r}"
+                )
+            code = getattr(sub, "__vistk_pending_code__", None)
+            if code is not None:
+                # Clear the marker BEFORE exec so any circular-import
+                # chain returns the partially-populated module rather
+                # than recursing forever.
+                del sub.__vistk_pending_code__
+                exec(code, sub.__dict__)
+            # Cache for next access (skip the resolver on subsequent
+            # lookups — module-__dict__ lookup is faster than running
+            # __getattr__ every time).
+            parent_mod = sys.modules.get(parent_name)
+            if parent_mod is not None:
+                parent_mod.__dict__[name] = sub
+            return sub
+        return __getattr__
 
     @staticmethod
     def _ensure_executed(name: str):
@@ -475,16 +532,14 @@ class TabManager(Frame):
         (no per-tab routing), polluting ``sys.modules`` and breaking
         the per-tab isolation invariant.
 
-        Detection: does ``scr.script_path`` exist on disk?
-        ``script_path`` resolves to ``p_project + "/" + scr.script``,
-        which in dev points at the project's checkout (where the .py
-        files live) and in a release install points at the runtime/
-        root (where they don't — only wrapper .pyds ship there).
-        The release pipeline wipes runtime/ at the start of every
-        full build (see ``Release.release``), so stale .py leftovers
-        from previous pipelines no longer mislead this check.
+        Detection: Nuitka injects ``__compiled__`` into every compiled
+        module's globals.  Since VIStk ships as a compiled ``VIStk.pyd``
+        in release, this module (running inside that shared package)
+        has the attribute.  In dev VIStk is imported from source and
+        ``__compiled__`` is absent.
 
-        We tried two other discriminators and they both failed:
+        We've cycled through several other discriminators that all
+        failed in some scenario:
 
         * ``importlib.util.find_spec(stem)`` — returns ``None`` inside
           Nuitka's frozen runtime for loose .pyd files at the install
@@ -493,14 +548,19 @@ class TabManager(Frame):
         * ``sys.frozen`` — set by PyInstaller and Nuitka's onefile
           mode, but NOT by Nuitka's ``--standalone`` mode, which is
           what we ship.
+        * ``os.path.exists(scr.script_path)`` — fails when an install
+          ends up with .py files at the runtime root that we don't
+          control (Nuitka may copy the entry script's surrounding
+          tree into the .dist; old artifacts persist if the installer
+          merges over a previous install; etc.).
 
-        The presence-of-source check is the simplest signal that
-        actually distinguishes the two cases without relying on
-        per-tool conventions.
+        ``__compiled__`` is independent of filesystem state and
+        per-tool conventions — it's about how *this* code object was
+        produced, which is exactly the question we care about.
         """
-        if os.path.exists(scr.script_path):
-            return self._load_codes_from_source(scr)
-        return self._load_codes_from_embedded(scr)
+        if "__compiled__" in globals():
+            return self._load_codes_from_embedded(scr)
+        return self._load_codes_from_source(scr)
 
     def _load_codes_from_source(self, scr):
         """Read source .py files and return compiled code objects."""

--- a/VIStk/Objects/_TabManager.py
+++ b/VIStk/Objects/_TabManager.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import builtins
 import gc
+import importlib
+import importlib.util
 import inspect
+import marshal
+import os
 import queue
 import sys
 from tkinter import Frame
+from types import ModuleType
 
 from VIStk.Objects._Identity import new_id
 from VIStk.Widgets._TabBar import TabBar, _BG_BAR
@@ -33,6 +39,33 @@ def set_tab_info(frame, info):
         mgr.set_tab_info(tab_id, info)
 
 
+class _PerTabProxy:
+    """Stand-in for ``Screens`` / ``modules`` inside a per-tab namespace.
+
+    When the routing ``__import__`` rewrites ``import Screens.<X>.Y`` to
+    ``import Screens.<X>__tab<id>.Y``, Python's ``IMPORT_NAME`` opcode
+    binds the local name ``Screens`` to whatever the import returned.
+    Subsequent attribute access (``Screens.<X>.Y.something``) walks
+    attributes — never re-entering ``__import__`` — so the binding
+    must answer for ``.<X>``.
+
+    This proxy intercepts the screen-name attribute and returns the
+    per-tab package; everything else (``Screens.defaults``,
+    ``Screens.root``, ...) delegates to the real package.
+    """
+    __slots__ = ("_real", "_intercept_name", "_intercept_target")
+
+    def __init__(self, real_pkg, intercept_name, intercept_target):
+        object.__setattr__(self, "_real",             real_pkg)
+        object.__setattr__(self, "_intercept_name",   intercept_name)
+        object.__setattr__(self, "_intercept_target", intercept_target)
+
+    def __getattr__(self, name):
+        if name == self._intercept_name:
+            return self._intercept_target
+        return getattr(self._real, name)
+
+
 class TabManager(Frame):
     """Manages the tabbed screen area of a DetachedWindow.
 
@@ -55,9 +88,20 @@ class TabManager(Frame):
     lookup is non-deterministic in the presence of duplicate labels.
     Callers that hold a specific instance should pass the ID.
 
-    Hook lookup priority: if ``modules/<screen>/m_<screen>.py`` exists,
-    ``TabManager`` checks it first for ``on_focused``, ``on_unfocused``, and
-    ``configure_menu``.  The screen module is used as a fallback.
+    Per-tab screen namespaces
+    -------------------------
+    :meth:`open_screen` builds an isolated Python namespace for each tab,
+    registered in ``sys.modules`` under ``Screens.<name>__tab<id>`` and
+    ``modules.<name>__tab<id>``.  The entry script and every ``f_*`` /
+    ``m_*`` / ``j_*`` submodule are exec'd into per-tab module objects,
+    so two tabs of the same screen do NOT share module-level state.
+    See :meth:`_build_namespace`.
+
+    Tab moves between panes (:meth:`move_tab`) destroy and rebuild the
+    Tk frame (Tk can't reparent widgets) but preserve the per-tab
+    namespace.  The screen's ``setup()`` runs again to bind widgets to
+    the new frame; Python state (StringVar values, loaded data,
+    closures) survives.
 
     Callbacks (receive ``tab_id: int`` as the first argument)::
 
@@ -80,7 +124,12 @@ class TabManager(Frame):
         """Stable process-unique pane ID (0.4.7)."""
 
         self._tabs: dict[int, dict] = {}
-        """tab_id -> {tab_id, display_name, frame, module, hooks, icon, base_name, info, _info_trace}"""
+        """tab_id -> {tab_id, display_name, frame, module, icon, base_name, info, _info_trace}
+
+        ``module`` is the per-tab namespace built by :meth:`_build_namespace`.
+        Hooks (``on_focused``, ``on_quit``, ``configure_menu``, ...) live
+        inside that same namespace — no separate ``hooks`` key.
+        """
         self._active: int | None = None
         self._position: str = position
 
@@ -120,14 +169,20 @@ class TabManager(Frame):
     # ── Action queue pump ─────────────────────────────────────────────────────
 
     def _pump_actions(self):
-        """Drain queued navigation callables on the Tk main loop."""
+        """Drain queued navigation callables on the Tk main loop.
+
+        Exceptions raised by queued callables are printed to stderr —
+        previously swallowed silently, which made debugging "tab
+        didn't open and there's no error" scenarios impossible.
+        """
         try:
             while True:
                 fn = self._action_queue.get_nowait()
                 try:
                     fn()
                 except Exception:
-                    pass
+                    import traceback
+                    traceback.print_exc()
         except queue.Empty:
             pass
         try:
@@ -137,7 +192,6 @@ class TabManager(Frame):
 
     def _stop_action_pump(self, event=None):
         """Cancel the pending pump on widget destruction."""
-        # <Destroy> bubbles up from descendants; only act for this widget.
         if event is not None and event.widget is not self:
             return
         if self._action_pump_id is not None:
@@ -161,7 +215,7 @@ class TabManager(Frame):
         if not self._tab_bar_hidden:
             if self._position in ("top", "bottom"):
                 self.tab_bar.pack(side=self._position, fill="x")
-            else:  # left or right
+            else:
                 self.tab_bar.pack(side=self._position, fill="y")
         if self._position in ("top", "bottom"):
             self._content.pack(side="top", fill="both", expand=True)
@@ -243,54 +297,51 @@ class TabManager(Frame):
     def navigate(self, name: str, args=None):
         """Navigate this pane to a new screen.
 
-        Tears down the current screen (calling on_quit), cleans up modules,
-        imports the new screen, runs setup(), and handles args.
+        Tears down the current screen (calling on_quit), then opens a
+        fresh tab for *name* via :meth:`open_screen`.
         """
         from VIStk.Objects._Host import _HOST_INSTANCE
         if _HOST_INSTANCE is None:
             return
 
-        # 1. Call on_quit on active screen and close it
         if self._active is not None and self._active in self._tabs:
             entry = self._tabs[self._active]
             module = entry.get("module")
-            hooks = entry.get("hooks")
-            quit_fn = (getattr(hooks, "on_quit", None)
-                       or getattr(module, "on_quit", None))
+            quit_fn = getattr(module, "on_quit", None)
             if quit_fn:
                 try:
                     if quit_fn() is False:
                         return  # vetoed
                 except Exception:
                     pass
-            base_name = entry.get("base_name", entry.get("display_name", name))
             self.close_tab(self._active)
-            self._cleanup_screen_modules(base_name)
 
-        # 2. Import new screen
         scr = _HOST_INSTANCE.Project.getScreen(name)
         if scr is None:
             return
-        module = _HOST_INSTANCE._import_screen(scr)
-        hooks = _HOST_INSTANCE._import_hooks(scr)
-        icon = _HOST_INSTANCE._load_tab_icon(scr)
+        icon    = _HOST_INSTANCE._load_tab_icon(scr)
         display = _HOST_INSTANCE._unique_display_name(name)
+        tab_id  = self.open_screen(scr, display, icon=icon)
 
-        # 3. Open new tab
-        self.open_tab(display, module, hooks=hooks, icon=icon, base_name=name)
-
-        # 4. Handle args via ArgHandler
-        if args is not None and module and hasattr(module, "ArgHandler"):
-            try:
-                module.ArgHandler.handle(args)
-            except Exception:
-                pass
+        if args is not None and tab_id is not None:
+            module = self._tabs[tab_id].get("module")
+            if module and hasattr(module, "ArgHandler"):
+                try:
+                    module.ArgHandler.handle(args)
+                except Exception:
+                    pass
 
     def _cleanup_screen_modules(self, screen_name: str):
-        """Remove screen-specific entries from sys.modules to allow clean re-import."""
+        """Remove EVERY per-tab sys.modules entry for *screen_name*.
+
+        Sweeps every ``Screens.<screen_name>__tab*`` and
+        ``modules.<screen_name>__tab*`` registration.  Kept as a
+        screen-wide purge for callers that don't have a specific tab_id;
+        single-tab close uses :meth:`_destroy_namespace_entries` instead.
+        """
         prefixes = (
-            f"Screens.{screen_name}.",
-            f"modules.{screen_name}.",
+            f"Screens.{screen_name}__tab",
+            f"modules.{screen_name}__tab",
         )
         to_delete = [k for k in sys.modules if any(k.startswith(p) for p in prefixes)]
         for key in to_delete:
@@ -298,32 +349,348 @@ class TabManager(Frame):
         gc.collect()
 
     def _cleanup_all_modules(self):
-        """Clean up all screen modules owned by this TabManager."""
-        for entry in list(self._tabs.values()):
-            base_name = entry.get("base_name", entry.get("display_name", ""))
+        """Strip per-tab sys.modules entries for every tab in this manager.
+
+        Called by ``DetachedWindow._destroy_pane`` when a pane is
+        removed before its tabs went through ``close_tab``.  Defensive —
+        tabs closed via ``close_tab`` clean up their own namespace.
+        """
+        for tab_id, entry in list(self._tabs.items()):
+            base_name = entry.get("base_name") or entry.get("display_name")
             if base_name:
-                self._cleanup_screen_modules(base_name)
+                self._destroy_namespace_entries(tab_id, base_name)
+
+    # ── Per-tab namespace construction ────────────────────────────────────────
+
+    def _build_namespace(self, tab_id: int, scr) -> ModuleType:
+        """Build a fresh per-tab namespace for *scr* and exec its entry into it.
+
+        Registers per-tab versions of the screen's UI subpackage at
+        ``Screens.<name>__tab<id>`` (with each ``f_*`` / ``j_*`` as a
+        submodule) and the logic subpackage at ``modules.<name>__tab<id>``
+        (with each ``m_*`` as a submodule).  Every submodule shares a
+        routing ``__builtins__`` whose ``__import__`` redirects absolute
+        ``Screens.<name>.*`` / ``modules.<name>.*`` imports to the
+        per-tab variants; everything else passes through unchanged.
+
+        Pre-registers all submodules in ``sys.modules`` *before* exec'ing
+        any of them so circular imports between them resolve.
+
+        Returns the per-tab package.  Caller (:meth:`open_screen`) stores
+        it as ``tab_entry["module"]`` and invokes
+        ``module.setup(frame)`` / ``module.loop()`` / etc. on it.
+        """
+        pkg_name     = f"Screens.{scr.name}__tab{tab_id}"
+        mod_pkg_name = f"modules.{scr.name}__tab{tab_id}"
+
+        pkg = ModuleType(pkg_name)
+        pkg.__path__ = [scr.path]
+        sys.modules[pkg_name] = pkg
+
+        mod_pkg = ModuleType(mod_pkg_name)
+        mod_pkg.__path__ = [scr.m_path]
+        sys.modules[mod_pkg_name] = mod_pkg
+
+        # Routing builtins reference the per-tab packages, so they must
+        # exist in sys.modules first (already done above).
+        routing_builtins = self._make_routing_import(
+            tab_id, scr.name, pkg, mod_pkg,
+        )
+        pkg.__builtins__     = routing_builtins
+        mod_pkg.__builtins__ = routing_builtins
+
+        # Load code objects — from source files in dev, from the wrapper
+        # .pyd's ``_EMBEDDED`` dict in a compiled release build.
+        entry_code, screens_codes, modules_codes = self._load_screen_codes(scr)
+
+        # Pre-register every submodule under both per-tab packages with
+        # its pending code object attached.  Exec is deferred: the
+        # routing __import__ calls ``_ensure_executed`` to run any
+        # pending code at first reference.  This handles import-order
+        # surprises where module A (alphabetically earlier) does
+        # ``from B import name`` before B has been exec'd — eager
+        # exec in sorted order would return B's empty shell and
+        # raise ImportError on the name lookup.
+        for codes, parent_pkg, parent_name in (
+            (screens_codes, pkg,     pkg_name),
+            (modules_codes, mod_pkg, mod_pkg_name),
+        ):
+            for stem, code in codes.items():
+                full_name = f"{parent_name}.{stem}"
+                sub = ModuleType(full_name)
+                sub.__builtins__ = routing_builtins
+                sub.__vistk_pending_code__ = code   # exec-on-demand marker
+                sys.modules[full_name] = sub
+                setattr(parent_pkg, stem, sub)
+
+        # Exec the entry script into the per-tab package itself.  Its
+        # top-level imports cascade through the routing __import__,
+        # which exec's each submodule on demand in the correct order.
+        # After this returns, ``pkg.setup``, ``pkg.loop``, etc. are
+        # populated in ``pkg.__dict__``.
+        exec(entry_code, pkg.__dict__)
+        return pkg
+
+    @staticmethod
+    def _ensure_executed(name: str):
+        """Walk the dotted *name* and exec any per-tab submodule that
+        still carries pending code.
+
+        Called by the routing ``__import__`` before returning a
+        rewritten target so callers always see a fully-populated
+        module.  Safe to call repeatedly — pending-code attr is
+        cleared atomically before exec runs (sentinel prevents
+        recursive exec loops on circular imports).
+        """
+        parts = name.split(".")
+        for i in range(1, len(parts) + 1):
+            sub_name = ".".join(parts[:i])
+            mod = sys.modules.get(sub_name)
+            if mod is None:
+                continue
+            code = getattr(mod, "__vistk_pending_code__", None)
+            if code is None:
+                continue
+            # Clear marker before exec to defeat recursion in
+            # circular-import chains: if A.exec → triggers import
+            # of B → triggers import of A again, the second pass
+            # finds no pending code and returns A's current
+            # (partial) state — same semantics as Python's normal
+            # circular-import handling.
+            del mod.__vistk_pending_code__
+            exec(code, mod.__dict__)
+
+    def _load_screen_codes(self, scr):
+        """Return ``(entry_code, screens_codes, modules_codes)`` for *scr*.
+
+        Each return value is either a single code object (entry) or a
+        ``{stem: code_object}`` dict (screens/modules).
+
+        Resolution: prefer the wrapper ``.pyd``'s ``_EMBEDDED`` dict if
+        one is on the import path (compiled release), otherwise read
+        source files from disk (dev).  We probe with
+        :func:`importlib.util.find_spec` and only import when we know
+        the spec points at a compiled extension — importing a source
+        ``.py`` would execute its top-level code with normal builtins
+        (no per-tab routing), polluting ``sys.modules`` and breaking
+        the per-tab isolation invariant.
+
+        Detection: does ``scr.script_path`` exist on disk?
+        ``script_path`` resolves to ``p_project + "/" + scr.script``,
+        which in dev points at the project's checkout (where the .py
+        files live) and in a release install points at the runtime/
+        root (where they don't — only wrapper .pyds ship there).
+        The release pipeline wipes runtime/ at the start of every
+        full build (see ``Release.release``), so stale .py leftovers
+        from previous pipelines no longer mislead this check.
+
+        We tried two other discriminators and they both failed:
+
+        * ``importlib.util.find_spec(stem)`` — returns ``None`` inside
+          Nuitka's frozen runtime for loose .pyd files at the install
+          root, even when ``importlib.import_module`` of the same name
+          succeeds.
+        * ``sys.frozen`` — set by PyInstaller and Nuitka's onefile
+          mode, but NOT by Nuitka's ``--standalone`` mode, which is
+          what we ship.
+
+        The presence-of-source check is the simplest signal that
+        actually distinguishes the two cases without relying on
+        per-tool conventions.
+        """
+        if os.path.exists(scr.script_path):
+            return self._load_codes_from_source(scr)
+        return self._load_codes_from_embedded(scr)
+
+    def _load_codes_from_source(self, scr):
+        """Read source .py files and return compiled code objects."""
+        entry = self._compile_file(scr.script_path)
+        screens = self._compile_dir(scr.path)   if os.path.isdir(scr.path)   else {}
+        modules = self._compile_dir(scr.m_path) if os.path.isdir(scr.m_path) else {}
+        return entry, screens, modules
+
+    def _load_codes_from_embedded(self, scr):
+        """Read marshalled bytecode from the compiled wrapper's ``_EMBEDDED``
+        dict and unmarshal into code objects.
+
+        The wrapper is the compiled .pyd produced by the release pipeline
+        (see ``Release._build_screen_wrapper``).  It exposes a single
+        attribute, ``_EMBEDDED``, with shape::
+
+            {"entry":   <bytes>,
+             "screens": {stem: <bytes>, ...},
+             "modules": {stem: <bytes>, ...}}
+
+        where each ``<bytes>`` value is the output of ``marshal.dumps``
+        on the original source's compiled code object.
+        """
+        stem = os.path.splitext(scr.script)[0]
+        mod = importlib.import_module(stem)
+        e = mod._EMBEDDED
+        return (
+            marshal.loads(e["entry"]),
+            {k: marshal.loads(v) for k, v in e.get("screens", {}).items()},
+            {k: marshal.loads(v) for k, v in e.get("modules", {}).items()},
+        )
+
+    @staticmethod
+    def _compile_file(path: str):
+        """Read one source file and return its compiled code object."""
+        with open(path, "rb") as f:
+            return compile(f.read(), path, "exec")
+
+    @classmethod
+    def _compile_dir(cls, src_dir: str) -> dict:
+        """Return ``{stem: code_object}`` for every ``*.py`` in *src_dir*
+        except ``__init__.py``."""
+        out: dict = {}
+        for fname in sorted(os.listdir(src_dir)):
+            if fname.endswith(".py") and fname != "__init__.py":
+                stem = fname[:-3]
+                out[stem] = cls._compile_file(f"{src_dir}/{fname}")
+        return out
+
+    def _make_routing_import(self, tab_id: int, screen_name: str,
+                              per_tab_screens, per_tab_modules):
+        """Return a ``__builtins__`` dict whose ``__import__`` reroutes
+        ``Screens.<screen_name>.*`` and ``modules.<screen_name>.*`` to
+        the per-tab versions, leaving everything else unchanged.
+
+        For ``import X.Y.Z`` (empty fromlist) returns a
+        :class:`_PerTabProxy` so subsequent attribute access on the
+        local ``Screens`` / ``modules`` binding routes through the
+        per-tab namespace.  For ``from X.Y import Z`` (non-empty
+        fromlist) returns the rewritten leaf module directly — Python
+        applies ``getattr(leaf, "Z")`` and the leaf IS the per-tab
+        module, so the right thing happens.
+        """
+        real = builtins.__import__
+        sp, ts = f"Screens.{screen_name}", f"Screens.{screen_name}__tab{tab_id}"
+        mp, tm = f"modules.{screen_name}", f"modules.{screen_name}__tab{tab_id}"
+
+        # Ensure the real top-level packages exist in sys.modules before
+        # wrapping them — they hold shared modules like ``Screens.defaults``
+        # and ``modules.menu`` that screen code passes through to.  First
+        # screen open will be the import trigger; subsequent opens find
+        # them already cached.
+        real_screens = sys.modules.get("Screens") or importlib.import_module("Screens")
+        real_modules = sys.modules.get("modules") or importlib.import_module("modules")
+
+        screens_proxy = _PerTabProxy(real_screens, screen_name, per_tab_screens)
+        modules_proxy = _PerTabProxy(real_modules, screen_name, per_tab_modules)
+
+        ensure = self._ensure_executed
+
+        def routing_import(name, glb=None, loc=None, fromlist=(), level=0):
+            if level == 0:
+                rewritten = None
+                proxy = None
+                if name == sp or name.startswith(sp + "."):
+                    rewritten = ts + name[len(sp):]
+                    proxy = screens_proxy
+                elif name == mp or name.startswith(mp + "."):
+                    rewritten = tm + name[len(mp):]
+                    proxy = modules_proxy
+
+                if rewritten is not None:
+                    # Exec the target module's pending code (if any)
+                    # before real __import__ uses it — otherwise the
+                    # leaf comes back as an empty pre-registered shell.
+                    ensure(rewritten)
+                    result = real(rewritten, glb, loc, fromlist, 0)
+                    # ``from <pkg> import <name>`` may name a submodule.
+                    # Ensure those are exec'd too; real __import__ won't
+                    # re-trigger load on pre-registered modules.
+                    if fromlist:
+                        for item in fromlist:
+                            if item == "*":
+                                continue
+                            ensure(f"{rewritten}.{item}")
+                    return result if fromlist else proxy
+
+                # ``from modules import <screen_name>`` /
+                # ``from Screens import <screen_name>`` — the new stitch
+                # convention emits this pattern.  Real ``__import__``
+                # would return the on-disk ``modules`` / ``Screens``
+                # package and ``IMPORT_FROM`` would fail because the
+                # package doesn't expose the per-tab module as an
+                # attribute.  Return the proxy instead — its
+                # ``__getattr__`` answers for ``screen_name`` with the
+                # per-tab module.
+                if fromlist and screen_name in fromlist:
+                    if name == "modules":
+                        ensure(tm)
+                        return modules_proxy
+                    if name == "Screens":
+                        ensure(ts)
+                        return screens_proxy
+            return real(name, glb, loc, fromlist, level)
+
+        nb = dict(builtins.__dict__)
+        nb["__import__"] = routing_import
+        return nb
+
+    def _destroy_namespace_entries(self, tab_id: int, screen_name: str):
+        """Drop this tab's per-tab sys.modules entries.
+
+        Targeted counterpart to :meth:`_cleanup_screen_modules` —
+        removes only ``Screens.<screen_name>__tab<tab_id>*`` and
+        ``modules.<screen_name>__tab<tab_id>*``, leaving sibling tabs
+        of the same screen intact.
+        """
+        prefixes = (
+            f"Screens.{screen_name}__tab{tab_id}",
+            f"modules.{screen_name}__tab{tab_id}",
+        )
+        to_del = [k for k in sys.modules
+                  if any(k == p or k.startswith(p + ".") for p in prefixes)]
+        for k in to_del:
+            del sys.modules[k]
+
+    # ── Tab opening ───────────────────────────────────────────────────────────
+
+    def open_screen(self, scr, display: str, icon=None,
+                    insert_idx: int = -1, tab_id: int | None = None) -> int | None:
+        """Open *scr* as a new tab, building a fresh per-tab namespace.
+
+        Allocates ``tab_id`` (or uses the supplied one — for
+        force-refresh and split-rebuild scenarios that preserve
+        identity), builds the per-tab namespace via
+        :meth:`_build_namespace`, then registers the tab via
+        :meth:`open_tab` with the freshly-built module.
+        """
+        if tab_id is None:
+            existing = self._id_for_display(display)
+            if existing is not None:
+                self.tab_bar.focus_tab(existing)
+                return None
+            tab_id = new_id()
+        elif tab_id in self._tabs:
+            return None
+
+        instance = self._build_namespace(tab_id, scr)
+        return self.open_tab(display, instance, icon=icon,
+                             insert_idx=insert_idx, base_name=scr.name,
+                             tab_id=tab_id)
 
     def open_tab(self, name: str, module, hooks=None, icon=None,
                  insert_idx: int = -1, base_name: str = None,
                  tab_id: int | None = None) -> int | None:
-        """Open a new tab and build its screen UI.
+        """Place an already-built *module* as a new tab.
 
-        Args:
-            name:       Display label shown on the tab button.
-            module:     Imported screen module.
-            hooks:      Optional hooks module from ``modules/<name>/m_<name>.py``.
-            icon:       Optional ``PIL.ImageTk.PhotoImage``.
-            insert_idx: 0-based insertion position; -1 appends.
-            base_name:  Screen registry name (same as *name* if no suffix).
-            tab_id:     Optional existing tab_id to reuse (for SplitView
-                rebuilds that must preserve tab identity across pane
-                destruction). When ``None`` a fresh ID is allocated.
+        Low-level entry point used by:
+          * :meth:`open_screen` after building a per-tab namespace
+          * :meth:`move_tab` to place a moved tab's preserved namespace
+          * ``SplitView`` snapshot/rebuild to restore tabs with their
+            existing per-tab namespaces
 
-        Returns:
-            The tab's ``tab_id`` on success, ``None`` if a tab with this
-            exact display name already exists in *this* pane (callers with
-            the same label across panes are fine).
+        The legacy *hooks* argument is accepted for back-compat but
+        ignored — under the per-tab namespace design hooks live inside
+        ``module`` (the per-tab namespace).
+
+        Returns the tab's ``tab_id`` on success, ``None`` if a tab with
+        this exact display name already exists in *this* pane (callers
+        with the same label across panes are fine).
         """
         # Reject only if the same ``tab_id`` is already registered —
         # SplitView rebuilds call with an explicit ``tab_id`` and require
@@ -354,11 +721,10 @@ class TabManager(Frame):
             "display_name":  name,
             "frame":         frame,
             "module":        module,
-            "hooks":         hooks,
             "icon":          icon,
             "base_name":     base_name if base_name is not None else name,
             "info":          "",
-            "_info_trace":   None,   # (StringVar, trace_id) | None
+            "_info_trace":   None,
         }
 
         if module and hasattr(module, "setup"):
@@ -400,8 +766,77 @@ class TabManager(Frame):
         self.tab_bar.open_tab(tab_id, name, icon=icon, insert_idx=insert_idx)
         return tab_id
 
+    def move_tab(self, source_mgr: "TabManager", tab_id: int,
+                 insert_idx: int = -1) -> int | None:
+        """Move *tab_id* from *source_mgr* to this manager.
+
+        Tk widgets can't be reparented cleanly, so the source frame is
+        destroyed and a fresh one built under this manager's content
+        frame; ``setup(new_frame)`` runs again to bind widgets to it.
+        The per-tab sys.modules entries (and the per-tab namespace they
+        contain) are preserved — module-level state like ``StringVar``
+        values, loaded LRF data, and callback closures survive the move.
+
+        The ``tab_id`` is preserved across the move so external
+        references (recorded focus IDs, pane-parent lookups) stay valid.
+
+        Returns the preserved ``tab_id`` on success, ``None`` if the tab
+        wasn't found in *source_mgr* or destination already holds the ID.
+        """
+        if tab_id not in source_mgr._tabs:
+            return None
+        if tab_id in self._tabs:
+            return None
+
+        entry     = source_mgr._tabs[tab_id]
+        display   = entry["display_name"]
+        icon      = entry.get("icon")
+        base_name = entry.get("base_name", display)
+        module    = entry.get("module")
+        trace     = entry.get("_info_trace")
+        info_str  = entry.get("info", "")
+
+        # Tear down source pane's view of this tab without touching
+        # sys.modules — the per-tab namespace lives on.
+        if source_mgr._active == tab_id:
+            source_mgr._deactivate(tab_id)
+            source_mgr._active = None
+        if trace is not None:
+            var, tid = trace
+            try:
+                var.trace_remove("write", tid)
+            except Exception:
+                pass
+        try:
+            entry["frame"].destroy()
+        except Exception:
+            pass
+        del source_mgr._tabs[tab_id]
+        source_mgr.tab_bar.close_tab(tab_id)
+
+        # Build the new frame and re-run setup with the preserved module
+        new_id_returned = self.open_tab(display, module, icon=icon,
+                                         insert_idx=insert_idx,
+                                         base_name=base_name, tab_id=tab_id)
+        if new_id_returned is None:
+            return None
+
+        # Restore the info trace on the new pane (prefer StringVar if
+        # the caller wired one originally)
+        if trace is not None:
+            var, _ = trace
+            self.set_tab_info(tab_id, var)
+        elif info_str:
+            self.set_tab_info(tab_id, info_str)
+
+        return tab_id
+
     def close_tab(self, key, skip_on_quit: bool = False) -> bool:
         """Close the tab identified by *key* (tab_id or display label).
+
+        Destroys the per-tab namespace as part of teardown.  Callers
+        that want to move a tab between managers without losing its
+        namespace should use :meth:`move_tab` instead.
 
         Args:
             key:          Tab ID (int) or display label (str).
@@ -412,14 +847,13 @@ class TabManager(Frame):
         if tab_id is None:
             return False
 
-        entry = self._tabs[tab_id]
+        entry     = self._tabs[tab_id]
+        base_name = entry.get("base_name") or entry.get("display_name", "")
 
         # Call on_quit unless skipped (e.g. window close already checked)
         if not skip_on_quit:
-            module = entry.get("module")
-            hooks = entry.get("hooks")
-            quit_fn = (getattr(hooks, "on_quit", None)
-                       or getattr(module, "on_quit", None))
+            module  = entry.get("module")
+            quit_fn = getattr(module, "on_quit", None)
             if quit_fn:
                 try:
                     if quit_fn() is False:
@@ -441,6 +875,12 @@ class TabManager(Frame):
             self._active = None
 
         entry["frame"].destroy()
+
+        # Drop per-tab sys.modules entries for this tab.  Sibling tabs
+        # of the same screen are unaffected.
+        if base_name:
+            self._destroy_namespace_entries(tab_id, base_name)
+
         del self._tabs[tab_id]
         self.tab_bar.close_tab(tab_id)
         return True
@@ -457,11 +897,13 @@ class TabManager(Frame):
         return self._resolve_id(key) is not None
 
     def force_refresh_tab(self, key) -> bool:
-        """Close and reopen the identified tab at its current position, re-running ``setup``.
+        """Close and reopen the identified tab, re-running ``setup`` with
+        a fresh per-tab namespace.
 
         Preserves the same ``tab_id`` across the refresh so external
-        references (``_pane_parents`` look-ups, recorded focus IDs, etc.)
-        remain valid.
+        references survive.  In-tab state is intentionally lost — that's
+        the point of "refresh."  For state-preserving moves between
+        panes, use :meth:`move_tab`.
         """
         tab_id = self._resolve_id(key)
         if tab_id is None:
@@ -469,20 +911,21 @@ class TabManager(Frame):
         idx       = self.tab_bar.get_tab_idx(tab_id)
         entry     = self._tabs[tab_id]
         display   = entry["display_name"]
-        module    = entry.get("module")
-        hooks     = entry.get("hooks")
         icon      = entry.get("icon")
         base_name = entry.get("base_name", display)
 
-        # Tear down without calling on_quit
+        from VIStk.Objects._Host import _HOST_INSTANCE
+        if _HOST_INSTANCE is None:
+            return False
+        scr = _HOST_INSTANCE.Project.getScreen(base_name)
+        if scr is None:
+            return False
+
         if not self.close_tab(tab_id, skip_on_quit=True):
             return False
 
-        # Re-open reusing the original tab_id so any external reference to
-        # this tab (e.g. focus tracking in SplitView) survives the refresh.
-        new_tab_id = self.open_tab(display, module, hooks=hooks, icon=icon,
-                                    insert_idx=idx, base_name=base_name,
-                                    tab_id=tab_id)
+        new_tab_id = self.open_screen(scr, display, icon=icon,
+                                       insert_idx=idx, tab_id=tab_id)
         return new_tab_id is not None
 
     def set_tab_info(self, key, info) -> None:
@@ -517,11 +960,16 @@ class TabManager(Frame):
     # ── Hook lookup ────────────────────────────────────────────────────────────
 
     def _get_hook(self, tab_id: int, hook_name: str):
+        """Look up *hook_name* on the tab's per-tab namespace.
+
+        Under the per-tab namespace design hooks
+        (``on_focused``, ``on_unfocused``, ``on_quit``,
+        ``configure_menu``, ``has_unsaved``) and the rest of the
+        screen's API both live in the same per-tab module — no separate
+        hooks module to consult.
+        """
         entry = self._tabs.get(tab_id, {})
-        fn = getattr(entry.get("hooks"), hook_name, None)
-        if fn is None:
-            fn = getattr(entry.get("module"), hook_name, None)
-        return fn
+        return getattr(entry.get("module"), hook_name, None)
 
     # ── Internal ───────────────────────────────────────────────────────────────
 
@@ -531,10 +979,8 @@ class TabManager(Frame):
             return
         self._tabs[tab_id]["info"] = info
         name = self._tabs[tab_id]["display_name"]
-        # Update tab button text
-        display = f"{name} \u2014 {info}" if info else name
+        display = f"{name} — {info}" if info else name
         self.tab_bar.update_tab_label(tab_id, display)
-        # Notify interested parties (Host, DetachedWindow)
         if self.on_tab_info_change:
             self.on_tab_info_change(tab_id, info)
 
@@ -552,7 +998,7 @@ class TabManager(Frame):
             self.on_tab_deactivate(tab_id)
 
     def _call_configure_menu(self, tab_id: int):
-        """Call configure_menu on the active tab's hooks or module.
+        """Call configure_menu on the active tab's per-tab namespace.
 
         Supports both new signature (tabmanager) and old signature (menubar)
         for backwards compatibility.
@@ -564,7 +1010,6 @@ class TabManager(Frame):
             sig = inspect.signature(cfg)
             params = list(sig.parameters.keys())
             if params and params[0] == "menubar":
-                # Old signature — pass menubar directly for compat
                 if self._menubar:
                     cfg(self._menubar)
             else:
@@ -630,19 +1075,14 @@ class TabManager(Frame):
 
     def _on_merge_request(self, tab_id: int, source_bar: "TabBar",
                           insert_idx: int = -1):
-        """A drag from *source_bar* was released over this bar at *insert_idx*."""
+        """A drag from *source_bar* was released over this bar at *insert_idx*.
+
+        Uses :meth:`move_tab` so the per-tab namespace and in-tab state
+        survive the merge.
+        """
         source_mgr = source_bar.owner
         if source_mgr is None or source_mgr is self:
             return
         if not source_mgr.has_tab(tab_id):
             return
-        entry     = source_mgr._tabs[tab_id]
-        display   = entry["display_name"]
-        module    = entry.get("module")
-        hooks     = entry.get("hooks")
-        icon      = entry.get("icon")
-        base_name = entry.get("base_name", display)
-        if not source_mgr.close_tab(tab_id, skip_on_quit=True):
-            return
-        self.open_tab(display, module, hooks=hooks, icon=icon,
-                      insert_idx=insert_idx, base_name=base_name)
+        self.move_tab(source_mgr, tab_id, insert_idx=insert_idx)

--- a/VIStk/Structures/Installer.py
+++ b/VIStk/Structures/Installer.py
@@ -1514,8 +1514,10 @@ def binstall(desktop:list[str], selected_screens:list[str]):
 
     # Phase 2: Back up files that will be overwritten (for rollback on failure)
     backup_dir = None
+    backup_failed: set[str] = set()
     if n_backup > 0:
         backup_dir = tempfile.mkdtemp(prefix="vis_backup_")
+        _log_write(f"backup start: {n_backup} files into {backup_dir}")
         for idx, file in enumerate(files_to_extract):
             file_label.config(text=f"Backing up: {os.path.basename(file)}")
             root.update()
@@ -1523,11 +1525,23 @@ def binstall(desktop:list[str], selected_screens:list[str]):
             if dest.exists():
                 backup_path = Path(backup_dir) / file
                 backup_path.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(dest, backup_path)
+                _log_write(f"  backup [{idx+1}/{n_backup}] {file}")
+                try:
+                    shutil.copy2(dest, backup_path)
+                except (PermissionError, OSError) as e:
+                    # File is locked (e.g. host .exe / a loaded .pyd
+                    # from a running install).  Skip backup of this
+                    # one file rather than hanging the whole install.
+                    # If extract later fails, rollback skips this file
+                    # — degraded recovery but not a hang.
+                    _log_write(f"    BACKUP SKIPPED: {type(e).__name__}: {e}")
+                    backup_failed.add(file)
             pct = scan_end + int((idx + 1) / n_backup * (backup_end - scan_end))
             progress_bar.config(value=pct)
             pct_label.config(text=f"{pct}%")
             root.update()
+        _log_write(f"backup done: {n_backup - len(backup_failed)} ok, "
+                   f"{len(backup_failed)} skipped")
 
     # Phase 3: Extract changed/new files; rollback on failure
     try:

--- a/VIStk/Structures/_Release.py
+++ b/VIStk/Structures/_Release.py
@@ -16,6 +16,7 @@ import datetime
 import hashlib
 import importlib.metadata
 import json
+import marshal
 from VIStk.Structures._Version import Version
 
 # Nuitka writes ``.pyd`` on Windows and ``.so`` on Linux/macOS for both
@@ -117,8 +118,9 @@ class Release(Project):
         self.extra_nuitka_args: list[str] = _nuitka_cfg.get("extra_args", [])
 
         # Serializes the .dist → runtime/ merge step inside
-        # _compile_screen_exe / compile_host so parallel binary compiles
-        # don't race on shared runtime files (python313.dll, tcl/, ...).
+        # compile_host so its ``.dist`` doesn't race on shared runtime
+        # files (python313.dll, tcl/, ...) if other phases ever ship
+        # things into runtime/ concurrently.
         self._merge_lock = threading.Lock()
 
     def _resolve_release_targets(self) -> list[Screen] | None:
@@ -396,13 +398,21 @@ class Release(Project):
                 segment = segment.strip()
                 if not segment:
                     continue
-                # C file compilation progress
-                m = _re.search(r'Compiled (\d+)[/ ](?:out of )?(\d+)', segment)
+                # C file compilation progress — Nuitka emits variants like
+                # "Compiled 23/47", "Compiled 23 of 47", or
+                # "Compiled 23 out of 47" depending on version.
+                m = _re.search(r'Compiled (\d+)\s*(?:/|of|out of)\s*(\d+)', segment)
                 if m:
                     self._status(f"{prefix} — C {m.group(1)}/{m.group(2)}")
                     continue
                 if 'Backend C linking' in segment:
                     self._status(f"{prefix} — linking")
+                    continue
+                # Analysis / optimization phase — long-running silent
+                # gaps before the C compile, where progress otherwise
+                # appears stuck on "...".
+                if 'Optimizing modules' in segment or 'Doing module' in segment:
+                    self._status(f"{prefix} — analyzing")
                     continue
                 # Capture last FATAL/error line for failure reporting
                 if 'FATAL' in segment or 'error:' in segment.lower():
@@ -432,11 +442,13 @@ class Release(Project):
         compile targets resolve from the install root (see
         :meth:`_make_bootstrap_wrapper`).
 
-        Parallel-safe: uses ``_run_nuitka_silent`` so concurrent binary
-        compiles don't fight over the progress line, and the .dist →
-        runtime/ merge is wrapped in ``self._merge_lock`` so concurrent
-        merges don't race on shared runtime files (python313.dll,
-        tcl/, ...).  Returns ``(ok, err)``.
+        Uses ``_run_nuitka`` (live progress) since the Host is now the
+        only binary in a build — under the always-Host model there are
+        no per-screen .exes competing for the progress line.  The .dist
+        → runtime/ merge is wrapped in ``self._merge_lock`` for safety
+        if any other phase ever races on runtime files.  Returns
+        ``(ok, err)`` — err is always empty on this path because
+        ``_run_nuitka`` prints failure details itself before returning.
         """
         ixt = ".ico" if sys.platform == "win32" else ".xbm"
         icon_file = f"{self.p_project}/Icons/{self.d_icon}{ixt}"
@@ -495,9 +507,8 @@ class Release(Project):
         entry_script = self._entry_for_compile(self.host_script)
         parts.append(entry_script)
 
-        ok, err = self._run_nuitka_silent(parts, self.p_project)
-        if not ok:
-            return False, err or "nuitka returned non-zero"
+        if not self._run_nuitka(parts, self.title, self.p_project):
+            return False, ""  # _run_nuitka already printed the failure line
 
         with self._merge_lock:
             if not self._place_exe_output(entry_script, self.title):
@@ -549,52 +560,38 @@ class Release(Project):
         return True
 
     def compile_screens(self, mode="all"):
-        """Compile each screen plus its per-screen modules sub-package.
+        """Compile each screen's wrapper .pyd and (optionally) the Host .exe.
 
-        For every tabbed screen in ``release_targets``, two artifacts
-        ship to the install:
+        For every screen in ``release_targets`` a single wrapper ``.pyd``
+        is produced at ``runtime/<stem>.pyd``.  The wrapper bundles
+        marshalled bytecode for the entry script and every ``f_*`` /
+        ``j_*`` / ``m_*`` source file; per-tab namespaces are built from
+        that dict at runtime by ``TabManager._build_namespace``.  No
+        separate ``Screens/<name>.pyd`` or ``modules/<name>.pyd``
+        artifacts ship.
 
-        * ``Screens/<name>.pyd`` — the screen's UI entry, compiled from
-          ``<name>.py``.
-        * ``modules/<name>.pyd`` — the screen's logic sub-package,
-          compiled from ``modules/<name>/`` (only when that directory
-          exists).
-
-        Both kinds of jobs share one parallel call so workers stay busy.
-        Workers default to ``cpu_count // 2`` to leave headroom for
-        Nuitka's per-process C compiler subprocesses.
-
-        Standalone screens (``tabbed=false``) with ``release=true`` stay
-        serial — each is ``--standalone`` and merges its ``.dist`` into
-        the shared ``self.final`` directory, where concurrent merges
-        would race on common runtime files (python3xx.dll, etc.).
-
-        ``mode`` filters which screens to compile: ``"pyd"`` for tabbed
-        screens (and their modules), ``"exe"`` for standalone release
-        screens only, or ``"all"`` for both (default).
+        ``mode`` filters which compilations to run: ``"pyd"`` for screen
+        wrappers, ``"exe"`` for the Host binary, or ``"all"`` for both
+        (default).  Under the always-Host model there are no per-screen
+        .exes — every screen opens through the Host (as a tab or a
+        chromeless DetachedWindow); the Host binary is the only .exe
+        in the install.
         """
-        ixt = ".ico" if sys.platform == "win32" else ".xbm"
-
         if mode in ("all", "pyd"):
-            tabbed = [s for s in self.release_targets if s.tabbed]
-            modules = self._modules_for_release()
-            screens_pkgs = self._screens_for_release()
-            if tabbed or modules or screens_pkgs:
-                # Tabbed entry .pyds now go to runtime root (was Screens/);
-                # runtime dir already exists from earlier phases.
-                if modules:
-                    os.makedirs(f"{self.runtime}/modules", exist_ok=True)
-                if screens_pkgs:
-                    os.makedirs(f"{self.runtime}/Screens", exist_ok=True)
-                if not self._compile_pyds_parallel(tabbed, modules, screens_pkgs):
+            # Wrapper .pyd is built for every release target — tabbed and
+            # standalone alike — so the Host can open any of them as a
+            # tab through TabManager._build_namespace.
+            screens = list(self.release_targets)
+            if screens:
+                if not self._compile_pyds_parallel(screens):
                     return False
 
         if mode in ("all", "exe"):
-            # Parallel: every standalone screen .exe + the Host .exe.
-            # Each job acquires self._merge_lock around its .dist →
-            # runtime/ merge so concurrent compiles don't race on
-            # shared runtime files (python313.dll, tcl/, ...).
-            if not self._compile_binaries_parallel():
+            # compile_host now uses _run_nuitka (live progress) and
+            # manages its own step/cat_index bookkeeping — no need to
+            # increment here.  Failure detail is printed by _run_nuitka.
+            ok, _err = self.compile_host()
+            if not ok:
                 return False
 
         return True
@@ -891,63 +888,129 @@ class Release(Project):
             out.append("--no-deployment-flag=excluded-module-usage")
         return out
 
-    def _compile_screen_pyd(self, scr) -> tuple[bool, str]:
-        """Compile one tabbed screen entry script → ``runtime/<stem>.pyd``.
+    def _build_screen_wrapper(self, scr) -> str:
+        """Generate the per-screen wrapper ``.py`` source and return its path.
 
-        Lives at the runtime root (not inside ``Screens/``) because that
-        slot is now occupied by the per-screen UI sub-package compile
-        (``Screens/<name>/`` → ``runtime/Screens/<name>.pyd``, see
-        :meth:`_compile_one_screen_package`).  Co-locating with a
-        same-named standalone .exe is fine — Python only resolves the
-        .pyd for imports.
+        The wrapper contains a single ``_EMBEDDED`` dict holding marshalled
+        bytecode for the screen's entry script and every ``f_*`` / ``j_*``
+        in ``Screens/<name>/`` plus every ``m_*`` in ``modules/<name>/``.
+        At runtime ``TabManager._load_codes_from_embedded`` reads this
+        dict and unmarshals into code objects for per-tab exec.
+
+        Wrapper file is named ``<stem>.py`` (where ``stem`` is the entry
+        script's basename without extension) so the Nuitka-compiled
+        ``.pyd`` exports ``PyInit_<stem>`` — what Python looks for when
+        the runtime does ``importlib.import_module(stem)``.  It lives
+        under ``self.build_dir/wrappers/`` to avoid colliding with
+        anything Nuitka writes at the build_dir root.
+        """
+        stem = os.path.splitext(scr.script)[0]
+        embedded: dict = {"entry": None, "screens": {}, "modules": {}}
+
+        # Entry script
+        with open(scr.script_path, "rb") as f:
+            entry_src = f.read()
+        embedded["entry"] = marshal.dumps(compile(entry_src, scr.script, "exec"))
+
+        # Screens/<name>/f_*, j_*
+        if os.path.isdir(scr.path):
+            for fname in sorted(os.listdir(scr.path)):
+                if not fname.endswith(".py") or fname == "__init__.py":
+                    continue
+                full = os.path.join(scr.path, fname)
+                with open(full, "rb") as f:
+                    src = f.read()
+                embedded["screens"][fname[:-3]] = marshal.dumps(compile(src, full, "exec"))
+
+        # modules/<name>/m_*
+        if os.path.isdir(scr.m_path):
+            for fname in sorted(os.listdir(scr.m_path)):
+                if not fname.endswith(".py") or fname == "__init__.py":
+                    continue
+                full = os.path.join(scr.m_path, fname)
+                with open(full, "rb") as f:
+                    src = f.read()
+                embedded["modules"][fname[:-3]] = marshal.dumps(compile(src, full, "exec"))
+
+        # Per-screen subdir so multiple screens with name collisions
+        # (impossible today but cheap insurance) don't stomp each other.
+        wrapper_dir = os.path.join(self.build_dir, "wrappers", stem)
+        os.makedirs(wrapper_dir, exist_ok=True)
+        wrapper_path = os.path.join(wrapper_dir, f"{stem}.py")
+        wrapper_src = (
+            f'"""Per-screen bundle for {scr.name!r} — VIS release artifact.\n'
+            f"\n"
+            f"Loaded by VIStk.Objects._TabManager when the Host opens this\n"
+            f"screen.  Contains marshalled bytecode for the entry script and\n"
+            f"every f_*, j_*, and m_* file; per-tab namespaces are built\n"
+            f"from this dict at runtime.\n"
+            f'"""\n'
+            f"\n"
+            f"_EMBEDDED = {embedded!r}\n"
+        )
+        with open(wrapper_path, "w", encoding="utf-8") as f:
+            f.write(wrapper_src)
+        return wrapper_path
+
+    def _compile_screen_pyd(self, scr) -> tuple[bool, str]:
+        """Compile one screen → ``runtime/<stem>.pyd``.
+
+        Builds a wrapper ``.py`` containing marshalled bytecode for the
+        entry script and every ``f_*`` / ``j_*`` / ``m_*`` source file,
+        then Nuitka-compiles that wrapper with ``--module``.  At runtime
+        ``TabManager._build_namespace`` imports this .pyd, reads its
+        ``_EMBEDDED`` dict, and exec's the bytecode into per-tab
+        namespaces — no separate ``Screens/<name>.pyd`` or
+        ``modules/<name>.pyd`` artifacts are produced.
+
+        The wrapper has no runtime imports beyond the standard library,
+        so the previous ``--include-package`` + ``--nofollow-import-to``
+        dance falls away.
+
+        Wrapper file is named ``<stem>.py`` (matching the entry script
+        stem) so the produced .pyd exports ``PyInit_<stem>`` — required
+        for ``importlib.import_module(stem)`` at runtime to succeed.
+        Each screen's wrapper + output live in their own subdir under
+        ``build_dir/wrappers/<stem>/`` so concurrent compiles don't
+        race on shared output paths.
 
         Threadsafe — uses :meth:`_run_nuitka_silent` so concurrent calls
         don't fight over the progress display.  Returns ``(ok, error)``.
         """
         stem = os.path.splitext(scr.script)[0]
-        # Bundle this screen's own UI + logic subpackages directly into
-        # the tabbed entry .pyd, mirroring the standalone .exe build.
-        # Without --include-package + parent exclusion, Nuitka emits a
-        # stub Screens.<name> referenced by the entry's import statements
-        # and the stub shadows the on-disk runtime/Screens/<name>.pyd
-        # at load time, ImportError'ing on the f_* submodule lookup.
-        # Bundling makes the entry .pyd self-contained for its own
-        # imports; other screens' subpackages stay nofollow'd.
-        #
-        # Only include subpackages that actually exist on disk — some
-        # screens are single-file (no Screens/<name>/ subdir, no
-        # modules/<name>/ subdir).  Passing --include-package= for a
-        # non-existent package makes Nuitka FATAL out with "failed to
-        # locate package".
-        own_subpkgs = {"Screens", "modules"}
-        include_flags: list[str] = []
-        screens_subdir = os.path.join(self.p_project, "Screens", scr.name)
-        if os.path.isdir(screens_subdir):
-            include_flags.append(f"--include-package=Screens.{scr.name}")
-            own_subpkgs.add(f"Screens.{scr.name}")
-        modules_subdir = os.path.join(self.p_project, "modules", scr.name)
-        if os.path.isdir(modules_subdir):
-            include_flags.append(f"--include-package=modules.{scr.name}")
-            own_subpkgs.add(f"modules.{scr.name}")
+        wrapper_path = self._build_screen_wrapper(scr)
+        wrapper_dir = os.path.dirname(wrapper_path)
+
         parts = [
             sys.executable, "-m", "nuitka", "--module",
             *self._compiler_args(),
-            f"--output-dir={self.build_dir}",
+            f"--output-dir={wrapper_dir}",
             "--assume-yes-for-downloads",
-            *include_flags,
-            *self._nofollow_flags(exclude_self=own_subpkgs),
-            scr.script,
+            *self._nofollow_flags(),
+            wrapper_path,
         ]
 
-        ok, err = self._run_nuitka_silent(parts, self.p_project)
+        ok, err = self._run_nuitka_silent(parts, wrapper_dir)
         if not ok:
             return False, err or "nuitka returned non-zero"
 
-        built_mods = glob.glob(f"{self.build_dir}{stem}*{_MOD_EXT}")
-        if not built_mods:
-            return False, f"no {_MOD_EXT} produced at {self.build_dir}{stem}*{_MOD_EXT}"
-        for bp in built_mods:
-            shutil.move(bp, f"{self.runtime}/{stem}{_MOD_EXT}")
+        # Output is in the wrapper's isolated subdir.  May be plain
+        # ``<stem>.pyd`` or ABI-tagged like ``<stem>.cp313-win_amd64.pyd``
+        # depending on Nuitka config.  Either way, move it to the
+        # runtime root as ``<stem>.pyd``.
+        built = glob.glob(f"{wrapper_dir}/{stem}*{_MOD_EXT}")
+        if not built:
+            return False, f"no {_MOD_EXT} produced at {wrapper_dir}/{stem}*{_MOD_EXT}"
+        target = f"{self.runtime}/{stem}{_MOD_EXT}"
+        if os.path.exists(target):
+            os.remove(target)
+        # If Nuitka emitted multiple variants (rare), prefer the exact
+        # stem match.
+        primary = next(
+            (bp for bp in built if os.path.basename(bp) == f"{stem}{_MOD_EXT}"),
+            built[0],
+        )
+        shutil.move(primary, target)
         return True, ""
 
     def _run_parallel(self, jobs: list, label: str, max_workers: int) -> bool:
@@ -1000,123 +1063,20 @@ class Release(Project):
                                 f.cancel()
         return all_ok
 
-    def _compile_pyds_parallel(self, screens: list, modules: list,
-                               screens_pkgs: list) -> bool:
-        """Compile screens, their modules sub-packages, and their Screens
-        UI sub-packages concurrently.
+    def _compile_pyds_parallel(self, screens: list) -> bool:
+        """Compile every tabbed screen's wrapper .pyd concurrently.
 
-        All job kinds run in the same ``ThreadPoolExecutor`` so workers
-        stay busy.  Workers default to ``cpu_count // 2`` to leave
-        headroom for Nuitka's per-process C compiler subprocesses.
+        Each screen produces ONE wrapper .pyd at ``runtime/<stem>.pyd``
+        containing marshalled bytecode for the entry script and every
+        ``f_*`` / ``j_*`` / ``m_*`` source file — no separate
+        ``Screens/<name>.pyd`` or ``modules/<name>.pyd`` artifacts.
+
+        Workers default to ``cpu_count // 2`` to leave headroom for
+        Nuitka's per-process C compiler subprocesses.
         """
         max_workers = max(1, (os.cpu_count() or 4) // 2)
-        jobs = []
-        for s in screens:
-            jobs.append((s.name, lambda s=s: self._compile_screen_pyd(s)))
-        for name, path in modules:
-            jobs.append((f"modules.{name}",
-                         lambda n=name, p=path: self._compile_one_module(n, p)))
-        for name, path in screens_pkgs:
-            jobs.append((f"Screens.{name}",
-                         lambda n=name, p=path: self._compile_one_screen_package(n, p)))
-        return self._run_parallel(jobs, "module", max_workers)
-
-    def _compile_one_module(self, screen_name: str, mod_path: str) -> tuple[bool, str]:
-        """Compile ``modules/<screen>/`` → ``final/modules/<screen>.pyd``.
-
-        Each job uses an isolated build subdir to avoid colliding with
-        the matching screen's ``.pyd`` compile (both produce a ``.pyd``
-        whose stem is the screen's leaf name, so they'd otherwise stomp
-        each other's intermediates inside ``self.build_dir``).
-
-        Threadsafe — uses :meth:`_run_nuitka_silent`.
-        """
-        out_dir = f"{self.build_dir}modules_{screen_name}/"
-        os.makedirs(out_dir, exist_ok=True)
-        self_target = f"modules.{screen_name}"
-        parts = [
-            sys.executable, "-m", "nuitka", "--module",
-            *self._compiler_args(),
-            f"--include-package={self_target}",
-            f"--output-dir={out_dir}",
-            "--assume-yes-for-downloads",
-            # Self gets --include-package; every other compile target
-            # (other modules siblings, Screens, shared packages) gets
-            # --nofollow-import-to so we don't bundle anything that
-            # ships as its own .pyd.
-            *self._nofollow_flags(exclude_self=self_target),
-            mod_path,
-        ]
-
-        ok, err = self._run_nuitka_silent(parts, self.p_project)
-        if not ok:
-            return False, err or "nuitka returned non-zero"
-
-        built = glob.glob(f"{out_dir}*{_MOD_EXT}")
-        if not built:
-            return False, f"no {_MOD_EXT} produced for modules.{screen_name}"
-        target = f"{self.runtime}/modules/{screen_name}{_MOD_EXT}"
-        # If multiple .pyds came out, pick the one that matches the leaf
-        # (Nuitka may emit a cpython-tagged sibling).  Prefer exact stem.
-        primary = next((bp for bp in built
-                        if os.path.basename(bp).startswith(f"{screen_name}.")
-                        or os.path.basename(bp).startswith(f"{screen_name}{_MOD_EXT}")),
-                       built[0])
-        shutil.move(primary, target)
-        return True, ""
-
-    def _compile_one_screen_package(self, screen_name: str, src_path: str) -> tuple[bool, str]:
-        """Compile ``Screens/<screen>/`` → ``runtime/Screens/<screen>.pyd``.
-
-        Same shape as :meth:`_compile_one_module` but for the per-screen
-        UI sub-package.  Exposes ``f_*`` section files as submodules
-        accessible via ``import Screens.<screen>.f_xxx`` at runtime.
-        The runtime/Screens/<name>.pyd slot was freed by moving the
-        entry-script compile to runtime/<name>.pyd (see
-        :meth:`_compile_screen_pyd`).
-
-        Threadsafe — uses :meth:`_run_nuitka_silent`.
-        """
-        # Nuitka --module + --include-package needs __init__.py as an
-        # anchor to discover and bundle submodules.  Without it the
-        # compiled .pyd loads cleanly at runtime but exposes nothing —
-        # `import Screens.<name>.f_xxx` raises ImportError.  Bail
-        # early with an actionable message instead of producing a stub.
-        init_path = os.path.join(src_path, "__init__.py")
-        if not os.path.exists(init_path):
-            return False, (
-                f"Screens/{screen_name}/ is a namespace package (no "
-                f"__init__.py) — Nuitka can't bundle its f_* submodules. "
-                f"Run: touch Screens/{screen_name}/__init__.py"
-            )
-
-        out_dir = f"{self.build_dir}screens_{screen_name}/"
-        os.makedirs(out_dir, exist_ok=True)
-        self_target = f"Screens.{screen_name}"
-        parts = [
-            sys.executable, "-m", "nuitka", "--module",
-            *self._compiler_args(),
-            f"--include-package={self_target}",
-            f"--output-dir={out_dir}",
-            "--assume-yes-for-downloads",
-            *self._nofollow_flags(exclude_self=self_target),
-            src_path,
-        ]
-
-        ok, err = self._run_nuitka_silent(parts, self.p_project)
-        if not ok:
-            return False, err or "nuitka returned non-zero"
-
-        built = glob.glob(f"{out_dir}*{_MOD_EXT}")
-        if not built:
-            return False, f"no {_MOD_EXT} produced for Screens.{screen_name}"
-        target = f"{self.runtime}/Screens/{screen_name}{_MOD_EXT}"
-        primary = next((bp for bp in built
-                        if os.path.basename(bp).startswith(f"{screen_name}.")
-                        or os.path.basename(bp).startswith(f"{screen_name}{_MOD_EXT}")),
-                       built[0])
-        shutil.move(primary, target)
-        return True, ""
+        jobs = [(s.name, lambda s=s: self._compile_screen_pyd(s)) for s in screens]
+        return self._run_parallel(jobs, "screen", max_workers)
 
     def _compile_shared_parallel(self, packages: list) -> bool:
         """Compile shared packages concurrently.
@@ -1188,135 +1148,15 @@ class Release(Project):
             shutil.move(bp, f"{self.runtime}/{pkg}{_MOD_EXT}")
         return True, ""
 
-    def _compile_screen_exe(self, scr, ixt: str) -> tuple[bool, str]:
-        """Compile one standalone screen → ``final/<scr.name>.exe``.
-
-        Honors the project-level ``onefile`` flag: standalone produces a
-        ``.dist`` that gets merged into ``self.runtime``, onefile produces
-        a single ``.exe`` that gets moved.
-
-        Parallel-safe: uses ``_run_nuitka_silent`` and wraps the
-        ``.dist`` → ``runtime/`` merge in ``self._merge_lock`` so
-        concurrent binary compiles don't race on shared runtime files.
-        Returns ``(ok, err)``.
-        """
-        icon = (scr.icon if scr.icon else self.d_icon) + ixt
-        icon_file = f"{self.p_project}/Icons/{icon}"
-
-        mode = "--onefile" if self.onefile else "--standalone"
-        parts = [
-            sys.executable, "-m", "nuitka", mode,
-            *self._compiler_args(),
-            "--enable-plugin=tk-inter",
-            # See compile_host() for why this is needed alongside the plugin.
-            "--include-package=tkinter",
-            f"--output-dir={self.build_dir}",
-            f"--output-filename={scr.name}{_EXE_EXT}",
-            "--assume-yes-for-downloads",
-        ]
-        if icon_file and exists(icon_file):
-            parts.append(f"--windows-icon-from-ico={icon_file}")
-        if self.company:
-            parts.append(f"--windows-company-name={self.company}")
-            parts.append(f"--windows-product-name={self.title}")
-            year = datetime.datetime.now().year
-            parts.append(f"--windows-file-description={scr.name}")
-            parts.append(f"--copyright=Copyright {year} {self.company}")
-        parts.append(f"--windows-product-version={self.Version}")
-        # TEMP DEBUG: console disabled so startup errors are visible.
-        # Revert before shipping.
-        # if sys.platform == "win32":
-        #     parts.append("--windows-console-mode=disable")
-        # Standalone screens share the Host runtime at the install root
-        # (python3xx.dll, .pyd, third-party packages).  Follow direct
-        # imports for everything except other compile targets — those
-        # ship as their own .pyds and must not be bundled in.
-        #
-        # Exception: this screen's own ``Screens.<name>`` and
-        # ``modules.<name>`` sub-packages are NOT nofollow'd, so Nuitka
-        # bundles them (with every f_*/m_* sibling) directly into this
-        # .exe.  Without that, Nuitka emits a stub Screens.<name> just
-        # for the import statement to resolve against — that stub has
-        # no f_* siblings, so `import Screens.<name>.f_xxx` raises
-        # ImportError despite the on-disk .pyd being present (frozen
-        # importer wins over filesystem).  Letting the .exe bundle the
-        # subpackages directly makes it self-contained for those
-        # imports.  Other screens' subpackages stay nofollow'd.
-        #
-        # The TOP-LEVEL ``Screens`` and ``modules`` entries must also
-        # be excluded from nofollow.  Nuitka's
-        # ``--nofollow-import-to=Screens`` cascades to the entire
-        # package ("to the whole package in any case", per the
-        # Nuitka docs), so leaving it in would block Nuitka from
-        # following into ``Screens.<name>`` no matter what the
-        # subpackage-level flags say.
-        own_subpkgs = {"Screens", "modules"}
-        parts.append("--follow-imports")
-        # Force-bundle every submodule of this screen's own UI/logic
-        # packages.  modules/<name>/__init__.py uses lazy
-        # importlib.import_module() inside __getattr__ to load
-        # m_* siblings, which Nuitka's static analysis can't see; without
-        # --include-package it bundles the __init__ but not the m_*
-        # files, and the lazy lookup ModuleNotFoundErrors at runtime.
-        #
-        # Only include subpackages that actually exist on disk — single-
-        # file screens (no Screens/<name>/ subdir, no modules/<name>/
-        # subdir) would otherwise FATAL out with Nuitka's
-        # "failed to locate package" error.
-        screens_subdir = os.path.join(self.p_project, "Screens", scr.name)
-        if os.path.isdir(screens_subdir):
-            parts.append(f"--include-package=Screens.{scr.name}")
-            own_subpkgs.add(f"Screens.{scr.name}")
-        modules_subdir = os.path.join(self.p_project, "modules", scr.name)
-        if os.path.isdir(modules_subdir):
-            parts.append(f"--include-package=modules.{scr.name}")
-            own_subpkgs.add(f"modules.{scr.name}")
-        parts.extend(self._nofollow_flags(exclude_self=own_subpkgs))
-        # Same stdlib bundling as compile_host so standalone screens
-        # also expose the full stdlib to shared .pyds loaded at runtime.
-        parts.extend(self._stdlib_includes())
-        parts.extend(self.extra_nuitka_args)
-
-        entry_script = self._entry_for_compile(scr.script)
-        parts.append(entry_script)
-
-        ok, err = self._run_nuitka_silent(parts, self.p_project)
-        if not ok:
-            return False, err or "nuitka returned non-zero"
-
-        with self._merge_lock:
-            if not self._place_exe_output(entry_script, scr.name):
-                return False, "merge into runtime/ failed"
-            # Post-condition: the screen's exe is inside runtime/.
-            expected_exe = os.path.join(self.runtime, f"{scr.name}{_EXE_EXT}")
-            if not exists(expected_exe):
-                return False, (
-                    f"expected {expected_exe} after merge but it is missing"
-                )
-        return True, ""
-
-    def _compile_binaries_parallel(self) -> bool:
-        """Compile every standalone screen .exe and the Host .exe in
-        parallel.
-
-        Each job runs Nuitka silently and acquires ``self._merge_lock``
-        around its ``.dist`` → ``runtime/`` merge so concurrent compiles
-        don't race on shared runtime files (python313.dll, tcl/, ...).
-        Workers default to ``min(n_jobs, cpu_count // 2)`` — same
-        heuristic as the Modules phase, capped at the job count so we
-        don't spin up more threads than there is work.
-        """
-        ixt = ".ico" if sys.platform == "win32" else ".xbm"
-        jobs = []
-        for scr in self.release_targets:
-            if scr.tabbed:
-                continue
-            jobs.append((scr.name,
-                         lambda s=scr: self._compile_screen_exe(s, ixt)))
-        jobs.append((self.title, self.compile_host))
-
-        max_workers = min(len(jobs), max(1, (os.cpu_count() or 4) // 2))
-        return self._run_parallel(jobs, "binary", max_workers)
+    # NOTE (0.5.X+): Standalone per-screen .exes are gone.  Every
+    # installed project ships exactly one binary — the Host .exe —
+    # and every screen (tabbed or formerly-standalone) loads through
+    # the Host as either a regular tab or a chromeless DetachedWindow.
+    # Direct-launch by the user happens via Start Menu shortcuts that
+    # invoke ``<project>.exe <ScreenName>`` (Host honors the screen
+    # name as a startup argument).  The ``release`` field on Screen no
+    # longer triggers an .exe build; it gates Start Menu shortcut
+    # creation in the installer instead.
 
     @staticmethod
     def _has_binary_extensions(pkg_dir: str) -> bool:
@@ -1671,6 +1511,14 @@ class Release(Project):
         os.makedirs(self.location, exist_ok=True)
         os.makedirs(self.build_dir, exist_ok=True)
 
+        #Wipe runtime/ from any previous build.  Without this, leftover
+        #per-screen .exes (from the old pre-always-Host pipeline) or
+        #stale source .py files from older flows persist into the new
+        #install, both bloating binaries.zip and tripping the runtime's
+        #dev/release detection in TabManager._load_screen_codes.
+        if os.path.isdir(self.runtime):
+            shutil.rmtree(self.runtime)
+
         #Check default screen
         if self.default_screen is None:
             print("Warning: No default screen set in project.json.", flush=True)
@@ -1691,17 +1539,19 @@ class Release(Project):
                 shared_pkgs.append(pkg)
         pkg_count = len(shared_pkgs)
 
-        screen_count = sum(1 for s in self.release_targets if s.tabbed)
-        module_count = len(self._modules_for_release())
-        screen_pkg_count = len(self._screens_for_release())
-        binary_count = sum(1 for s in self.release_targets if not s.tabbed) + 1  # +1 = Host
+        # Every release target produces one wrapper .pyd — tabbed and
+        # standalone alike — so the Host can open it as a tab.  Under
+        # the always-Host model there are no per-screen .exes; the Host
+        # binary is the only one in the install.
+        screen_count = len(self.release_targets)
+        binary_count = 1  # Host .exe only
 
         all_screens = self.Groups[Group.ALL].screenlist
         if len(self.release_targets) < len([s for s in all_screens if s.tabbed or s.release]):
             print(f"Partial release: {len(self.release_targets)} screen(s) included.",
                   flush=True)
 
-        total = pkg_count + screen_count + module_count + screen_pkg_count + binary_count
+        total = pkg_count + screen_count + binary_count
         self._step = 0
         self._total_steps = total
         print(f"\n{self.title} Release - {total} Compilations", flush=True)
@@ -1717,34 +1567,29 @@ class Release(Project):
             return
         phase_times["Required Packages"] = time.monotonic() - t0
 
-        # Screens + Modules (.pyd) — same parallel call
-        self._category = "Modules"
+        # Screen wrappers (.pyd) — one per release target, parallel
+        self._category = "Screens"
         self._cat_index = 0
-        self._cat_count = screen_count + module_count + screen_pkg_count
+        self._cat_count = screen_count
         t0 = time.monotonic()
         if not self.compile_screens(mode="pyd"):
             self._status("", newline=True)
-            print(f"\nRelease FAILED during Screen/Module compilation.", flush=True)
+            print(f"\nRelease FAILED during Screen wrapper compilation.", flush=True)
             return
-        phase_times["Modules"] = time.monotonic() - t0
+        phase_times["Screens"] = time.monotonic() - t0
 
-        # Binaries (.exe)
-        self._category = "Binaries"
+        # Host binary (.exe) — the only binary under the always-Host model
+        self._category = "Host"
         self._cat_index = 0
         self._cat_count = binary_count
         t0 = time.monotonic()
-        # compile_screens(mode="exe") now bundles every standalone
-        # screen .exe AND the Host .exe into a single parallel pool —
-        # _compile_binaries_parallel orchestrates the merge under
-        # self._merge_lock so concurrent .dist merges into runtime/
-        # don't clobber each other.
         if not self.compile_screens(mode="exe"):
             self._status("", newline=True)
-            print(f"\nRelease FAILED during Binary compilation.", flush=True)
+            print(f"\nRelease FAILED during Host compilation.", flush=True)
             return
 
         self._status("", newline=True)
-        phase_times["Binaries"] = time.monotonic() - t0
+        phase_times["Host"] = time.monotonic() - t0
 
         installer_t0 = time.monotonic()
         #Clean Environment — copies Images/, Icons/, and .VIS/project.json
@@ -1753,24 +1598,14 @@ class Release(Project):
         #and the --windowed exe dies before any window appears.
         self.clean()
 
-        # Nuitka exes live at the install root and are launched directly.
-        # No PyInstaller launcher shim, no .Runtime/ indirection — see #105.
-
-        # Post-condition: every standalone screen we said we'd build must
-        # have its exe present inside runtime/.  Catches silent failures
-        # further upstream (issue #115) so we don't ship a binaries.zip
-        # that's missing the screens the user paid to compile.
-        missing_exes = []
-        for scr in self.release_targets:
-            if scr.tabbed:
-                continue
-            expected = os.path.join(self.runtime, f"{scr.name}{_EXE_EXT}")
-            if not exists(expected):
-                missing_exes.append(scr.name)
-        if missing_exes:
+        # Post-condition: the Host .exe must be present in runtime/.  No
+        # per-screen .exes to check anymore — every screen opens through
+        # the Host as a tab or chromeless DetachedWindow.
+        expected_host = os.path.join(self.runtime, f"{self.title}{_EXE_EXT}")
+        if not exists(expected_host):
             print(
-                f"\nRelease FAILED: standalone exe(s) missing from {self.runtime}: "
-                f"{', '.join(missing_exes)}.  Inspect the build output above "
+                f"\nRelease FAILED: Host binary missing from {self.runtime}: "
+                f"{self.title}{_EXE_EXT}.  Inspect the build output above "
                 f"for the underlying failure.",
                 flush=True,
             )

--- a/VIStk/Structures/_Release.py
+++ b/VIStk/Structures/_Release.py
@@ -1311,12 +1311,16 @@ class Release(Project):
         if exists(src):
             shutil.copy2(src, f"{vis_dest}/project.json")
 
-        # Rewrite installed project.json with .pyd script paths
+        # Prune installed project.json down to what we actually built.
+        # We intentionally do NOT rewrite ``scr.script`` extensions from
+        # .py to .pyd — TabManager's dev/release dispatch uses
+        # ``__compiled__`` rather than the script extension, and a
+        # previous attempt to rewrite caused asymmetric breakage when
+        # the rewriter only covered tabbed screens.
         installed_json = f"{vis_dest}/project.json"
         if exists(installed_json):
             with open(installed_json, "r") as f:
                 info = json.load(f)
-            # Prune installed project.json down to what we actually built.
             keep = {s.name for s in self.release_targets}
             for sname in list(info[self.title]["Screens"].keys()):
                 if sname not in keep:
@@ -1333,10 +1337,6 @@ class Release(Project):
                     groups[gname]["screens"] = pruned
                 else:
                     groups.pop(gname)
-            for screen_name, screen_data in info[self.title]["Screens"].items():
-                if screen_data.get("tabbed", False):
-                    stem = os.path.splitext(screen_data["script"])[0]
-                    screen_data["script"] = f"{stem}{_MOD_EXT}"
             with open(installed_json, "w") as f:
                 json.dump(info, f, indent=4)
 

--- a/VIStk/Structures/_Release.py
+++ b/VIStk/Structures/_Release.py
@@ -15,8 +15,10 @@ from zipfile import *
 import datetime
 import hashlib
 import importlib.metadata
+import importlib.util
 import json
 import marshal
+import zlib
 from VIStk.Structures._Version import Version
 
 # Nuitka writes ``.pyd`` on Windows and ``.so`` on Linux/macOS for both
@@ -38,7 +40,8 @@ class Release(Project):
     """A VIS Release object"""
     def __init__(self, flag:str="",type:str="",note:str="",
                  release_groups: list[str] | None = None,
-                 release_screens: list[str] | None = None):
+                 release_screens: list[str] | None = None,
+                 patch_mode: bool = False):
         """Creates a Release object to release or examine a release of a project
 
         ``release_groups`` and ``release_screens`` scope the build to a
@@ -46,6 +49,13 @@ class Release(Project):
         screen (every tabbed screen + every standalone with
         ``release=true``) is built.  Otherwise only the union of the named
         groups and explicit screens is built; the Host is always included.
+
+        ``patch_mode`` (``--patch`` on the CLI) builds a patch installer
+        without re-running Nuitka.  Existing wrapper .pyds in ``dist/``
+        are diffed against current source; differences land in a
+        VISKPATCH trailer appended to each affected .pyd.  Requires a
+        previous full release at the same ``dist/<pendix>/`` location —
+        hard error otherwise.  See :meth:`patch_screens`.
 
         Validation runs in ``__init__`` and prints + sets
         ``self.release_targets`` to ``None`` on any of:
@@ -61,6 +71,11 @@ class Release(Project):
         self.type = type
         self.flag = flag
         self.note = note
+        self.patch_mode: bool = patch_mode
+        """When ``True``, ``release()`` skips Nuitka compilation phases
+        and goes straight to :meth:`patch_screens` → :meth:`clean` →
+        installer build.  Requires an existing baseline build in
+        ``dist/<pendix>/runtime/``."""
 
         # Deliverables (final dist folders, installers, zips) and Nuitka
         # working dirs (per-flag caches) both live at the project root.
@@ -1013,6 +1028,257 @@ class Release(Project):
         shutil.move(primary, target)
         return True, ""
 
+    # ── VISKPATCH trailer ─────────────────────────────────────────────────────
+    #
+    # Format mirrors what :meth:`TabManager._read_viskpatch` consumes.
+    # Reader is the source of truth — see _TabManager.py for the layout
+    # diagram.  Summary: append the marshalled override dict, then a
+    # 22-byte fixed trailer ending in the magic ``b"VISKPATCH"``.
+
+    _VISKPATCH_MAGIC = b"VISKPATCH"
+    _VISKPATCH_HEADER_LEN = 22
+    _VISKPATCH_FORMAT_VERSION = 1
+
+    @classmethod
+    def _append_viskpatch_trailer(cls, pyd_path: str, overrides: dict) -> None:
+        """Marshal *overrides* and append a VISKPATCH trailer to *pyd_path*.
+
+        Caller is responsible for stripping any pre-existing trailer
+        first (see :meth:`_strip_viskpatch_trailer`) — appending without
+        stripping would leave the inner trailer's magic findable by
+        readers walking backward from a now-incorrect offset.
+
+        Encodes the patch with the current interpreter's
+        ``sys.version_info.major.minor`` so the reader can reject
+        marshal blobs produced for an incompatible Python.
+        """
+        payload = marshal.dumps(overrides)
+        checksum = zlib.crc32(payload)
+        pyver = (sys.version_info.major << 8) | sys.version_info.minor
+        trailer = (
+            checksum.to_bytes(4, "big")
+            + pyver.to_bytes(4, "big")
+            + len(payload).to_bytes(4, "big")
+            + bytes([cls._VISKPATCH_FORMAT_VERSION])
+            + cls._VISKPATCH_MAGIC
+        )
+        with open(pyd_path, "ab") as f:
+            f.write(payload)
+            f.write(trailer)
+
+    def _read_embedded_from_pyd(self, pyd_path: str) -> dict:
+        """Return the ``_EMBEDDED`` dict from a wrapper .pyd, read via subprocess.
+
+        Critical: must be a subprocess, NOT an in-process import.  On
+        Windows, ``importlib`` of a ``.pyd`` loads it as a DLL into the
+        current process and Windows holds an exclusive lock on the file
+        for the process lifetime — even after ``sys.modules.pop()``.
+        We'd hit ``PermissionError`` the moment patch mode tries to
+        ``open(pyd_path, "ab")`` for the trailer.  A subprocess loads
+        the DLL into its own address space; when it exits, the file
+        lock is released.
+
+        Side benefit: zero risk of polluting the build process's
+        ``sys.modules`` or causing import-order side effects for
+        whatever the wrapper happens to bake in.
+        """
+        stem = os.path.splitext(os.path.basename(pyd_path))[0]
+        # The subprocess script writes the pickled _EMBEDDED dict to
+        # its stdout as raw bytes; we read it back here.  Using pickle
+        # rather than marshal because pickle round-trips dict[str,
+        # dict|bytes] structures directly without further encoding.
+        script = (
+            "import sys, pickle, importlib.util\n"
+            f"spec = importlib.util.spec_from_file_location({stem!r}, {pyd_path!r})\n"
+            "mod = importlib.util.module_from_spec(spec)\n"
+            "spec.loader.exec_module(mod)\n"
+            "sys.stdout.buffer.write(pickle.dumps(dict(mod._EMBEDDED)))\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            err = result.stderr.decode(errors="replace").strip()
+            raise ImportError(
+                f"subprocess read of _EMBEDDED from {pyd_path} failed: {err}"
+            )
+        import pickle
+        return pickle.loads(result.stdout)
+
+    def _build_patch_overrides(self, scr, existing_embedded: dict) -> dict:
+        """Compile current source for *scr* and return a dict of entries
+        that differ from *existing_embedded*.
+
+        Returned dict mirrors the shape of ``_EMBEDDED`` but contains
+        only changed entries:
+
+            {"entry":   <bytes>?,         # present iff entry differs
+             "screens": {stem: <bytes>},  # only differing f_/j_ stems
+             "modules": {stem: <bytes>}}  # only differing m_ stems
+
+        Buckets are omitted when empty.  An empty top-level dict means
+        "current source matches the baseline — no patch needed."
+        """
+        overrides: dict = {}
+
+        # Entry script
+        with open(scr.script_path, "rb") as f:
+            new_entry = marshal.dumps(compile(f.read(), scr.script, "exec"))
+        if new_entry != existing_embedded.get("entry"):
+            overrides["entry"] = new_entry
+
+        # Screens/<name>/ — f_*, j_*
+        new_screens: dict = {}
+        if os.path.isdir(scr.path):
+            existing_screens = existing_embedded.get("screens", {}) or {}
+            for fname in sorted(os.listdir(scr.path)):
+                if not fname.endswith(".py") or fname == "__init__.py":
+                    continue
+                stem = fname[:-3]
+                full = os.path.join(scr.path, fname)
+                with open(full, "rb") as f:
+                    new = marshal.dumps(compile(f.read(), full, "exec"))
+                if new != existing_screens.get(stem):
+                    new_screens[stem] = new
+        if new_screens:
+            overrides["screens"] = new_screens
+
+        # modules/<name>/ — m_*
+        new_modules: dict = {}
+        if os.path.isdir(scr.m_path):
+            existing_modules = existing_embedded.get("modules", {}) or {}
+            for fname in sorted(os.listdir(scr.m_path)):
+                if not fname.endswith(".py") or fname == "__init__.py":
+                    continue
+                stem = fname[:-3]
+                full = os.path.join(scr.m_path, fname)
+                with open(full, "rb") as f:
+                    new = marshal.dumps(compile(f.read(), full, "exec"))
+                if new != existing_modules.get(stem):
+                    new_modules[stem] = new
+        if new_modules:
+            overrides["modules"] = new_modules
+
+        return overrides
+
+    @classmethod
+    def _strip_viskpatch_trailer(cls, pyd_path: str) -> bool:
+        """Truncate any VISKPATCH trailer from *pyd_path*.
+
+        Returns ``True`` if a trailer was found and removed, ``False``
+        if the file had no trailer (no-op).  Idempotent — safe to call
+        on a fresh .pyd that's never been patched.
+        """
+        try:
+            with open(pyd_path, "rb") as f:
+                f.seek(0, 2)
+                size = f.tell()
+                if size < cls._VISKPATCH_HEADER_LEN:
+                    return False
+                f.seek(-cls._VISKPATCH_HEADER_LEN, 2)
+                header = f.read(cls._VISKPATCH_HEADER_LEN)
+                if header[-9:] != cls._VISKPATCH_MAGIC:
+                    return False
+                version = header[-10]
+                length = int.from_bytes(header[-14:-10], "big")
+                if version != cls._VISKPATCH_FORMAT_VERSION:
+                    return False
+                trailer_total = cls._VISKPATCH_HEADER_LEN + length
+                if size < trailer_total:
+                    return False
+        except OSError:
+            return False
+        with open(pyd_path, "r+b") as f:
+            f.truncate(size - trailer_total)
+        return True
+
+    def patch_screens(self) -> bool:
+        """Append VISKPATCH trailers to existing wrapper .pyds.
+
+        Patch-mode entry point.  For every screen in
+        ``self.release_targets``:
+
+          1. Locate the wrapper .pyd at ``runtime/<stem>.pyd``.  Hard
+             error if missing — patch mode requires a baseline full
+             release to patch against.
+          2. Strip any pre-existing trailer in place so the import in
+             the next step reads the baseline ``_EMBEDDED``, and so
+             the trailer we append replaces (not stacks on) any
+             previous patch.
+          3. Import the wrapper to read ``_EMBEDDED``.
+          4. Compile current source files and diff against
+             ``_EMBEDDED``.  Build an overrides dict containing only
+             the entries that differ.
+          5. If overrides are empty, skip (nothing to patch for this
+             screen).  Otherwise append the new VISKPATCH trailer.
+
+        After all screens are processed, prints a per-screen summary.
+        Returns ``False`` and a loud warning if every screen reported
+        zero changes (no point shipping an empty patch installer).
+        """
+        print("Patching screen wrappers:", flush=True)
+        any_changes = False
+
+        for scr in self.release_targets:
+            stem = os.path.splitext(scr.script)[0]
+            pyd_path = f"{self.runtime}/{stem}{_MOD_EXT}"
+
+            if not exists(pyd_path):
+                print(
+                    f"  Patch FAILED: missing base wrapper {pyd_path}\n"
+                    f"  Run a full release first (without --patch) to "
+                    f"produce the baseline binaries.",
+                    flush=True,
+                )
+                return False
+
+            # Strip first so the import reads baseline, not an old patch
+            self._strip_viskpatch_trailer(pyd_path)
+
+            try:
+                existing = self._read_embedded_from_pyd(pyd_path)
+            except Exception as exc:
+                print(
+                    f"  Patch FAILED: cannot read _EMBEDDED from "
+                    f"{pyd_path} ({exc}). The wrapper may be corrupt "
+                    f"or built with an incompatible Python.",
+                    flush=True,
+                )
+                return False
+
+            overrides = self._build_patch_overrides(scr, existing)
+            if not overrides:
+                print(f"  {scr.name}: no changes", flush=True)
+                continue
+
+            self._append_viskpatch_trailer(pyd_path, overrides)
+            size_kb = (sum(len(v) for v in overrides.get("screens", {}).values())
+                       + sum(len(v) for v in overrides.get("modules", {}).values())
+                       + len(overrides.get("entry", b""))) / 1024
+            changed = []
+            if "entry" in overrides:
+                changed.append("entry")
+            changed.extend(f"screens/{k}" for k in overrides.get("screens", {}))
+            changed.extend(f"modules/{k}" for k in overrides.get("modules", {}))
+            print(
+                f"  {scr.name}: patched ({size_kb:.1f} KB, "
+                f"{len(changed)} file(s): {', '.join(changed)})",
+                flush=True,
+            )
+            any_changes = True
+
+        if not any_changes:
+            print(
+                "\nNo screens had source changes to patch.  The patch "
+                "installer would be a no-op; aborting.  Edit source "
+                "files and re-run, or use a full release.",
+                flush=True,
+            )
+            return False
+        return True
+
     def _run_parallel(self, jobs: list, label: str, max_workers: int) -> bool:
         """Run a list of compile jobs concurrently with shared progress.
 
@@ -1492,6 +1758,9 @@ class Release(Project):
         if self.release_targets is None:
             return
 
+        if self.patch_mode:
+            return self._release_patch()
+
         release_start = time.monotonic()
         phase_times: dict[str, float] = {}
 
@@ -1611,7 +1880,92 @@ class Release(Project):
             )
             return
 
-        #%Installer & Uninstaller Generation
+        installer_t0 = self._build_installer(phase_times)
+        if installer_t0 is None:
+            return
+
+        # Release-complete banner moved out of clean() so it lands
+        # after the installer is actually ready (#137).
+        print(
+            f"\n\nReleased a new"
+            f"{' '+self.flag+' ' if self.flag else ' '}"
+            f"build of {self.title}!",
+            flush=True,
+        )
+        self._print_release_summary(
+            time.monotonic() - release_start, phase_times,
+        )
+
+    def _release_patch(self):
+        """Patch-mode entry point — append VISKPATCH trailers, rebuild
+        installer, no Nuitka compilation.
+
+        Requires a previous full release at ``dist/<pendix>/runtime/`` to
+        patch against.  Hard error if the runtime tree is missing.
+
+        Pre-flight is reduced: skip the compiler / patchelf / Nuitka
+        tool checks (none of those run in patch mode), but still verify
+        pyinstaller is available since the installer build needs it.
+        """
+        release_start = time.monotonic()
+        phase_times: dict[str, float] = {}
+
+        if not exists(self.runtime):
+            print(
+                f"\nPatch release FAILED: no baseline build at "
+                f"{self.runtime}.  Run a full release (without --patch) "
+                f"to produce the baseline, then re-run --patch to ship "
+                f"source-level fixes on top of it.",
+                flush=True,
+            )
+            return
+
+        # Only pyinstaller is needed for patch mode; skip compiler and
+        # nuitka checks since we don't compile anything.
+        if not self._check_tools():
+            return
+
+        os.makedirs(self.location, exist_ok=True)
+
+        print(f"\n{self.title} Patch Release", flush=True)
+
+        # Patch screen wrappers in place
+        t0 = time.monotonic()
+        if not self.patch_screens():
+            return
+        phase_times["Patch"] = time.monotonic() - t0
+
+        # Refresh loose files (Icons, Images, project.json, top-level
+        # Screens/*.pyc, modules/*.pyc).  In-place — runtime/<X>.pyd
+        # wrappers we just patched are NOT touched by clean().
+        print("Refreshing screen data and resources", flush=True)
+        self.clean()
+
+        # Build the installer using the same flow as a full release.
+        installer_t0 = self._build_installer(phase_times)
+        if installer_t0 is None:
+            return
+
+        print(
+            f"\n\nReleased a"
+            f"{' '+self.flag+' ' if self.flag else ' '}"
+            f"PATCH for {self.title}!",
+            flush=True,
+        )
+        self._print_release_summary(
+            time.monotonic() - release_start, phase_times,
+        )
+
+    def _build_installer(self, phase_times: dict) -> float | None:
+        """Build the uninstaller + binaries.zip + installer.
+
+        Shared between full release and ``--patch`` mode.  Records
+        the elapsed time in ``phase_times["Installer"]``.  Returns the
+        installer-phase start timestamp (callers ignore the return,
+        but keeping it lets the caller distinguish failure (``None``)
+        from success.
+        """
+        installer_t0 = time.monotonic()
         binaries_zip = f"{self.location}binaries.zip"
 
         #Resolve icon for installer and uninstaller
@@ -1665,7 +2019,7 @@ class Release(Project):
             label="Uninstaller",
         )
         if cache_uninstaller is None:
-            return
+            return None
 
         #Copy uninstaller into build output so it ends up in binaries.zip
         uninst_dest_name = "Uninstaller.exe" if sys.platform == "win32" else "Uninstaller"
@@ -1688,7 +2042,7 @@ class Release(Project):
             label="Base installer",
         )
         if cache_base is None:
-            return
+            return None
 
         #Concatenate: cached base exe + binaries.zip = final installer
         installer_name = f"{self.pendix}_Installer"
@@ -1716,15 +2070,4 @@ class Release(Project):
         shutil.move(final_installer, downloads_installer)
         print(f"Installer ready: {downloads_installer}", flush=True)
         phase_times["Installer"] = time.monotonic() - installer_t0
-
-        # Release-complete banner moved out of clean() so it lands
-        # after the installer is actually ready (#137).
-        print(
-            f"\n\nReleased a new"
-            f"{' '+self.flag+' ' if self.flag else ' '}"
-            f"build of {self.title}!",
-            flush=True,
-        )
-        self._print_release_summary(
-            time.monotonic() - release_start, phase_times,
-        )
+        return installer_t0

--- a/VIStk/Structures/_Screen.py
+++ b/VIStk/Structures/_Screen.py
@@ -115,6 +115,17 @@ class Screen(VINFO):
         ``file:///``, etc.).
         """
       
+    @property
+    def script_path(self) -> str:
+        """Absolute path to this screen's entry script (``<project>/<script>``).
+
+        Used by :meth:`VIStk.Objects._TabManager.TabManager._build_namespace`
+        to read source for per-tab exec.  Same value as
+        ``self.p_project + "/" + self.script`` — exposed as a property so
+        callers don't have to know about the path layout.
+        """
+        return self.p_project + "/" + self.script
+
     def addElement(self,element:str) -> int:
         if validName(element):
             if not os.path.exists(self.path+"/f_"+element+".py"):

--- a/VIStk/VIS.py
+++ b/VIStk/VIS.py
@@ -207,6 +207,7 @@ def __main__():
             note:str=""
             release_groups:list[str]=[]
             release_screens:list[str]=[]
+            patch_mode: bool = False
             argstart = 2
 
             if len(inp) >= 3:
@@ -257,13 +258,17 @@ def __main__():
                                 return None
                             release_screens = [s.strip() for s in args[i+1].split(",") if s.strip()]
                             i += 2
+                        case "Patch" | "patch" | "P" | "p" | "-patch" | "-Patch":
+                            patch_mode = True
+                            i += 1
                         case _:
                             print(f"Unknown Argument \"{args[i]}\"")
                             return None
 
             rel = Release(flag, type, note,
                           release_groups=release_groups or None,
-                          release_screens=release_screens or None)
+                          release_screens=release_screens or None,
+                          patch_mode=patch_mode)
             rel.release()
             rel.restoreAll()
 


### PR DESCRIPTION
## Summary

- **Fixes** the multi-tab state-sharing bug: opening two tabs of the same screen now gives each tab an isolated Python namespace (`Screens.<name>__tab<id>` / `modules.<name>__tab<id>`). Module-level globals (StringVars, widget refs, loaded data) no longer bleed between tabs.
- **Collapses** per-screen release artifacts from three files (entry `.pyd` + `Screens/<name>.pyd` + `modules/<name>.pyd`) to one wrapper `.pyd` per screen. Wrapper holds marshalled bytecode in an `_EMBEDDED` dict; `TabManager` unmarshals into per-tab namespaces at runtime.
- **Removes** standalone per-screen `.exe`s. Every screen opens through the Host as a tab (or a chromeless `DetachedWindow` for `tabbed=false`). Only one `.exe` ships per project. The `release` field on `Screen` is repurposed to gate Start Menu shortcut creation (installer work — separate PR).
- **Adds** `TabManager.move_tab` so tab drag/merge/split/popout preserves the per-tab namespace across pane moves. Only the Tk frame rebuilds; `setup()` runs again with the new frame, but module state survives.

## Key files

| File | Change |
|---|---|
| `VIStk/Objects/_TabManager.py` | `_PerTabProxy`, `_build_namespace`, `_make_routing_import`, `_ensure_executed`, `open_screen`, `move_tab`, dev/release dispatch in `_load_screen_codes` |
| `VIStk/Structures/_Release.py` | `_build_screen_wrapper` (new), `_compile_screen_pyd` (rewrite), deleted `_compile_one_module` / `_compile_one_screen_package` / `_compile_binaries_parallel` / `_compile_screen_exe`, `runtime/` auto-wipe at release start |
| `VIStk/Objects/_Host.py` | Deleted `_import_screen` / `_import_hooks`; `_open_tab`/`_open_standalone` pass `scr` to `DetachedWindow` |
| `VIStk/Objects/_DetachedWindow.py` | `__init__` takes `scr`; popout/detach/split route through `move_tab` |
| `VIStk/Structures/_Screen.py` | New `script_path` property |

## How dev/release dispatch works

`TabManager._load_screen_codes` checks `os.path.exists(scr.script_path)`:
- **Dev**: project root has the `.py` files → compile from source each time
- **Release**: install root has no `.py` files (auto-wiped) → import the wrapper `.pyd`, read `_EMBEDDED`, unmarshal

`runtime/` is wiped at the start of every full release so stale artifacts from old pipelines don't trip this check.

## Test plan

- [x] Two `WorderEditor` tabs in dev — independent `wo` StringVar values, panels refresh independently
- [x] Multi-screen open in compiled build (AssetManager, FloorView, WOMBOM, etc.) — chromeless windows with own taskbar entries
- [x] Tab drag-merge between panes preserves WO number
- [x] Force-refresh rebuilds namespace (intentional state loss)
- [x] Standalone screens via `<project>.exe <ScreenName>` open as chromeless DetachedWindow
- [x] WorderEditor `setup(parent)` sentinel-check for one-time state init (PYWOM-side fix; see CLAUDE.md note)
- [x] PYWOM needs `dateutil` added to `hidden_imports` for FloorView (project packaging, not VIStk)

## Follow-ups (separate PRs)

1. **`VIS release --patch`** — diff source against existing `_EMBEDDED`, append VISKPATCH trailer to existing `.pyd`s, rebuild installer without recompiling through Nuitka. Designed but not built.
2. **Single-instance + IPC forwarding** — when launching `<project>.exe ScreenName` and an instance is already running, IPC the open request to it instead of spawning a second Host process. Designed but not built.
3. **Start Menu shortcut creation** in the installer — uses the `release` field on `Screen`.
4. **#140** — encrypt `_EMBEDDED` payloads.

## Conventions added in PYWOM CLAUDE.md

- `setup(parent)` may be called multiple times per tab (on first open + every move) — guard one-time state init
- Never import another screen's modules (per-tab routing only intercepts `Screens.<own_name>.*` / `modules.<own_name>.*`)

closes: #137 
closes: #136 
closes: #15 


🤖 Generated with [Claude Code](https://claude.com/claude-code)