### PR TITLE
Outside Installable Media (OIM)

### DIFF
--- a/VIStk/Structures/Installer.py
+++ b/VIStk/Structures/Installer.py
@@ -241,6 +241,56 @@ for _name in _archive_binaries:
             and _name != title):
         _install_entries.append({"kind": "screen", "name": _name})
 
+# ── Outside Installable Media (OIM) discovery (0.5.4) ─────────────────────
+# OIM entries ship at the archive ROOT under OIM/<name>/ (deliberately NOT
+# under runtime/, so the host-selected catch-all never auto-installs them).
+# Folder-convention only — no project.json registration:
+#   OIM/<name>/manifest.json        optional {label, description, default, required}
+#   OIM/<name>/media/...            the payload (staged; the script installs it)
+#   OIM/<name>/icon/<image>         checkbox icon shown in the installer
+#   OIM/<name>/script/install.py    run in-process after media extraction
+#   OIM/<name>/script/uninstall.py  persisted; run by the Uninstaller
+# Each entry becomes a selectable {"kind": "media"} row on the installables
+# page; extraction + script execution are handled by _install_oim().
+_oim_entries: list[dict] = []
+_oim_required: set[str] = set()
+_oim_by_name: dict[str, dict] = {}
+_all_members = set(archive.namelist())
+_oim_names: set[str] = set()
+for _m in _all_members:
+    if _m.startswith("OIM/") and _m.count("/") >= 2:
+        _oim_names.add(_m.split("/")[1])
+for _oname in sorted(_oim_names):
+    _prefix = f"OIM/{_oname}/"
+    _members = [m for m in _all_members if m.startswith(_prefix) and not m.endswith("/")]
+    _manifest = {}
+    if _prefix + "manifest.json" in _all_members:
+        try:
+            with archive.open(_prefix + "manifest.json") as _mf:
+                _manifest = json.load(_mf)
+        except Exception:
+            _manifest = {}
+    _icon_member = next((m for m in _members if m.startswith(_prefix + "icon/")), None)
+    _install_member = _prefix + "script/install.py"
+    _uninstall_member = _prefix + "script/uninstall.py"
+    _required = bool(_manifest.get("required", False))
+    _entry = {
+        "name": _oname,
+        "label": _manifest.get("label", _oname),
+        "description": _manifest.get("description", ""),
+        "default": bool(_manifest.get("default", False)),
+        "required": _required,
+        "icon_member": _icon_member,
+        "install_script": _install_member if _install_member in _all_members else None,
+        "uninstall_script": _uninstall_member if _uninstall_member in _all_members else None,
+        "members": _members,
+    }
+    _oim_entries.append(_entry)
+    _oim_by_name[_oname] = _entry
+    if _required:
+        _oim_required.add(_oname)
+    _install_entries.append({"kind": "media", "name": _oname})
+
 # Detect license/EULA file in archive
 _license_text = None
 for _lname in ("LICENSE", "LICENSE.txt", "EULA.txt", "EULA.md"):
@@ -445,7 +495,7 @@ def _group_of(screen_name: str) -> str | None:
     return None
 
 def write_install_log(location, selected_screens, desktop_shortcuts,
-                      start_menu_shortcuts=None, path_entry=""):
+                      start_menu_shortcuts=None, path_entry="", oim_records=()):
     """Write install_log.json recording what was installed."""
     directories = [".VIS", "Icons", "Images"]
 
@@ -486,6 +536,24 @@ def write_install_log(location, selected_screens, desktop_shortcuts,
     if sys.platform == "win32":
         registry_key = f"HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{title}"
 
+    log_path = os.path.join(location, "runtime", ".VIS", "install_log.json")
+
+    # Merge OIM records with any already recorded.  A repair/update that
+    # doesn't re-select a medium must keep its prior uninstall hook so the
+    # Uninstaller can still undo it; new records for the same name win.
+    oim_merged: dict[str, dict] = {}
+    if os.path.exists(log_path):
+        try:
+            with open(log_path) as _ef:
+                for _rec in json.load(_ef).get("oim", []):
+                    if _rec.get("name"):
+                        oim_merged[_rec["name"]] = _rec
+        except Exception:
+            pass
+    for _rec in oim_records:
+        if _rec.get("name"):
+            oim_merged[_rec["name"]] = _rec
+
     log = {
         "app_name": title,
         "app_version": app_version,
@@ -498,9 +566,9 @@ def write_install_log(location, selected_screens, desktop_shortcuts,
         "directories": directories,
         "registry_key": registry_key,
         "path_entry": path_entry,
+        "oim": list(oim_merged.values()),
     }
 
-    log_path = os.path.join(location, "runtime", ".VIS", "install_log.json")
     with open(log_path, "w") as f:
         json.dump(log, f, indent=2)
 
@@ -618,6 +686,119 @@ def add_runtime_to_path(location):
         return ""
 
 
+def _run_oim_script(script_path: str, install_root, oim_name: str) -> bool:
+    """Exec an OIM post-extract script in-process and return success.
+
+    The installer is a frozen PyInstaller bundle: a clean target machine may
+    have no system Python, and ``sys.executable`` is the installer itself —
+    so we cannot shell out to an interpreter.  Instead the developer's script
+    is exec'd inside the installer's own interpreter (which carries the
+    standard library) and inherits the installer's elevation.  The script
+    owns the actual install of the staged media and receives this context as
+    module globals:
+
+      INSTALL_ROOT  install directory root
+      RUNTIME_DIR   <INSTALL_ROOT>/runtime (python3xx.dll, shared .pyds, ...)
+      MEDIA_DIR     <INSTALL_ROOT>/OIM/<name>/media — the staged payload
+      OIM_NAME      this entry's folder name
+      APP_TITLE     the project title
+      log(msg)      append a line to vis_installer.log
+
+    --windowed strips stdout/stderr, so all output is routed to the installer
+    log and any exception is caught (a failing script must never crash the
+    installer or abort the already-committed file install).
+    """
+    try:
+        with open(script_path, "r", encoding="utf-8") as f:
+            src = f.read()
+    except Exception as e:
+        _log_write(f"OIM[{oim_name}]: cannot read script {script_path}: {e}")
+        return False
+    ctx = {
+        "__name__": "__oim_install__",
+        "__file__": script_path,
+        "INSTALL_ROOT": str(install_root),
+        "RUNTIME_DIR": os.path.join(str(install_root), "runtime"),
+        "MEDIA_DIR": os.path.join(str(install_root), "OIM", oim_name, "media"),
+        "OIM_NAME": oim_name,
+        "APP_TITLE": title,
+        "log": lambda m: _log_write(f"OIM[{oim_name}]: {m}"),
+    }
+    try:
+        exec(compile(src, script_path, "exec"), ctx)
+        _log_write(f"OIM[{oim_name}]: install script completed")
+        return True
+    except Exception:
+        import traceback
+        _log_write(f"OIM[{oim_name}]: install script FAILED\n{traceback.format_exc()}")
+        return False
+
+
+def _install_oim(location, selected_media, status_cb=None) -> list[dict]:
+    """Extract, run, and record the selected OIM entries.
+
+    For each selected entry: stage its archive members into
+    ``<location>/OIM/<name>/``, exec ``script/install.py`` (the script
+    installs the media), and — only on success — persist
+    ``script/uninstall.py`` to ``runtime/.VIS/oim/<name>/`` for the
+    Uninstaller, record it, and delete the staged folder.  On failure the
+    staged folder is left in place for diagnosis and no record is written.
+    The ``OIM/`` root is removed once empty.  Returns the install records to
+    fold into install_log.json.  Shared by the GUI and ``--Quiet`` paths.
+    """
+    records: list[dict] = []
+    if not selected_media:
+        return records
+    oim_root = os.path.join(str(location), "OIM")
+    for entry in _oim_entries:
+        name = entry["name"]
+        if name not in selected_media:
+            continue
+        if status_cb:
+            status_cb(f"Installing media: {entry['label']}")
+        staged = os.path.join(oim_root, name)
+        try:
+            for member in entry["members"]:
+                archive.extract(member, location)
+        except Exception as e:
+            _log_write(f"OIM[{name}]: extraction failed: {e}")
+            if status_cb:
+                status_cb(f"Media '{entry['label']}' extraction failed — see vis_installer.log")
+            continue
+        ok = True
+        if entry["install_script"]:
+            script_path = os.path.join(str(location), *entry["install_script"].split("/"))
+            ok = _run_oim_script(script_path, location, name)
+        if not ok:
+            if status_cb:
+                status_cb(f"Media '{entry['label']}' install failed — see vis_installer.log")
+            continue  # leave staged folder for diagnosis; no record, no cleanup
+        uninstall_rel = None
+        if entry["uninstall_script"]:
+            src = os.path.join(str(location), *entry["uninstall_script"].split("/"))
+            dest_dir = os.path.join(str(location), "runtime", ".VIS", "oim", name)
+            try:
+                os.makedirs(dest_dir, exist_ok=True)
+                shutil.copy2(src, os.path.join(dest_dir, "uninstall.py"))
+                uninstall_rel = f"runtime/.VIS/oim/{name}/uninstall.py"
+            except Exception as e:
+                _log_write(f"OIM[{name}]: could not persist uninstall script: {e}")
+        records.append({
+            "name": name,
+            "label": entry["label"],
+            "uninstall_script": uninstall_rel,
+            "install_date": datetime.datetime.now().isoformat(timespec="seconds"),
+        })
+        shutil.rmtree(staged, ignore_errors=True)
+    # Once every staged entry is consumed, drop the empty OIM/ staging root.
+    try:
+        if os.path.isdir(oim_root) and not os.listdir(oim_root):
+            os.rmdir(oim_root)
+    except OSError:
+        pass
+    return records
+
+
 def verify_installation(location, arc) -> list[str]:
     """Check all installed files exist and match archive sizes.
 
@@ -711,6 +892,10 @@ if _VERIFY_MODE[0]:
     sys.exit(0 if not issues else 1)
 
 if QUIET is True:
+    # Captured before cinstalls is back-filled with "all screens" below, so
+    # OIM selection can honor a bare `--Quiet` (install everything) vs. an
+    # explicit screen list (install only named + required media).
+    _quiet_install_all = len(cinstalls) == 0
     if custom_path:
         floc = custom_path
     else:
@@ -752,6 +937,14 @@ if QUIET is True:
                     _expanded.append(_tok)
         cinstalls = _expanded
 
+    # OIM selection for quiet mode: required entries always; everything when
+    # a bare `--Quiet` installs all; otherwise only entries named on the CLI
+    # (an OIM name passed to --Quiet survives group expansion untouched).
+    selected_media_q = [
+        e["name"] for e in _oim_entries
+        if e["required"] or _quiet_install_all or e["name"] in cinstalls
+    ]
+
     is_update_quiet = os.path.exists(os.path.join(location, "runtime", ".VIS", "install_log.json"))
 
     # Check for running processes in quiet mode
@@ -782,6 +975,8 @@ if QUIET is True:
     host_selected_q = (not cinstalls) or (title in cinstalls)
     quiet_install_files = []
     for f in archive.namelist():
+        if f.startswith("OIM/"):
+            continue  # OIM is staged + run separately by _install_oim()
         if f.startswith(_base_prefixes_q):
             quiet_install_files.append(f)
         elif host_selected_q and f.startswith(_host_prefixes_q):
@@ -825,7 +1020,9 @@ if QUIET is True:
         print(f"  Skipping {quiet_skipped} unchanged file(s).")
     if not quiet_files_to_extract:
         print("No changes needed — already up to date.")
-        write_install_log(location, cinstalls, dinstalls)
+        oim_records = _install_oim(location, selected_media_q,
+                                   status_cb=lambda m: print(f"  {m}"))
+        write_install_log(location, cinstalls, dinstalls, oim_records=oim_records)
         register_uninstall(location)
         archive.close()
         sys.exit()
@@ -902,8 +1099,10 @@ if QUIET is True:
         q_start_menu.append(name)
 
     q_path_entry = add_runtime_to_path(location)
+    oim_records = _install_oim(location, selected_media_q,
+                               status_cb=lambda m: print(f"  {m}"))
     write_install_log(location, cinstalls, dinstalls, q_start_menu,
-                      path_entry=q_path_entry)
+                      path_entry=q_path_entry, oim_records=oim_records)
     register_uninstall(location)
     print("Installation complete.")
     archive.close()
@@ -1073,7 +1272,20 @@ _group_vars: dict[str, tk.IntVar] = {}
 _group_expanded: dict[str, bool] = {}
 _group_child_widgets: dict[str, list[list[tk.Widget]]] = {}
 _group_arrow_vars: dict[str, tk.StringVar] = {}
+_media_vars: dict[str, tk.IntVar] = {}
+_media_header_done = [False]
 _grouped_page_active = False
+
+def _oim_icon(entry: dict):
+    """Return a 16x16 PhotoImage for an OIM entry; falls back to project icon."""
+    member = entry.get("icon_member")
+    if member:
+        try:
+            with archive.open(member) as f:
+                return PIL.ImageTk.PhotoImage(Image.open(f).resize((16, 16)))
+        except Exception:
+            pass
+    return PIL.ImageTk.PhotoImage(d_icon.resize((16, 16)))
 
 def _screen_icon(name: str):
     """Return a 16x16 PhotoImage for ``name``; falls back to project icon."""
@@ -1112,6 +1324,15 @@ def _refresh_tri_states():
             else:
                 gvar.set(0)
                 if widget: widget.state(['alternate'])
+        elif entry["kind"] == "media":
+            # Required media are always-on and disabled — excluded from the
+            # All accounting so the master can still reach a fully-off state.
+            if entry["name"] in _oim_required:
+                continue
+            v = _media_vars.get(entry["name"])
+            if v is not None:
+                total_on += v.get()
+                total_leaves += 1
         else:
             v = _screen_vars.get(entry["name"])
             if v is not None:
@@ -1156,10 +1377,15 @@ def _on_all_clicked():
     because a tri-state master cycles through combinations of ``alternate``
     and the underlying IntVar that are not reliable across platforms.
     """
-    any_off = any(v.get() == 0 for v in _screen_vars.values())
+    any_off = (any(v.get() == 0 for v in _screen_vars.values())
+               or any(v.get() == 0 for n, v in _media_vars.items()
+                      if n not in _oim_required))
     target = 1 if any_off else 0
     for v in _screen_vars.values():
         v.set(target)
+    for n, v in _media_vars.items():
+        if n not in _oim_required:  # required media stay on
+            v.set(target)
     _refresh_tri_states()
 
 def _toggle_group_expand(gname: str):
@@ -1177,13 +1403,15 @@ def makechecks_grouped():
     global var_all, img_options, _grouped_page_active
     global _screen_vars, _group_vars, _group_expanded
     global _group_child_widgets, _group_arrow_vars
-    global _group_checkbox_widgets
+    global _group_checkbox_widgets, _media_vars
     _screen_vars = {}
     _group_vars = {}
     _group_expanded = {}
     _group_child_widgets = {}
     _group_arrow_vars = {}
     _group_checkbox_widgets = {}
+    _media_vars = {}
+    _media_header_done[0] = False
     img_options = []
     _grouped_page_active = True
 
@@ -1218,6 +1446,29 @@ def makechecks_grouped():
             if scr_ver:
                 ver_lbl = ttk.Label(install_options, text=scr_ver, foreground="gray40")
                 ver_lbl.grid(row=row, column=3, sticky=(tk.E,), padx=(0, 8))
+            row += 1
+        elif entry["kind"] == "media":
+            oim = _oim_by_name[entry["name"]]
+            # One-time "Additional Software" header before the first medium.
+            if not _media_header_done[0]:
+                hdr = ttk.Label(install_options, text="Additional Software",
+                                foreground="gray30")
+                hdr.grid(row=row, column=1, columnspan=2, sticky=(tk.W,), pady=(10, 0))
+                _media_header_done[0] = True
+                row += 1
+                install_options.rowconfigure(row, weight=1)
+            img = _oim_icon(oim)
+            img_options.append(img)
+            required = entry["name"] in _oim_required
+            mvar = tk.IntVar(value=1 if (required or oim["default"]) else 0)
+            _media_vars[entry["name"]] = mvar
+            mtext = oim["label"] + (f"  —  {oim['description']}" if oim["description"] else "")
+            mcb = ttk.Checkbutton(install_options, text=mtext, variable=mvar,
+                                  command=_on_child_clicked, image=img, compound=tk.LEFT)
+            mcb.grid(row=row, column=2, sticky=(tk.N, tk.S, tk.E, tk.W))
+            mcb.state(['!alternate'])
+            if required:
+                mcb.state(['disabled'])  # always installed; can't be toggled off
             row += 1
         else:
             gname = entry["name"]
@@ -1274,6 +1525,14 @@ def makechecks_grouped():
 def _collect_selected_screens() -> list[str]:
     """Return the list of screens currently checked on the installables page."""
     return [name for name, v in _screen_vars.items() if v.get() == 1]
+
+def _collect_selected_media() -> list[str]:
+    """Return OIM entry names currently checked (required entries always)."""
+    out = [name for name, v in _media_vars.items() if v.get() == 1]
+    for n in _oim_required:
+        if n not in out:
+            out.append(n)
+    return out
 
 def _prompt_dependencies(selected: list[str]) -> bool:
     """Warn about unmet ``requires`` / ``suggests`` before leaving the page.
@@ -1480,7 +1739,7 @@ back.grid(row=1,column=1,padx=2,pady=4,sticky=(tk.N,tk.S,tk.E,tk.W))
 close = ttk.Button(control,text="Close",command=root.destroy)
 close.grid(row=1,column=0,padx=2,pady=4,sticky=(tk.N,tk.S,tk.E,tk.W))
 
-def binstall(desktop:list[str], selected_screens:list[str]):
+def binstall(desktop:list[str], selected_screens:list[str], selected_media:list[str]=()):
     """Installs the selected binaries"""
     # Snapshot shortcut selections before destroying the UI
     shortcut_selections = [
@@ -1554,6 +1813,8 @@ def binstall(desktop:list[str], selected_screens:list[str]):
     install_files = []
     host_selected = title in selected_screens
     for file in archive.namelist():
+        if file.startswith("OIM/"):
+            continue  # OIM is staged + run separately by _install_oim()
         if file in _excluded_files:
             continue
         if file.startswith(_base_prefixes):
@@ -1763,12 +2024,25 @@ def binstall(desktop:list[str], selected_screens:list[str]):
                  install_root=True)
         start_menu_shortcuts.append(name)
 
+    # Install selected Outside Installable Media, after the core files have
+    # committed.  A failing media script never rolls back the (successful)
+    # app install — it just logs and is surfaced via the status line.
+    oim_records = []
+    if selected_media:
+        file_label.config(text="Installing additional software...")
+        root.update()
+        oim_records = _install_oim(
+            location, selected_media,
+            status_cb=lambda m: (file_label.config(text=m), root.update()),
+        )
+
     # Write install log and register in Add/Remove Programs
     file_label.config(text="Registering installation...")
     root.update()
     path_entry = add_runtime_to_path(location)
     write_install_log(location, selected_screens, actual_shortcuts,
-                      start_menu_shortcuts, path_entry=path_entry)
+                      start_menu_shortcuts, path_entry=path_entry,
+                      oim_records=oim_records)
     register_uninstall(location)
 
     _log_write(f"install complete: {len(files_to_extract)} files, "
@@ -1826,6 +2100,7 @@ def nextpage():
     """Goes to the next installer page"""
     global _grouped_page_active
     selected_screens = _collect_selected_screens()
+    selected_media = _collect_selected_media()
     if not _prompt_dependencies(selected_screens):
         return  # user cancelled; stay on the installables page
     selected_screens = _collect_selected_screens()  # may have been mutated
@@ -1841,7 +2116,7 @@ def nextpage():
     makechecks(selected_screens, show_versions=False)
 
     #Install Button
-    install = ttk.Button(control, text="Install",command=lambda: binstall(selected_screens, selected_screens))
+    install = ttk.Button(control, text="Install",command=lambda: binstall(selected_screens, selected_screens, selected_media))
     install.grid(row=1,column=2,padx=2,pady=4,sticky=(tk.N,tk.S,tk.E,tk.W))
 
 if _license_text:

--- a/VIStk/Structures/Installer.py
+++ b/VIStk/Structures/Installer.py
@@ -241,7 +241,7 @@ for _name in _archive_binaries:
             and _name != title):
         _install_entries.append({"kind": "screen", "name": _name})
 
-# ── Outside Installable Media (OIM) discovery (0.5.4) ─────────────────────
+# ── Outside Installable Media (OIM) discovery (0.5.5) ─────────────────────
 # OIM entries ship at the archive ROOT under OIM/<name>/ (deliberately NOT
 # under runtime/, so the host-selected catch-all never auto-installs them).
 # Folder-convention only — no project.json registration:

--- a/VIStk/Structures/Uninstaller.py
+++ b/VIStk/Structures/Uninstaller.py
@@ -217,6 +217,42 @@ def remove_runtime_from_path(log):
             pass
 
 
+def run_oim_uninstall(log):
+    """Run each recorded OIM uninstall hook before the file sweep.
+
+    Mirrors the installer's in-process exec model: the Uninstaller is a
+    frozen bundle, so a persisted ``uninstall.py`` is exec'd in-process with
+    a small context rather than shelled out to a (possibly absent) system
+    Python.  Paths resolve against the log's recorded ``install_location``.
+    Errors are reported but never abort the uninstall.  Called only on a
+    full uninstall — the app, and any media it registered, is going away.
+    """
+    install_root = log.get("install_location", "")
+    for rec in log.get("oim", []):
+        rel = rec.get("uninstall_script")
+        name = rec.get("name", "")
+        if not rel or not install_root:
+            continue
+        script_path = os.path.join(install_root, *rel.split("/"))
+        if not os.path.exists(script_path):
+            continue
+        try:
+            with open(script_path, "r", encoding="utf-8") as f:
+                src = f.read()
+            ctx = {
+                "__name__": "__oim_uninstall__",
+                "__file__": script_path,
+                "INSTALL_ROOT": install_root,
+                "RUNTIME_DIR": os.path.join(install_root, "runtime"),
+                "OIM_NAME": name,
+                "APP_TITLE": log.get("app_name", ""),
+                "log": lambda m, _n=name: print(f"  OIM[{_n}]: {m}"),
+            }
+            exec(compile(src, script_path, "exec"), ctx)
+        except Exception as e:
+            print(f"  OIM[{name}] uninstall hook FAILED: {e}")
+
+
 def remove_installed_files(log, location, progress_fn=None):
     """Remove screen executables, directories, and install_log.json.
 
@@ -441,6 +477,8 @@ if QUIET:
 
     remove_runtime_from_path(log)
     print("  Removed runtime from PATH")
+
+    run_oim_uninstall(log)
 
     def _print_progress(step, total, label):
         print(f"  [{step}/{total}] {label}")
@@ -672,6 +710,9 @@ def _do_uninstall():
         root.update()
         remove_registry_entry(filtered_log)
         remove_runtime_from_path(filtered_log)
+        progress_label.config(text="Running media uninstall hooks...")
+        root.update()
+        run_oim_uninstall(log)
 
     def _gui_progress(step, total, label):
         progress_label.config(text=label)

--- a/VIStk/Structures/_Release.py
+++ b/VIStk/Structures/_Release.py
@@ -1661,7 +1661,7 @@ class Release(Project):
         # installer extracts + runs each entry per the user's selection.
         # Scripts stay as .py source (the installer execs them); the media
         # payload is copied verbatim.
-        src = f"{self.p_project}/OIM/"
+        src = self.p_oim
         if exists(src):
             shutil.copytree(src, f"{out_dir}/OIM/", dirs_exist_ok=True)
             entries = [d for d in os.listdir(src)

--- a/VIStk/Structures/_Release.py
+++ b/VIStk/Structures/_Release.py
@@ -1655,6 +1655,21 @@ class Release(Project):
         if exists(src):
             shutil.copytree(src, f"{self.runtime}/Icons/", dirs_exist_ok=True)
 
+        # Ship Outside Installable Media (OIM) at the install ROOT (out_dir,
+        # not runtime/) so it rides into binaries.zip via root_dir=self.final
+        # but stays OUT of the runtime/ host-selected catch-all — the
+        # installer extracts + runs each entry per the user's selection.
+        # Scripts stay as .py source (the installer execs them); the media
+        # payload is copied verbatim.
+        src = f"{self.p_project}/OIM/"
+        if exists(src):
+            shutil.copytree(src, f"{out_dir}/OIM/", dirs_exist_ok=True)
+            entries = [d for d in os.listdir(src)
+                       if os.path.isdir(os.path.join(src, d))]
+            if entries:
+                print(f"Bundled {len(entries)} OIM entr(y/ies): "
+                      f"{', '.join(sorted(entries))}", flush=True)
+
         # Ship top-level framework support files in Screens/ and modules/
         # as .pyc.  Per-screen subdirectories (Screens/AssetManager/,
         # modules/FloorView/, ...) are already compiled into the per-screen

--- a/VIStk/Structures/_VINFO.py
+++ b/VIStk/Structures/_VINFO.py
@@ -233,6 +233,15 @@ class VINFO():
         """The Location of the Project `/Icons` Folder"""
         self.p_images = self.p_project + "/Images"
         """The Location of the Project  `/Images` Folder"""
+        self.p_oim = self.p_project + "/OIM"
+        """The Location of the Project `/OIM` (Outside Installable Media) Folder.
+
+        Optional folder-convention area for non-VIStk installable media
+        (e.g. a COM-registered add-in) shipped alongside the app.  Each
+        ``OIM/<name>/`` holds ``media/`` (payload), ``icon/``, an optional
+        ``manifest.json``, and ``script/install.py`` / ``script/uninstall.py``
+        run by the installer/uninstaller.  Ridden into ``binaries.zip`` by
+        :meth:`Release.clean`."""
 
     def restoreAll(self):
         """Undoes screen isolation"""

--- a/changelog.md
+++ b/changelog.md
@@ -828,6 +828,35 @@ A reusable right-click popup menu so screens stop hand-coding the `tkinter.Menu`
 
 ---
 
+### 0.5.5 Outside Installable Media (OIM)
+
+Lets a project ship non-VIStk installable media (e.g. a COM-registered SolidWorks/.NET add-in) *inside* the same installer, surfaced as an opt-in install choice with a developer-supplied post-extract script.
+
+**Folder convention** (`<project>/OIM/<name>/`, no `project.json` registration — discovered like `commands/`):
+
+- `manifest.json` *(optional)* — `label`, `description`, `default` (default `false`), `required` (default `false`).
+- `media/` — the payload; staged into the install dir, then the script installs it.
+- `icon/<image>` — the checkbox icon shown in the installer.
+- `script/install.py` *(optional)* — run **in-process** in the installer's interpreter after the entry's media is extracted.
+- `script/uninstall.py` *(optional)* — persisted to `runtime/.VIS/oim/<name>/` and run by the Uninstaller on a full uninstall.
+
+**Release pipeline**
+
+- `Release.clean()` copies `OIM/` to the install **root** of the build (`self.final/OIM/`, not `runtime/`) so it rides into `binaries.zip` via `root_dir=self.final` while staying out of the host-selected `runtime/` catch-all. `VINFO.p_oim` added as the canonical path.
+
+**Installer**
+
+- OIM entries are discovered by scanning the appended archive for `OIM/<name>/…` and rendered as `kind:"media"` rows under an **Additional Software** header on the installables page; required entries render checked + disabled, optional default to off. Integrated into the master **All** / tri-state accounting (required entries excluded so *All* can still reach fully-off).
+- Selected media are handled by `_install_oim()` (shared by GUI and `--Quiet`): stage → exec `install.py` → on success persist `uninstall.py` + record in `install_log.json` (`"oim"` array, merged on repair) + delete the staged folder; the empty `OIM/` root is then removed. A failing script logs to `vis_installer.log`, is surfaced in the status line, and **never** rolls back the committed app install.
+- Script execution is **in-process `exec()`** (the frozen installer can't shell out to a system Python, and `sys.executable` is the installer). Scripts receive `INSTALL_ROOT`, `RUNTIME_DIR`, `MEDIA_DIR`, `OIM_NAME`, `APP_TITLE`, and a `log()` callable, inherit the installer's `--uac-admin` elevation, and must be idempotent (re-run on every install/repair).
+- `--Quiet` selects required media always, all media on a bare `--Quiet`, and named media otherwise.
+
+**Uninstaller**
+
+- `run_oim_uninstall()` execs each recorded `uninstall.py` (same in-process model + context) **before** the file sweep, on a full uninstall only — closing the orphaning gap for media that registers state outside the install dir (COM/regasm, GAC, plugin folders).
+
+---
+
 ### 0.6.X Application Settings
 
 Settings stored per-project in `.VIS/settings.json`, accessed via `Project.settings`.

--- a/documentation.md
+++ b/documentation.md
@@ -41,6 +41,7 @@ VIStk is a lightweight framework that makes building multi-screen Tkinter applic
 - [Utilities](#utilities)
   - [fUtil](#futil)
 - [Templates and the #% System](#templates-and-the--system)
+- [Outside Installable Media (OIM)](#outside-installable-media-oim)
 
 ---
 
@@ -61,6 +62,8 @@ MyProject/
 │   └── <screen>/           ← logic files, prefixed m_ (e.g. m_header.py)
 ├── Icons/                  ← .ico (Windows) or .xbm (Linux) icon files
 ├── Images/                 ← image assets used by VIMG
+├── OIM/                    ← (optional) Outside Installable Media — non-VIStk
+│   └── <name>/             ←   media shipped + installed alongside the app
 ├── <screen>.py             ← main script for each screen
 └── dist/                   ← compiled binaries (created on release)
 ```
@@ -1516,6 +1519,90 @@ if __name__ == "__main__":
 The `if __name__ == "__main__":` guard is required for tabbed screens. When the Host imports the module to call `setup()`, this guard prevents the standalone loop from running. When the script is executed directly (standalone mode), the guard allows it to run normally.
 
 **Hook placement:** `configure_menu`, `on_focused`, and `on_unfocused` can be moved to `modules/<screen>/m_<screen>.py` to keep business logic separate from UI. The Host checks the module file first and falls back to the screen script.
+
+---
+
+## Outside Installable Media (OIM)
+
+OIM lets a project ship **non-VIStk installable media** — anything the VIStk Python build pipeline can't produce, such as a COM-registered C# add-in, an MSI, or a driver — *inside the same installer*, surfaced as an opt-in install choice with a developer-supplied post-extract script. It is a pure **folder convention** (discovered like `commands/`); nothing is registered in `project.json`.
+
+### Folder layout
+
+```text
+MyProject/
+└── OIM/
+    └── <Name>/
+        ├── manifest.json        ← optional metadata (see below)
+        ├── media/               ← the payload (staged, then your script installs it)
+        ├── icon/<image>         ← checkbox icon shown in the installer
+        └── script/
+            ├── install.py       ← optional; runs after media extraction
+            └── uninstall.py     ← optional; runs on a full uninstall
+```
+
+`manifest.json` (all keys optional):
+
+```json
+{
+  "label": "SolidWOM Add-in",
+  "description": "WOM integration for SolidWorks",
+  "default": false,
+  "required": false
+}
+```
+
+- `label` / `description` — shown on the installer's **Additional Software** row (defaults to the folder name).
+- `default` — checkbox checked by default (default `false`, so OIM never silently bloats an install).
+- `required` — always installed, rendered checked + disabled (excluded from the **All** toggle).
+
+### How it ships and installs
+
+1. **Release** — `Release.clean()` copies `OIM/` to the install root of the build (`dist/<project>/OIM/`), so it rides into `binaries.zip` but stays out of the host-selected `runtime/` catch-all.
+2. **Selection** — the installer discovers each `OIM/<name>/` in the archive and renders it as a selectable row; `--Quiet` installs required media always, all media on a bare `--Quiet`, and named media otherwise.
+3. **Install** — for each selected entry the installer stages `media/` into `<install>/OIM/<name>/`, execs `script/install.py`, and on success persists `script/uninstall.py` + records the entry in `install_log.json`, then deletes the staged folder. A failing script is logged to `vis_installer.log` and surfaced in the UI but **never rolls back the committed app install**.
+4. **Uninstall** — on a full uninstall the Uninstaller execs each recorded `uninstall.py` *before* sweeping files, so media that registered state outside the install dir (COM/regasm, plugin folders) is cleaned up.
+
+### The script contract
+
+`install.py` / `uninstall.py` run **in-process** in the installer's/uninstaller's own interpreter. They are *not* run by a system Python — a clean target machine may not have one, and the frozen installer's `sys.executable` is the installer itself. Practical consequences:
+
+- **Idempotent**: the script re-runs on every install/repair (OIM is staged fresh each time, not persisted). Re-registering or re-stamping a config must be safe.
+- **Stdlib subset**: only modules bundled into the frozen installer are importable. `os`, `sys`, `json`, `subprocess`, `pathlib`, `shutil` are available — the realistic pattern is to *shell out* (`regasm`, `msiexec`) or copy/stamp files. Avoid exotic stdlib (`sqlite3`, `lzma`, …) and third-party imports.
+- **Elevated**: the installer runs `--uac-admin`, so the script inherits admin (regasm's HKLM write works).
+- **Quiet on failure**: wrap risky work in `try/except` and report via `log()` — `--windowed` swallows `print`.
+
+Injected globals:
+
+| Name | Meaning |
+|------|---------|
+| `INSTALL_ROOT` | the install directory root |
+| `RUNTIME_DIR` | `<INSTALL_ROOT>/runtime` (the app's `python3xx.dll`, shared `.pyd`s, e.g. `pywomlib.pyd`) |
+| `MEDIA_DIR` | `<INSTALL_ROOT>/OIM/<name>/media` — the staged payload (install scripts only) |
+| `OIM_NAME` | this entry's folder name |
+| `APP_TITLE` | the project title |
+| `log(msg)` | append a line to the installer/uninstaller log |
+
+Example `script/install.py` (register a SolidWorks add-in and point it at the app's `pywomlib.pyd`):
+
+```python
+import os, json, subprocess
+
+dll = os.path.join(MEDIA_DIR, "SolidWOM.AddIn.dll")
+
+# Stamp the add-in's config with this install's real runtime path.
+cfg = os.path.join(MEDIA_DIR, "solidwom.config.json")
+data = json.load(open(cfg))
+data["ExtraPaths"] = [RUNTIME_DIR]            # where pywomlib.pyd lives
+json.dump(data, open(cfg, "w"), indent=2)
+
+regasm = r"C:\Windows\Microsoft.NET\Framework64\v4.0.30319\RegAsm.exe"
+rc = subprocess.call([regasm, "/codebase", dll])
+log(f"regasm returned {rc}")
+if rc != 0:
+    raise RuntimeError("RegAsm registration failed")   # keeps the entry staged for diagnosis
+```
+
+The matching `script/uninstall.py` would run `RegAsm /u` on the same DLL using `RUNTIME_DIR`/`INSTALL_ROOT` to locate it.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "VIStk"
-version = "0.5.4"
+version = "0.5.5"
 license = {file="LICENSE"}
 dependencies = [
   "pyinstaller",

--- a/tests/test_oim_e2e.py
+++ b/tests/test_oim_e2e.py
@@ -1,0 +1,151 @@
+"""End-to-end OIM test: quiet install + uninstall against a synthetic archive.
+
+Builds a minimal project tree with one OIM entry, zips it as the installer's
+fallback ``binaries.zip``, runs ``Installer.py --Quiet`` and then
+``Uninstaller.py --Quiet`` as subprocesses, and asserts the staging / script-
+exec / log-record / cleanup / uninstall-hook behavior.  No SolidWorks or real
+release build required.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+STRUCT = HERE.parent / "VIStk" / "Structures"
+
+
+def _build_project(p: Path):
+    """Write a minimal valid project tree under *p*."""
+    vis = p / "runtime" / ".VIS"
+    vis.mkdir(parents=True)
+    project = {
+        "TestApp": {
+            "Screens": {},
+            "defaults": {"icon": "x", "default_screen": None},
+            "metadata": {"version": "1.0.0", "company": "testco"},
+            "release_info": {"location": "./dist/", "hidden_imports": [], "groups": {}},
+            "host": {"script": ".VIS/Host.py"},
+        }
+    }
+    (vis / "project.json").write_text(json.dumps(project), encoding="utf-8")
+
+    # An OIM entry: manifest (default-on), media payload, install + uninstall.
+    oim = p / "OIM" / "TestMedia"
+    (oim / "media").mkdir(parents=True)
+    (oim / "script").mkdir(parents=True)
+    (oim / "icon").mkdir(parents=True)
+    (oim / "manifest.json").write_text(
+        json.dumps({"label": "Test Media", "description": "demo", "default": True}),
+        encoding="utf-8",
+    )
+    (oim / "media" / "payload.txt").write_text("PAYLOAD", encoding="utf-8")
+    (oim / "icon" / "icon.txt").write_text("not-a-real-image", encoding="utf-8")
+    # install.py: prove context is injected, media is staged, and write a marker.
+    (oim / "script" / "install.py").write_text(
+        "import os\n"
+        "assert OIM_NAME == 'TestMedia', OIM_NAME\n"
+        "assert APP_TITLE == 'TestApp', APP_TITLE\n"
+        "assert os.path.isdir(RUNTIME_DIR), RUNTIME_DIR\n"
+        "payload = os.path.join(MEDIA_DIR, 'payload.txt')\n"
+        "assert open(payload).read() == 'PAYLOAD'\n"
+        "open(os.path.join(INSTALL_ROOT, 'INSTALL_RAN.marker'), 'w').write(OIM_NAME)\n"
+        "log('install marker written')\n",
+        encoding="utf-8",
+    )
+    # uninstall.py: write a marker OUTSIDE the install root (the parent dir),
+    # since the uninstaller's blind sweep wipes everything under INSTALL_ROOT
+    # right after this hook runs — a real hook also acts outside the dir
+    # (unregister COM, etc.).
+    (oim / "script" / "uninstall.py").write_text(
+        "import os\n"
+        "parent = os.path.dirname(INSTALL_ROOT)\n"
+        "open(os.path.join(parent, 'UNINSTALL_RAN.marker'), 'w').write(OIM_NAME)\n"
+        "log('uninstall marker written')\n",
+        encoding="utf-8",
+    )
+
+
+def _zip_dir(src: Path, zip_path: Path):
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for f in src.rglob("*"):
+            if f.is_file():
+                zf.write(f, f.relative_to(src).as_posix())
+
+
+def main():
+    tmp = Path(tempfile.mkdtemp(prefix="oim_e2e_"))
+    try:
+        proj = tmp / "proj"
+        proj.mkdir()
+        _build_project(proj)
+
+        # Stage Installer.py + Uninstaller.py in a dir with binaries.zip beside.
+        run_dir = tmp / "run"
+        run_dir.mkdir()
+        shutil.copy2(STRUCT / "Installer.py", run_dir / "Installer.py")
+        shutil.copy2(STRUCT / "Uninstaller.py", run_dir / "Uninstaller.py")
+        _zip_dir(proj, run_dir / "binaries.zip")
+
+        install_target = tmp / "target"  # installer appends /TestApp
+        install_root = install_target / "TestApp"
+
+        env = dict(os.environ)
+        # Ensure the editable VIStk import resolves for the subprocess.
+        env["PYTHONPATH"] = str(STRUCT.parent.parent) + os.pathsep + env.get("PYTHONPATH", "")
+
+        # -- Install --------------------------------------------------------
+        r = subprocess.run(
+            [sys.executable, str(run_dir / "Installer.py"),
+             "--Quiet", "--Path", str(install_target)],
+            capture_output=True, text=True, env=env, cwd=str(run_dir),
+        )
+        print("-- installer stdout --\n" + r.stdout)
+        if r.returncode != 0:
+            print("-- installer stderr --\n" + r.stderr)
+            raise SystemExit(f"installer exited {r.returncode}")
+
+        log_path = install_root / "runtime" / ".VIS" / "install_log.json"
+        assert log_path.exists(), f"missing install log at {log_path}"
+        log = json.loads(log_path.read_text())
+        assert "oim" in log, "install_log has no 'oim' array"
+        names = [r["name"] for r in log["oim"]]
+        assert names == ["TestMedia"], names
+        rec = log["oim"][0]
+        assert rec["uninstall_script"] == "runtime/.VIS/oim/TestMedia/uninstall.py", rec
+
+        assert (install_root / "INSTALL_RAN.marker").exists(), "install.py did not run"
+        assert not (install_root / "OIM").exists(), "staged OIM/ was not cleaned up"
+        assert (install_root / "runtime" / ".VIS" / "oim" / "TestMedia" / "uninstall.py").exists(), \
+            "uninstall script was not persisted"
+        print("PASS install: oim recorded, script ran, staging cleaned, uninstall persisted")
+
+        # -- Uninstall ------------------------------------------------------
+        # --Path is the install ROOT; _find_install_log() reads
+        # <root>/runtime/.VIS/install_log.json and OIM paths resolve via the
+        # log's recorded install_location.
+        ru = subprocess.run(
+            [sys.executable, str(run_dir / "Uninstaller.py"),
+             "--Quiet", "--Path", str(install_root)],
+            capture_output=True, text=True, env=env, cwd=str(run_dir),
+        )
+        print("-- uninstaller stdout --\n" + ru.stdout)
+        if ru.returncode != 0:
+            print("-- uninstaller stderr --\n" + ru.stderr)
+            raise SystemExit(f"uninstaller exited {ru.returncode}")
+
+        assert (install_target / "UNINSTALL_RAN.marker").exists(), "uninstall.py did not run"
+        print("PASS uninstall: uninstall hook ran")
+
+        print("\nALL OIM E2E CHECKS PASSED")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds **Outside Installable Media (OIM)** — a way for a VIStk project to ship non-VIStk installable media (e.g. a COM-registered SolidWorks/.NET add-in, an MSI, a driver) *inside the same installer*, surfaced as an opt-in install choice with a developer-supplied, in-process post-extract script.

Pure folder convention (discovered like `commands/` — no `project.json` registration):

```
<project>/OIM/<Name>/
  manifest.json        optional: label, description, default=false, required=false
  media/               payload (staged; the script installs it)
  icon/<image>         installer checkbox icon
  script/install.py    in-process post-extract hook
  script/uninstall.py  persisted; run by the uninstaller
```

## What changed

- **`_Release.clean()`** — copies `OIM/` to the install **root** of the build, so it rides into `binaries.zip` via `root_dir=self.final` but stays out of the `runtime/` host-selected catch-all.
- **`_VINFO`** — adds `p_oim`.
- **`Installer.py`** — archive discovery of `OIM/<name>/`; new `kind:"media"` rows under an *Additional Software* header (required = checked+disabled, integrated into the All/tri-state accounting); `_run_oim_script` (in-process `exec` with `INSTALL_ROOT`/`RUNTIME_DIR`/`MEDIA_DIR`/`OIM_NAME`/`APP_TITLE`/`log`, inherits `--uac-admin` elevation); `_install_oim` (stage → exec → on success persist uninstall + record + clean staging; on failure keep for diagnosis and **never** roll back the committed app install); `OIM/` carve-out in both GUI and `--Quiet` file selection; `install_log.json` `"oim"` array with merge-on-repair.
- **`Uninstaller.py`** — `run_oim_uninstall` execs persisted `uninstall.py` hooks **before** the file sweep (full uninstall only), resolving paths via the log's `install_location` — closes the orphaning gap for media that registers state outside the install dir (COM/regasm, plugin folders).
- **Docs** — `changelog.md` `0.5.5` + `documentation.md` OIM section. **Test** — `tests/test_oim_e2e.py` synthetic-archive install+uninstall e2e (passing).

## Script execution model

The installer/uninstaller are frozen PyInstaller bundles, so scripts run **in-process via `exec()`** (a clean machine may have no system Python, and `sys.executable` is the installer itself). Scripts must be **idempotent** and limited to the frozen stdlib subset (`os`, `json`, `subprocess`, `pathlib`, …) — the intended pattern is to shell out (`regasm`, `msiexec`) or copy/stamp files.

## Notes

- **Rebased onto `master`** (PR #143 Host single-instance / CLI-IPC). The first push was accidentally based on a pre-#143 local commit, which produced the conflicts; the OIM hooks were re-applied onto the #143 versions and the branch now sits cleanly on top of `master` (one commit, `MERGEABLE`).
- The two pre-existing issues flagged on the first push are both **already handled by #143** and need no action: `is_compiled()` exists in master's `_VINFO`, and the uninstaller now locates its log under `runtime/.VIS/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
